### PR TITLE
Fix cursor jumping to the end of the text after each keypress on iOS

### DIFF
--- a/ios/RCTBaseTextInputView+Markdown.m
+++ b/ios/RCTBaseTextInputView+Markdown.m
@@ -27,8 +27,10 @@
 {
   RCTMarkdownUtils *markdownUtils = [self getMarkdownUtils];
   if (markdownUtils != nil) {
+    UITextRange *range = self.backedTextInputView.selectedTextRange;
     NSAttributedString *attributedText = [markdownUtils parseMarkdown:self.backedTextInputView.attributedText];
     [self.backedTextInputView setAttributedText:attributedText];
+    [self.backedTextInputView setSelectedTextRange:range notifyDelegate:YES];
   }
 
   // Call the original method


### PR DESCRIPTION
Fixes #15.

Updating `.attributedText` property resets the position of the cursor to the end of the text. Whenever we overwrite attributed string, we need to first store the selection and restore it afterwards. In particular, we need to do it in `-[RCTBackedTextFieldDelegateAdapter markdown_textFieldDidChange]` which is responsible for proper handling of height of the text input when typing the first letter of heading (for example `# L`).

<table>
<thead>
<tr>
<th>Before</th>
<th>After</th>
</tr>
</thead>
<tbody>
<tr>
<td><video src="https://github.com/tomekzaw/react-native-markdown-text-input/assets/20516055/a943cc8a-3aba-413c-b590-52f38508c4be" /></td>
<td><video src="https://github.com/tomekzaw/react-native-markdown-text-input/assets/20516055/0f949dd7-b18e-47f2-b4ef-dfe246962cb5" /></td>
</tr>
</tbody>
</table>