### PR TITLE
Fix multiple watcher calls on Android

### DIFF
--- a/android/src/main/java/com/expensify/livemarkdown/MarkdownTextWatcher.java
+++ b/android/src/main/java/com/expensify/livemarkdown/MarkdownTextWatcher.java
@@ -9,6 +9,8 @@ import androidx.annotation.NonNull;
 public class MarkdownTextWatcher implements TextWatcher {
   private final MarkdownUtils mMarkdownUtils;
 
+  private boolean mShouldSkip = false;
+
   public MarkdownTextWatcher(@NonNull MarkdownUtils markdownUtils) {
     mMarkdownUtils = markdownUtils;
   }
@@ -19,14 +21,18 @@ public class MarkdownTextWatcher implements TextWatcher {
   }
 
   @Override
-  public void onTextChanged(CharSequence s, int start, int before, int count)  {
+  public void onTextChanged(CharSequence s, int start, int before, int count) {
+    if (mShouldSkip) {
+      return;
+    }
     if (s instanceof SpannableStringBuilder) {
       mMarkdownUtils.applyMarkdownFormatting((SpannableStringBuilder) s);
+      mShouldSkip = true;
     }
   }
 
   @Override
   public void afterTextChanged(Editable editable) {
-
+    mShouldSkip = false;
   }
 }


### PR DESCRIPTION
For some reason, `MarkdownTextWatcher#onTextChanged` is called twice on each update (both from UI event as well as a result of a React render, i.e. 4 times in total).

This PR skips the second execution of `MarkdownUtils#applyMarkdownFormatting` so effectively it is called only twice (once as a result of UI event and once as a result of React render).

See [here](https://stackoverflow.com/questions/17535415/textwatcher-events-are-being-fired-multiple-times) for details.

Closes #19.