### PR TITLE
Fix heading line height on iOS

### DIFF
--- a/ios/RCTMarkdownUtils.mm
+++ b/ios/RCTMarkdownUtils.mm
@@ -108,7 +108,6 @@
       [attributedString addAttribute:NSParagraphStyleAttributeName value:paragraphStyle range:range];
     } else if ([type isEqualToString:@"h1"]) {
       NSMutableParagraphStyle *paragraphStyle = [NSMutableParagraphStyle new];
-      paragraphStyle.lineHeightMultiple = 1;
       NSRange range2 = NSMakeRange(range.location - 2, range.length + 2);
       [attributedString addAttribute:NSParagraphStyleAttributeName value:paragraphStyle range:range2];
     }


### PR DESCRIPTION
This PR fixes overlapping lines of text in headings when line height is set.

Fixes #61 on iOS.

```diff
   input: {
-    fontSize: 20,
+    fontSize: 12,
+    lineHeight: 20,
     width: 300,
     padding: 5,
     borderColor: 'gray',
     borderWidth: 1,
     textAlignVertical: 'top',
  },
```

<table>
<thead>
<tr>
<th>Before</th>
<th>After</th>
</tr>
</thead>
<tbody>
<tr>
<td><video src="https://github.com/tomekzaw/react-native-markdown-text-input/assets/20516055/6311d1b5-973b-48f9-8ab0-051047d31ef4" /></td>
<td><video src="https://github.com/tomekzaw/react-native-markdown-text-input/assets/20516055/40ac1580-2fc6-47a7-8a37-9cb52b4a43ad" /></td>
</tr>
</tbody>
</table>