### PR TITLE
Fix typing attributes after quoted heading on iOS

### DIFF
--- a/ios/RCTUITextView+Markdown.mm
+++ b/ios/RCTUITextView+Markdown.mm
@@ -20,7 +20,11 @@
     UITextRange *range = self.selectedTextRange;
     super.attributedText = [RCTMarkdownUtils parseMarkdown:self.attributedText.string];
     [super setSelectedTextRange:range]; // prevents cursor from jumping at the end when typing in the middle of the text
-    self.typingAttributes = @{NSFontAttributeName: [UIFont boldSystemFontOfSize:20]}; // removes indent in new line when typing after quote
+
+    if ([self.attributedText length] > 0) {
+      UIFont *font = [self.attributedText attribute:NSFontAttributeName atIndex:0 effectiveRange:NULL];
+      self.typingAttributes = @{NSFontAttributeName:font}; // removes indent in new line when typing after quote
+    }
   }
     
   // Call the original method


### PR DESCRIPTION
This PR fixes the cursor height when inserting a newline. We set `.typingAttributes` in order to eliminate unwanted left margin in the following line after blockquote. Previously, we would assume that font size is always 20pt. This was incorrect for quoted heading as well as for different default font size specified in `RCTMarkdownUtils`. After the changes, we read the font size of the first char in the text input. This is correct because the only style which affects the font size is heading and it needs to start with `# ` in the default font size.

<table>
<thead>
<tr>
<th>Before</th>
<th>After</th>
</tr>
</thead>
<tbody>
<tr>
<td><video src="https://github.com/tomekzaw/react-native-markdown-text-input/assets/20516055/5e71ea9a-9739-4b78-a645-da900d73c53b" /></td>
<td><video src="https://github.com/tomekzaw/react-native-markdown-text-input/assets/20516055/759fd224-8fcb-4623-ad35-169c7803b453" /></td>
</tr>
</tbody>
</table>