### PR TITLE
Draw line in blockquotes on Android

### DIFF
--- a/android/src/main/java/com/markdowntextinput/MarkdownUtils.java
+++ b/android/src/main/java/com/markdowntextinput/MarkdownUtils.java
@@ -8,7 +8,6 @@ import android.text.Spanned;
 import android.text.style.AbsoluteSizeSpan;
 import android.text.style.BackgroundColorSpan;
 import android.text.style.ForegroundColorSpan;
-import android.text.style.LeadingMarginSpan;
 import android.text.style.StrikethroughSpan;
 import android.text.style.StyleSpan;
 import android.text.style.TypefaceSpan;
@@ -61,6 +60,7 @@ public class MarkdownUtils {
   private static final int COLOR_MENTION_HERE = Color.argb(100, 252, 232, 142);
   private static final int COLOR_MENTION_USER = Color.argb(100, 176, 217, 255);
   private static final int COLOR_CODE_BACKGROUND = Color.argb(100, 211, 211, 211);
+  private static final int COLOR_QUOTE_LINE = Color.GRAY;
 
   // Spans
   private static Object makeBoldSpan() {
@@ -112,7 +112,7 @@ public class MarkdownUtils {
   }
 
   private static Object makeBlockquoteMarginSpan() {
-    return new LeadingMarginSpan.Standard(20);
+    return new QuoteSpan(COLOR_QUOTE_LINE, 15, 20);
   }
 
   public void applyMarkdownFormatting(SpannableStringBuilder ssb) {

--- a/android/src/main/java/com/markdowntextinput/QuoteSpan.java
+++ b/android/src/main/java/com/markdowntextinput/QuoteSpan.java
@@ -1,0 +1,38 @@
+package com.markdowntextinput;
+
+import android.graphics.Canvas;
+import android.graphics.Paint;
+import android.text.Layout;
+import android.text.style.LeadingMarginSpan;
+
+public class QuoteSpan implements LeadingMarginSpan {
+  private final int color;
+  private final int stripeWidth;
+  private final int gapWidth;
+
+  public QuoteSpan(int color, int stripeWidth, int gapWidth) {
+    this.color = color;
+    this.stripeWidth = stripeWidth;
+    this.gapWidth = gapWidth;
+  }
+
+  @Override
+  public int getLeadingMargin(boolean first) {
+    return stripeWidth + gapWidth;
+  }
+
+  @Override
+  public void drawLeadingMargin(Canvas c, Paint p, int x, int dir, int top, int baseline, int bottom,
+                                CharSequence text, int start, int end, boolean first, Layout layout) {
+    Paint.Style originalStyle = p.getStyle();
+    int originalColor = p.getColor();
+
+    p.setStyle(Paint.Style.FILL);
+    p.setColor(color);
+
+    c.drawRect(x, top, x + dir * stripeWidth, bottom, p);
+
+    p.setStyle(originalStyle);
+    p.setColor(originalColor);
+  }
+}


### PR DESCRIPTION
This PR adds a vertical line for blockquotes on Android.

Despite the fact that `QuoteSpan` is available out-of-the-box on Android starting from API 28, we need to implement it on our own because we support `minSdkVersion 21`.

<img width="479" alt="Zrzut ekranu 2023-12-22 o 21 48 24" src="https://github.com/tomekzaw/react-native-markdown-text-input/assets/20516055/4538d424-5934-4c2e-8608-b8bad74d871e">