### PR TITLE
Draw line in blockquotes on iOS

### DIFF
--- a/ios/MarkdownLayoutManager.h
+++ b/ios/MarkdownLayoutManager.h
@@ -1,0 +1,8 @@
+#import <UIKit/UIKit.h>
+#import <react-native-markdown-text-input/RCTMarkdownUtils.h>
+
+@interface MarkdownLayoutManager : NSLayoutManager
+
+@property(nonatomic) RCTMarkdownUtils *markdownUtils;
+
+@end

--- a/ios/MarkdownLayoutManager.m
+++ b/ios/MarkdownLayoutManager.m
@@ -1,0 +1,29 @@
+#import <react-native-markdown-text-input/MarkdownLayoutManager.h>
+
+@implementation MarkdownLayoutManager
+
+- (void)drawBackgroundForGlyphRange:(NSRange)glyphsToShow atPoint:(CGPoint)origin {
+  [super drawBackgroundForGlyphRange:glyphsToShow atPoint:origin];
+
+  [self enumerateLineFragmentsForGlyphRange:glyphsToShow usingBlock:^(CGRect rect, CGRect usedRect, NSTextContainer * _Nonnull textContainer, NSRange glyphRange, BOOL * _Nonnull stop) {
+    __block BOOL isQuote = NO;
+    RCTMarkdownUtils *markdownUtils = [self valueForKey:@"markdownUtils"];
+    [markdownUtils.quoteRanges enumerateObjectsUsingBlock:^(NSValue *item, NSUInteger idx, BOOL * _Nonnull stop) {
+      NSRange range = [item rangeValue];
+      NSUInteger start = range.location;
+      NSUInteger end = start + range.length;
+      NSUInteger location = glyphRange.location;
+      if (location >= start && location < end) {
+        isQuote = YES;
+        *stop = YES;
+      }
+    }];
+    if (isQuote) {
+      CGRect lineRect = CGRectMake(5, rect.origin.y + 5, 5, rect.size.height);
+      [[UIColor lightGrayColor] setFill];
+      UIRectFill(lineRect);
+    }
+  }];
+}
+
+@end

--- a/ios/MarkdownTextInputViewView.mm
+++ b/ios/MarkdownTextInputViewView.mm
@@ -1,6 +1,7 @@
 #import <React/RCTUITextField.h>
 #import <react/debug/react_native_assert.h>
 
+#import <react-native-markdown-text-input/MarkdownLayoutManager.h>
 #import <react-native-markdown-text-input/MarkdownTextInputViewView.h>
 #import <react-native-markdown-text-input/RCTBackedTextFieldDelegateAdapter+Markdown.h>
 #import <react-native-markdown-text-input/RCTUITextView+Markdown.h>
@@ -10,6 +11,8 @@
 #else
 #import <react-native-markdown-text-input/RCTBaseTextInputView+Markdown.h>
 #endif /* RCT_NEW_ARCH_ENABLED */
+
+#import <objc/runtime.h>
 
 @implementation MarkdownTextInputViewView {
 #ifdef RCT_NEW_ARCH_ENABLED
@@ -62,6 +65,8 @@
   } else if ([backedTextInputView isKindOfClass:[RCTUITextView class]]) {
     _textView = (RCTUITextView *)backedTextInputView;
     [_textView setMarkdownUtils:markdownUtils];
+    object_setClass(_textView.layoutManager, [MarkdownLayoutManager class]);
+    [_textView.layoutManager setValue:markdownUtils forKey:@"markdownUtils"];
   } else {
     react_native_assert(false && "Cannot enable Markdown for this type of TextInput.");
   }
@@ -72,6 +77,10 @@
   [_textInput setMarkdownUtils:nil];
   [_adapter setMarkdownUtils:nil];
   [_textView setMarkdownUtils:nil];
+  if (_textView != nil) {
+    [_textView.layoutManager setValue:nil forKey:@"markdownUtils"];
+    object_setClass(_textView.layoutManager, [NSLayoutManager class]);
+  }
 }
 
 @end

--- a/ios/RCTMarkdownUtils.h
+++ b/ios/RCTMarkdownUtils.h
@@ -2,6 +2,8 @@
 
 @interface RCTMarkdownUtils : NSObject
 
+@property(nonatomic) NSMutableArray<NSValue *> *quoteRanges;
+
 - (instancetype)initWithBackedTextInputView:(UIView<RCTBackedTextInputViewProtocol> *)backedTextInputView;
 
 - (NSAttributedString *)parseMarkdown:(NSAttributedString *)input;

--- a/ios/RCTMarkdownUtils.mm
+++ b/ios/RCTMarkdownUtils.mm
@@ -46,7 +46,7 @@
   NSMutableAttributedString *attributedString = [[NSMutableAttributedString alloc] initWithString:inputString attributes:_backedTextInputView.defaultTextAttributes];
   [attributedString beginEditing];
 
-  NSMutableArray *quoteRanges = [NSMutableArray new];
+  _quoteRanges = [NSMutableArray new];
 
   [ranges enumerateObjectsUsingBlock:^(id _Nonnull obj, NSUInteger idx, BOOL * _Nonnull stop) {
     NSArray *item = obj;
@@ -88,7 +88,6 @@
     } else if ([type isEqualToString:@"mention"]) {
         [attributedString addAttribute:NSBackgroundColorAttributeName value:[[UIColor alloc] initWithRed:252/255.0 green:232/255.0 blue:142/255.0 alpha:1.0] range:range];
     } else if ([type isEqualToString:@"mention-user"]) {
-
         // TODO: change mention color when it mentions current user
         [attributedString addAttribute:NSBackgroundColorAttributeName value:[[UIColor alloc] initWithRed:176/255.0 green:217/255.0 blue:255/255.0 alpha:1.0] range:range];
     } else if ([type isEqualToString:@"link"]) {
@@ -99,7 +98,7 @@
       paragraphStyle.firstLineHeadIndent = 11;
       paragraphStyle.headIndent = 11;
       [attributedString addAttribute:NSParagraphStyleAttributeName value:paragraphStyle range:range];
-      [quoteRanges addObject:[NSValue valueWithRange:range]];
+      [_quoteRanges addObject:[NSValue valueWithRange:range]];
     } else if ([type isEqualToString:@"pre"]) {
       NSMutableParagraphStyle *paragraphStyle = [NSMutableParagraphStyle new];
       paragraphStyle.firstLineHeadIndent = 5;


### PR DESCRIPTION
This PR adds a vertical line for blockquotes on iOS.

Note: the implementation uses TextKit 1 API because TextKit 2 is available from iOS 16.0, hence the following warning:

<img width="785" alt="warning" src="https://github.com/tomekzaw/react-native-markdown-text-input/assets/20516055/dd23b558-4121-43ff-9844-a7faea46d39a">

```
UITextView 4 462 522 368 is switching to TextKit 1 compatibility mode because its layoutManager was accessed.
Break on void _UITextViewEnablingCompatibilityMode(UITextView *__strong, BOOL) to debug.
```

<table>
<thead>
<tr>
<th>Paper</th>
<th>Fabric</th>
</tr>
</thead>
<tbody>
<tr>
<td><img width="507" alt="paper" src="https://github.com/tomekzaw/react-native-markdown-text-input/assets/20516055/64ba5d74-a019-4f33-a069-486c158b1e29"></td>
<td><img width="507" alt="fabric" src="https://github.com/tomekzaw/react-native-markdown-text-input/assets/20516055/d6c80873-2a04-456b-af0a-93a2df8b0ed4"></td>
</tr>
</tbody>
</table>