### PR TITLE
Set background color for code blocks on iOS

### DIFF
--- a/ios/RCTMarkdownUtils.mm
+++ b/ios/RCTMarkdownUtils.mm
@@ -107,8 +107,7 @@
       [_quoteRanges addObject:[NSValue valueWithRange:range]];
     } else if ([type isEqualToString:@"pre"]) {
       [attributedString addAttribute:NSForegroundColorAttributeName value:_markdownStyle.preColor range:range];
-      NSString *firstChar = [inputString substringWithRange:NSMakeRange(range.location, 1)];
-      NSRange rangeForBackground = [firstChar isEqualToString:@"\n"] ? NSMakeRange(range.location + 1, range.length - 1) : range;
+      NSRange rangeForBackground = [inputString characterAtIndex:range.location] == '\n' ? NSMakeRange(range.location + 1, range.length - 1) : range;
       [attributedString addAttribute:NSBackgroundColorAttributeName value:_markdownStyle.preBackgroundColor range:rangeForBackground];
       // TODO: pass background color and ranges to layout manager
     } else if ([type isEqualToString:@"h1"]) {


### PR DESCRIPTION
This PR adds missing background color for code blocks on iOS. Also, it correctly covers both cases:
1. the contents starts directly after opening \`\`\`.
1. the contents starts in a new line after opening \`\`\`.

<img src="https://github.com/software-mansion-labs/react-native-live-markdown/assets/20516055/27b3982e-cc21-4ab5-b8d1-f010a7b602ba" width="350" />
