### PR TITLE
Introduce defaultTextAttributes comparison for Markdown memoization

### DIFF
--- a/ios/RCTMarkdownUtils.mm
+++ b/ios/RCTMarkdownUtils.mm
@@ -22,9 +22,7 @@
   }
 
   NSString *inputString = [input string];
-  BOOL defaultTextAttributesUnchanged = _prevTextAttributes != nil && [_backedTextInputView.defaultTextAttributes isEqualToDictionary:_prevTextAttributes];
-
-  if ([inputString isEqualToString:_prevInputString] && defaultTextAttributesUnchanged) {
+  if ([inputString isEqualToString:_prevInputString] && [_backedTextInputView.defaultTextAttributes isEqualToDictionary:_prevTextAttributes]) {
     return _prevAttributedString;
   }
 


### PR DESCRIPTION
Introduced memoization prevents parsing the string when the input string remains unchanged. This behavior blocks parsing the string when only props are changed.

To tackle this problem, I've updated the condition for memo - now it also compares previous and up-to-date defaultTextAttributes

Solves #62 