### PR TITLE
Memoize JS parser output on Android

### DIFF
--- a/android/src/main/java/com/expensify/livemarkdown/MarkdownUtils.java
+++ b/android/src/main/java/com/expensify/livemarkdown/MarkdownUtils.java
@@ -67,6 +67,10 @@ public class MarkdownUtils {
 
   private static native String nativeParseMarkdown(String input);
 
+  private String mPrevInput;
+
+  private String mPrevOutput;
+
   private final List<Object> mSpans = new LinkedList<>();
 
   private MarkdownStyle mMarkdownStyle;
@@ -153,7 +157,15 @@ public class MarkdownUtils {
     removeSpans(ssb);
 
     String input = ssb.toString();
-    String output = parseMarkdown(input);
+    String output;
+    if (input.equals(mPrevInput)) {
+      output = mPrevOutput;
+    } else {
+      output = parseMarkdown(input);
+      mPrevInput = input;
+      mPrevOutput = output;
+    }
+
     try {
       JSONArray ranges = new JSONArray(output);
       for (int i = 0; i < ranges.length(); i++) {


### PR DESCRIPTION
Since the JS parser is usually invoked at least twice on each value change (once as a result of UI event and once as a result of React render), it makes sense to memoize the JSON output on Android. This PR does exactly that.

Closes #73.