### PR TITLE
Memoize previous string on Android

### DIFF
--- a/android/src/main/java/com/markdowntextinput/MarkdownUtils.java
+++ b/android/src/main/java/com/markdowntextinput/MarkdownUtils.java
@@ -53,6 +53,8 @@ public class MarkdownUtils {
 
   private final List<Object> mSpans = new LinkedList<>();
 
+  private String mPreviouslyFormattedString = "";
+
   // Colors
   private static final int COLOR_CODE = Color.rgb(6, 25, 109);
   private static final int COLOR_LINK = Color.BLUE;
@@ -116,9 +118,12 @@ public class MarkdownUtils {
   }
 
   public void applyMarkdownFormatting(SpannableStringBuilder ssb) {
-    removeSpans(ssb);
-
     String input = ssb.toString();
+    if (input.equals(mPreviouslyFormattedString)) {
+      return;
+    }
+
+    removeSpans(ssb);
     String output = nativeParseMarkdown(input);
     try {
       JSONArray array = new JSONArray(output);
@@ -139,6 +144,8 @@ public class MarkdownUtils {
     } catch (JSONException e) {
       // Do nothing
     }
+
+    mPreviouslyFormattedString = input;
   }
 
   private void applyRange(SpannableStringBuilder ssb, String type, int start, int end) {


### PR DESCRIPTION
`applyMarkdownFormatting` is called exactly 4 times on each value change on Android.

This PR stores the previously formatted text and skips clearing and applying spans if the text stays the same.

https://github.com/tomekzaw/react-native-markdown-text-input/assets/20516055/50744bc3-7e72-42aa-8128-a0197394cebd