### PR TITLE
Fix calling `onScroll` multiple times with incorrect y-axis offset

### DIFF
--- a/ios/MarkdownTextInputDecoratorView.mm
+++ b/ios/MarkdownTextInputDecoratorView.mm
@@ -89,10 +89,10 @@
   }
   if (_textView != nil) {
     [_textView setMarkdownUtils:nil];
-//    if (_textView.layoutManager != nil && [object_getClass(_textView.layoutManager) isEqual:[MarkdownLayoutManager class]]) {
-//      [_textView.layoutManager setValue:nil forKey:@"markdownUtils"];
-//      object_setClass(_textView.layoutManager, [NSLayoutManager class]);
-//    }
+   if (_textView.layoutManager != nil && [object_getClass(_textView.layoutManager) isEqual:[MarkdownLayoutManager class]]) {
+     [_textView.layoutManager setValue:nil forKey:@"markdownUtils"];
+     object_setClass(_textView.layoutManager, [NSLayoutManager class]);
+   }
   }
 }
 

--- a/ios/MarkdownTextInputDecoratorView.mm
+++ b/ios/MarkdownTextInputDecoratorView.mm
@@ -89,10 +89,10 @@
   }
   if (_textView != nil) {
     [_textView setMarkdownUtils:nil];
-   if (_textView.layoutManager != nil && [object_getClass(_textView.layoutManager) isEqual:[MarkdownLayoutManager class]]) {
-     [_textView.layoutManager setValue:nil forKey:@"markdownUtils"];
-     object_setClass(_textView.layoutManager, [NSLayoutManager class]);
-   }
+    if (_textView.layoutManager != nil && [object_getClass(_textView.layoutManager) isEqual:[MarkdownLayoutManager class]]) {
+      [_textView.layoutManager setValue:nil forKey:@"markdownUtils"];
+      object_setClass(_textView.layoutManager, [NSLayoutManager class]);
+    }
   }
 }
 

--- a/ios/MarkdownTextInputDecoratorView.mm
+++ b/ios/MarkdownTextInputDecoratorView.mm
@@ -70,8 +70,10 @@
   } else if ([backedTextInputView isKindOfClass:[RCTUITextView class]]) {
     _textView = (RCTUITextView *)backedTextInputView;
     [_textView setMarkdownUtils:_markdownUtils];
-    object_setClass(_textView.layoutManager, [MarkdownLayoutManager class]);
-    [_textView.layoutManager setValue:_markdownUtils forKey:@"markdownUtils"];
+    NSLayoutManager *layoutManager = _textView.layoutManager; // switching to TextKit 1 compatibility mode
+    layoutManager.allowsNonContiguousLayout = NO; // workaround for onScroll issue
+    object_setClass(layoutManager, [MarkdownLayoutManager class]);
+    [layoutManager setValue:_markdownUtils forKey:@"markdownUtils"];
   } else {
     react_native_assert(false && "Cannot enable Markdown for this type of TextInput.");
   }
@@ -87,10 +89,10 @@
   }
   if (_textView != nil) {
     [_textView setMarkdownUtils:nil];
-    if (_textView.layoutManager != nil && [object_getClass(_textView.layoutManager) isEqual:[MarkdownLayoutManager class]]) {
-      [_textView.layoutManager setValue:nil forKey:@"markdownUtils"];
-      object_setClass(_textView.layoutManager, [NSLayoutManager class]);
-    }
+//    if (_textView.layoutManager != nil && [object_getClass(_textView.layoutManager) isEqual:[MarkdownLayoutManager class]]) {
+//      [_textView.layoutManager setValue:nil forKey:@"markdownUtils"];
+//      object_setClass(_textView.layoutManager, [NSLayoutManager class]);
+//    }
   }
 }
 


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Details
<!-- Explanation of the change or anything fishy that is going on -->

Fixes #139. Fixes #136.

This PR fixes the incorrect behavior of `MarkdownTextInput` when `maxHeight` is set, in particular:
1. eliminates emitting `onLayout` events on each keypress with incorrect y-axis offset
2. restores automatically scrolling to the next line once newline character is appended 

Source: https://stackoverflow.com/a/43270032/23325954

### Related Issues
<!-- Please replace GH_LINK with the link to the GitHub issue this Pull Request is related to -->
GH_LINK

### Manual Tests
<!---
Most changes should have accompanying tests. Describe the tests you added or if no tests were added an explanation about why one was not needed.
--->

### Linked PRs
<!---
Please include links to any update PRs in repos that must change their package.json version.
--->