### PR TITLE
Cleanup test assertions

### DIFF
--- a/parser/__tests__/index.test.js
+++ b/parser/__tests__/index.test.js
@@ -1,14 +1,10 @@
 require('../out.js');
 
-const SAME = Symbol('same');
-
 expect.extend({
-  toBeParsedAs(received, expectedText, expectedRanges) {
+  toBeParsedAs(received, expectedRanges) {
+    const expectedText = received;
     const [actualText, actualRanges] =
       global.parseMarkdownToTextAndRanges(received);
-    if (expectedText === SAME) {
-      expectedText = received;
-    }
     if (actualText !== expectedText) {
       return {
         pass: false,
@@ -32,15 +28,15 @@ expect.extend({
 });
 
 test('empty string', () => {
-  expect('').toBeParsedAs(SAME, []);
+  expect('').toBeParsedAs([]);
 });
 
 test('no formatting', () => {
-  expect('Hello, world!').toBeParsedAs(SAME, []);
+  expect('Hello, world!').toBeParsedAs([]);
 });
 
 test('bold', () => {
-  expect('Hello, *world*!').toBeParsedAs(SAME, [
+  expect('Hello, *world*!').toBeParsedAs([
     ['syntax', 7, 1],
     ['bold', 8, 5],
     ['syntax', 13, 1],
@@ -48,7 +44,7 @@ test('bold', () => {
 });
 
 test('italic', () => {
-  expect('Hello, _world_!').toBeParsedAs(SAME, [
+  expect('Hello, _world_!').toBeParsedAs([
     ['syntax', 7, 1],
     ['italic', 8, 5],
     ['syntax', 13, 1],
@@ -56,7 +52,7 @@ test('italic', () => {
 });
 
 test('strikethrough', () => {
-  expect('Hello, ~world~!').toBeParsedAs(SAME, [
+  expect('Hello, ~world~!').toBeParsedAs([
     ['syntax', 7, 1],
     ['strikethrough', 8, 5],
     ['syntax', 13, 1],
@@ -65,40 +61,38 @@ test('strikethrough', () => {
 
 describe('mention', () => {
   test('normal', () => {
-    expect('@here Hello!').toBeParsedAs(SAME, [['mention', 0, 5]]);
+    expect('@here Hello!').toBeParsedAs([['mention', 0, 5]]);
   });
 
   test('with additional letters', () => {
-    expect('@herex').toBeParsedAs(SAME, []);
+    expect('@herex').toBeParsedAs([]);
   });
 
   test('with punctation marks', () => {
-    expect('@here!').toBeParsedAs(SAME, [['mention', 0, 5]]);
+    expect('@here!').toBeParsedAs([['mention', 0, 5]]);
   });
 });
 
 describe('mention-user', () => {
   test('normal', () => {
-    expect('@mail@mail.com Hello!').toBeParsedAs(SAME, [
-      ['mention-user', 0, 14],
-    ]);
+    expect('@mail@mail.com Hello!').toBeParsedAs([['mention-user', 0, 14]]);
   });
 
   test('without top-level domain', () => {
-    expect('@mail@mail').toBeParsedAs(SAME, []);
+    expect('@mail@mail').toBeParsedAs([]);
   });
 
   test('with punctation marks', () => {
-    expect('@mail@mail.com!').toBeParsedAs(SAME, [['mention-user', 0, 14]]);
+    expect('@mail@mail.com!').toBeParsedAs([['mention-user', 0, 14]]);
   });
 });
 
 test('plain link', () => {
-  expect('https://example.com').toBeParsedAs(SAME, [['link', 0, 19]]);
+  expect('https://example.com').toBeParsedAs([['link', 0, 19]]);
 });
 
 test('labeled link', () => {
-  expect('[Link](https://example.com)').toBeParsedAs(SAME, [
+  expect('[Link](https://example.com)').toBeParsedAs([
     ['syntax', 0, 1],
     ['syntax', 5, 2],
     ['link', 7, 19],
@@ -107,7 +101,7 @@ test('labeled link', () => {
 });
 
 test('link with same label as href', () => {
-  expect('[https://example.com](https://example.com)').toBeParsedAs(SAME, [
+  expect('[https://example.com](https://example.com)').toBeParsedAs([
     ['syntax', 0, 1],
     ['syntax', 20, 2],
     ['link', 22, 19],
@@ -116,22 +110,21 @@ test('link with same label as href', () => {
 });
 
 test('no nesting links while typing', () => {
-  expect('[link](www.google.com').toBeParsedAs(SAME, [['link', 7, 14]]);
+  expect('[link](www.google.com').toBeParsedAs([['link', 7, 14]]);
 });
 
 test('link with query string', () => {
-  expect('https://example.com?name=John&age=25&city=NewYork').toBeParsedAs(
-    SAME,
-    [['link', 0, 49]]
-  );
+  expect('https://example.com?name=John&age=25&city=NewYork').toBeParsedAs([
+    ['link', 0, 49],
+  ]);
 });
 
 test('plain email', () => {
-  expect('someone@example.com').toBeParsedAs(SAME, [['link', 0, 19]]);
+  expect('someone@example.com').toBeParsedAs([['link', 0, 19]]);
 });
 
 test('labeled email', () => {
-  expect('[Email](mailto:someone@example.com)').toBeParsedAs(SAME, [
+  expect('[Email](mailto:someone@example.com)').toBeParsedAs([
     ['syntax', 0, 1],
     ['syntax', 6, 2],
     ['link', 8, 26],
@@ -141,7 +134,7 @@ test('labeled email', () => {
 
 describe('email with same label as address', () => {
   test('label and address without "mailto:"', () => {
-    expect('[someone@example.com](someone@example.com)').toBeParsedAs(SAME, [
+    expect('[someone@example.com](someone@example.com)').toBeParsedAs([
       ['syntax', 0, 1],
       ['syntax', 20, 2],
       ['link', 22, 19],
@@ -150,33 +143,27 @@ describe('email with same label as address', () => {
   });
 
   test('label with "mailto:"', () => {
-    expect('[mailto:someone@example.com](someone@example.com)').toBeParsedAs(
-      SAME,
-      [
-        ['syntax', 0, 1],
-        ['syntax', 27, 2],
-        ['link', 29, 19],
-        ['syntax', 48, 1],
-      ]
-    );
+    expect('[mailto:someone@example.com](someone@example.com)').toBeParsedAs([
+      ['syntax', 0, 1],
+      ['syntax', 27, 2],
+      ['link', 29, 19],
+      ['syntax', 48, 1],
+    ]);
   });
 
   test('address with "mailto:"', () => {
-    expect('[someone@example.com](mailto:someone@example.com)').toBeParsedAs(
-      SAME,
-      [
-        ['syntax', 0, 1],
-        ['syntax', 20, 2],
-        ['link', 22, 26],
-        ['syntax', 48, 1],
-      ]
-    );
+    expect('[someone@example.com](mailto:someone@example.com)').toBeParsedAs([
+      ['syntax', 0, 1],
+      ['syntax', 20, 2],
+      ['link', 22, 26],
+      ['syntax', 48, 1],
+    ]);
   });
 
   test('label and address with "mailto:"', () => {
     expect(
       '[mailto:someone@example.com](mailto:someone@example.com)'
-    ).toBeParsedAs(SAME, [
+    ).toBeParsedAs([
       ['syntax', 0, 1],
       ['syntax', 27, 2],
       ['link', 29, 26],
@@ -186,7 +173,7 @@ describe('email with same label as address', () => {
 });
 
 test('inline code', () => {
-  expect('Hello `world`!').toBeParsedAs(SAME, [
+  expect('Hello `world`!').toBeParsedAs([
     ['syntax', 6, 1],
     ['code', 7, 5],
     ['syntax', 12, 1],
@@ -194,7 +181,7 @@ test('inline code', () => {
 });
 
 test('codeblock', () => {
-  expect('```\nHello world!\n```').toBeParsedAs(SAME, [
+  expect('```\nHello world!\n```').toBeParsedAs([
     ['syntax', 0, 3],
     ['pre', 3, 14],
     ['syntax', 17, 3],
@@ -203,21 +190,21 @@ test('codeblock', () => {
 
 describe('quote', () => {
   test('with single space', () => {
-    expect('> Hello world!').toBeParsedAs(SAME, [
+    expect('> Hello world!').toBeParsedAs([
       ['syntax', 0, 1],
       ['blockquote', 0, 14],
     ]);
   });
 
   test('with multiple spaces', () => {
-    expect('>      Hello world!').toBeParsedAs(SAME, [
+    expect('>      Hello world!').toBeParsedAs([
       ['syntax', 0, 1],
       ['blockquote', 0, 19],
     ]);
   });
 
   test('without space', () => {
-    expect('>Hello world!').toBeParsedAs(SAME, [
+    expect('>Hello world!').toBeParsedAs([
       ['syntax', 0, 1],
       ['blockquote', 0, 13],
     ]);
@@ -225,7 +212,7 @@ describe('quote', () => {
 });
 
 test('multiple blockquotes', () => {
-  expect('> Hello\n> beautiful\n> world').toBeParsedAs(SAME, [
+  expect('> Hello\n> beautiful\n> world').toBeParsedAs([
     ['syntax', 0, 1],
     ['blockquote', 0, 7],
     ['syntax', 8, 1],
@@ -236,7 +223,7 @@ test('multiple blockquotes', () => {
 });
 
 test('separate blockquotes', () => {
-  expect('> Lorem ipsum\ndolor\n> sit amet').toBeParsedAs(SAME, [
+  expect('> Lorem ipsum\ndolor\n> sit amet').toBeParsedAs([
     ['syntax', 0, 1],
     ['blockquote', 0, 13],
     ['syntax', 20, 1],
@@ -245,14 +232,14 @@ test('separate blockquotes', () => {
 });
 
 test('heading', () => {
-  expect('# Hello world').toBeParsedAs(SAME, [
+  expect('# Hello world').toBeParsedAs([
     ['syntax', 0, 2],
     ['h1', 2, 11],
   ]);
 });
 
 test('nested bold and italic', () => {
-  expect('*_Hello_*, _*world*_!').toBeParsedAs(SAME, [
+  expect('*_Hello_*, _*world*_!').toBeParsedAs([
     ['syntax', 0, 1],
     ['syntax', 1, 1],
     ['bold', 1, 7],
@@ -270,7 +257,7 @@ test('nested bold and italic', () => {
 
 describe('nested heading in blockquote', () => {
   test('without spaces', () => {
-    expect('># Hello world').toBeParsedAs(SAME, [
+    expect('># Hello world').toBeParsedAs([
       ['syntax', 0, 1],
       ['blockquote', 0, 14],
       ['syntax', 1, 2],
@@ -279,7 +266,7 @@ describe('nested heading in blockquote', () => {
   });
 
   test('with single space', () => {
-    expect('> # Hello world').toBeParsedAs(SAME, [
+    expect('> # Hello world').toBeParsedAs([
       ['syntax', 0, 1],
       ['blockquote', 0, 15],
       ['syntax', 2, 2],
@@ -288,7 +275,7 @@ describe('nested heading in blockquote', () => {
   });
 
   test('with multiple spaces after #', () => {
-    expect('>#    Hello world').toBeParsedAs(SAME, [
+    expect('>#    Hello world').toBeParsedAs([
       ['syntax', 0, 1],
       ['blockquote', 0, 17],
       ['syntax', 1, 2],
@@ -300,21 +287,21 @@ describe('nested heading in blockquote', () => {
 describe('trailing whitespace', () => {
   describe('after blockquote', () => {
     test('nothing', () => {
-      expect('> Hello world').toBeParsedAs(SAME, [
+      expect('> Hello world').toBeParsedAs([
         ['syntax', 0, 1],
         ['blockquote', 0, 13],
       ]);
     });
 
     test('single space', () => {
-      expect('> Hello world ').toBeParsedAs(SAME, [
+      expect('> Hello world ').toBeParsedAs([
         ['syntax', 0, 1],
         ['blockquote', 0, 14],
       ]);
     });
 
     test('newline', () => {
-      expect('> Hello world\n').toBeParsedAs(SAME, [
+      expect('> Hello world\n').toBeParsedAs([
         ['syntax', 0, 1],
         ['blockquote', 0, 13],
       ]);
@@ -323,35 +310,35 @@ describe('trailing whitespace', () => {
 
   describe('after heading', () => {
     test('nothing', () => {
-      expect('# Hello world').toBeParsedAs(SAME, [
+      expect('# Hello world').toBeParsedAs([
         ['syntax', 0, 2],
         ['h1', 2, 11],
       ]);
     });
 
     test('single space', () => {
-      expect('# Hello world ').toBeParsedAs(SAME, [
+      expect('# Hello world ').toBeParsedAs([
         ['syntax', 0, 2],
         ['h1', 2, 12],
       ]);
     });
 
     test('multiple spaces', () => {
-      expect('#   Hello world ').toBeParsedAs(SAME, [
+      expect('#   Hello world ').toBeParsedAs([
         ['syntax', 0, 2],
         ['h1', 2, 14],
       ]);
     });
 
     test('newline', () => {
-      expect('# Hello world\n').toBeParsedAs(SAME, [
+      expect('# Hello world\n').toBeParsedAs([
         ['syntax', 0, 2],
         ['h1', 2, 11],
       ]);
     });
 
     test('multiple quotes', () => {
-      expect('> # Hello\n> # world').toBeParsedAs(SAME, [
+      expect('> # Hello\n> # world').toBeParsedAs([
         ['syntax', 0, 1],
         ['blockquote', 0, 9],
         ['syntax', 2, 2],

--- a/parser/package-lock.json
+++ b/parser/package-lock.json
@@ -12,7 +12,6 @@
       "dependencies": {
         "expensify-common": "git+ssh://git@github.com/Expensify/expensify-common.git#c6bb3cfa56d12af9fa02e2bfc729646f5b64ef44",
         "patch-package": "^8.0.0",
-        "tslib": "^2.6.2",
         "underscore": "^1.13.6"
       },
       "devDependencies": {
@@ -4824,11 +4823,6 @@
         "node": ">=8.0"
       }
     },
-    "node_modules/tslib": {
-      "version": "2.6.2",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
-      "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
-    },
     "node_modules/type-detect": {
       "version": "4.0.8",
       "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
@@ -8650,11 +8644,6 @@
       "requires": {
         "is-number": "^7.0.0"
       }
-    },
-    "tslib": {
-      "version": "2.6.2",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
-      "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
     },
     "type-detect": {
       "version": "4.0.8",


### PR DESCRIPTION
This PR removes `SAME` from parser unit tests in favor of always checking the actual text against expected tests.