### PR TITLE
Remove leading margin after clearing blockquote on iOS

### DIFF
--- a/ios/RCTUITextView+Markdown.mm
+++ b/ios/RCTUITextView+Markdown.mm
@@ -19,11 +19,7 @@
     UITextRange *range = self.selectedTextRange;
     super.attributedText = [markdownUtils parseMarkdown:self.attributedText];
     [super setSelectedTextRange:range]; // prevents cursor from jumping at the end when typing in the middle of the text
-
-    if ([self.attributedText length] > 0) {
-      UIFont *font = [self.attributedText attribute:NSFontAttributeName atIndex:0 effectiveRange:NULL];
-      self.typingAttributes = @{NSFontAttributeName:font}; // removes indent in new line when typing after quote
-    }
+    self.typingAttributes = self.defaultTextAttributes; // removes indent in new line when typing after blockquote
   }
 
   // Call the original method


### PR DESCRIPTION
Closes #79.

This PR fixes invalid cursor position (in terms of leading margin) that occurs e.g. when clearing the text input that contains a blockquote.

<table>
<thead>
<tr>
<th>Before</th>
<th>After</th>
</tr>
</thead>
<tbody>
<tr>
<td><video src="https://github.com/tomekzaw/react-native-markdown-text-input/assets/20516055/639b2eee-993d-4557-a02f-d52a7d642705" /></td>
<td><video src="https://github.com/tomekzaw/react-native-markdown-text-input/assets/20516055/5faa597a-51c7-4e83-8089-594fb2741bac" /></td>
</tr>
</tbody>
</table>