### PR TITLE
Fix Android crash `mMarkdownStyle is null`

### DIFF
--- a/android/src/main/java/com/expensify/livemarkdown/MarkdownTextInputDecoratorView.java
+++ b/android/src/main/java/com/expensify/livemarkdown/MarkdownTextInputDecoratorView.java
@@ -70,7 +70,6 @@ public class MarkdownTextInputDecoratorView extends View {
       mReactEditText = null;
       mTextWatcher = null;
       mMarkdownUtils = null;
-      mMarkdownStyle = null;
     }
   }
 


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Details
<!-- Explanation of the change or anything fishy that is going on -->

This PR fixes the following crash on Android that happens when returning back to the screen where `MarkdownTextInput` is mounted:

```
02-03 13:20:42.924 19312 19312 E AndroidRuntime: java.lang.NullPointerException: mMarkdownStyle is null
02-03 13:20:42.924 19312 19312 E AndroidRuntime: 	at java.util.Objects.requireNonNull(Objects.java:232)
02-03 13:20:42.924 19312 19312 E AndroidRuntime: 	at com.expensify.livemarkdown.MarkdownUtils.a(SourceFile:5)
02-03 13:20:42.924 19312 19312 E AndroidRuntime: 	at f6.m.onTextChanged(SourceFile:14)
02-03 13:20:42.924 19312 19312 E AndroidRuntime: 	at com.facebook.react.views.textinput.g.onTextChanged(SourceFile:27)
02-03 13:20:42.924 19312 19312 E AndroidRuntime: 	at android.widget.TextView.sendOnTextChanged(TextView.java:12359)
02-03 13:20:42.924 19312 19312 E AndroidRuntime: 	at android.widget.TextView.handleTextChanged(TextView.java:12474)
02-03 13:20:42.924 19312 19312 E AndroidRuntime: 	at android.widget.TextView$ChangeWatcher.onTextChanged(TextView.java:15887)
02-03 13:20:42.924 19312 19312 E AndroidRuntime: 	at android.text.SpannableStringBuilder.sendTextChanged(SpannableStringBuilder.java:1268)
02-03 13:20:42.924 19312 19312 E AndroidRuntime: 	at android.text.SpannableStringBuilder.replace(SpannableStringBuilder.java:577)
02-03 13:20:42.924 19312 19312 E AndroidRuntime: 	at androidx.emoji2.text.x.replace(SourceFile:7)
02-03 13:20:42.924 19312 19312 E AndroidRuntime: 	at android.text.SpannableStringBuilder.replace(SpannableStringBuilder.java:508)
02-03 13:20:42.924 19312 19312 E AndroidRuntime: 	at androidx.emoji2.text.x.replace(SourceFile:4)
02-03 13:20:42.924 19312 19312 E AndroidRuntime: 	at androidx.emoji2.text.x.replace(SourceFile:1)
02-03 13:20:42.924 19312 19312 E AndroidRuntime: 	at android.view.inputmethod.BaseInputConnection.replaceTextInternal(BaseInputConnection.java:1026)
02-03 13:20:42.924 19312 19312 E AndroidRuntime: 	at android.view.inputmethod.BaseInputConnection.replaceText(BaseInputConnection.java:962)
02-03 13:20:42.924 19312 19312 E AndroidRuntime: 	at android.view.inputmethod.BaseInputConnection.commitText(BaseInputConnection.java:241)
02-03 13:20:42.924 19312 19312 E AndroidRuntime: 	at com.android.internal.inputmethod.EditableInputConnection.commitText(EditableInputConnection.java:222)
02-03 13:20:42.924 19312 19312 E AndroidRuntime: 	at android.view.inputmethod.InputConnectionWrapper.commitText(InputConnectionWrapper.java:207)
02-03 13:20:42.924 19312 19312 E AndroidRuntime: 	at android.view.inputmethod.InputConnectionWrapper.commitText(InputConnectionWrapper.java:207)
02-03 13:20:42.924 19312 19312 E AndroidRuntime: 	at com.facebook.react.views.textinput.i.commitText(SourceFile:32)
02-03 13:20:42.924 19312 19312 E AndroidRuntime: 	at android.view.inputmethod.RemoteInputConnectionImpl.lambda$commitText$17(RemoteInputConnectionImpl.java:649)
02-03 13:20:42.924 19312 19312 E AndroidRuntime: 	at android.view.inputmethod.RemoteInputConnectionImpl.$r8$lambda$jG8e73WUDH3moNu5UWHEmrz2eOk(Unknown Source:0)
02-03 13:20:42.924 19312 19312 E AndroidRuntime: 	at android.view.inputmethod.RemoteInputConnectionImpl$$ExternalSyntheticLambda18.run(Unknown Source:8)
02-03 13:20:42.924 19312 19312 E AndroidRuntime: 	at android.os.Handler.handleCallback(Handler.java:958)
02-03 13:20:42.924 19312 19312 E AndroidRuntime: 	at android.os.Handler.dispatchMessage(Handler.java:99)
02-03 13:20:42.924 19312 19312 E AndroidRuntime: 	at android.os.Looper.loopOnce(Looper.java:205)
02-03 13:20:42.924 19312 19312 E AndroidRuntime: 	at android.os.Looper.loop(Looper.java:294)
02-03 13:20:42.924 19312 19312 E AndroidRuntime: 	at android.app.ActivityThread.main(ActivityThread.java:8248)
02-03 13:20:42.924 19312 19312 E AndroidRuntime: 	at java.lang.reflect.Method.invoke(Native Method)
02-03 13:20:42.924 19312 19312 E AndroidRuntime: 	at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:552)
02-03 13:20:42.924 19312 19312 E AndroidRuntime: 	at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:971)
```

Most likely the root cause of the crash is that `onDetachedFromWindow` resets `mMarkdownStyle` and when the component gets mounted again, `onAttachedToWindow` is called before `setMarkdownStyle` and thus `applyMarkdownFormatting` has null `mMarkdownStyle` and `Object.assertNonNull` fails.


### Related Issues

Fixes https://github.com/Expensify/App/issues/35765

### Manual Tests
<!---
Most changes should have accompanying tests. Describe the tests you added or if no tests were added an explanation about why one was not needed.
--->

### Linked PRs
<!---
Please include links to any update PRs in repos that must change their package.json version.
--->