### PR TITLE
Use `useLayoutEffect` instead of `useEffect` for string parsing and height measurements

### DIFF
--- a/src/MarkdownTextInput.web.tsx
+++ b/src/MarkdownTextInput.web.tsx
@@ -9,7 +9,7 @@ import type {
   TextInputKeyPressEventData,
   TextInputFocusEventData,
 } from 'react-native';
-import React, {useEffect, useRef, useCallback, useMemo,useLayoutEffect} from 'react';
+import React, {useEffect, useRef, useCallback, useMemo, useLayoutEffect} from 'react';
 import type {CSSProperties, MutableRefObject, ReactEventHandler, FocusEventHandler, MouseEvent, KeyboardEvent, SyntheticEvent} from 'react';
 import {StyleSheet} from 'react-native';
 import * as ParseUtils from './web/parserUtils';
@@ -451,29 +451,35 @@ const MarkdownTextInput = React.forwardRef<TextInput, MarkdownTextInputProps>(
       divRef.current = r;
     };
 
-    useClientEffect(() => {
-      if (!divRef.current || processedValue === divRef.current.innerText) {
-        return;
-      }
+    useClientEffect(
+      function parseAndStyleValue() {
+        if (!divRef.current || processedValue === divRef.current.innerText) {
+          return;
+        }
 
-      if (value === undefined) {
-        parseText(divRef.current, divRef.current.innerText, processedMarkdownStyle);
-        return;
-      }
+        if (value === undefined) {
+          parseText(divRef.current, divRef.current.innerText, processedMarkdownStyle);
+          return;
+        }
 
-      const text = processedValue !== undefined ? processedValue : '';
-      parseText(divRef.current, text, processedMarkdownStyle, text.length);
-      updateTextColor(divRef.current, value);
-    }, [multiline, processedMarkdownStyle, processedValue]);
+        const text = processedValue !== undefined ? processedValue : '';
+        parseText(divRef.current, text, processedMarkdownStyle, text.length);
+        updateTextColor(divRef.current, value);
+      },
+      [multiline, processedMarkdownStyle, processedValue],
+    );
 
-    useClientEffect(function adjustHeightt() {
-      if (!divRef.current || !multiline) {
-        return;
-      }
-      const elementHeight = getElementHeight(divRef.current, inputStyles, numberOfLines);
-      divRef.current.style.height = elementHeight;
-      divRef.current.style.maxHeight = elementHeight;
-    }, [numberOfLines]);
+    useClientEffect(
+      function adjustHeight() {
+        if (!divRef.current || !multiline) {
+          return;
+        }
+        const elementHeight = getElementHeight(divRef.current, inputStyles, numberOfLines);
+        divRef.current.style.height = elementHeight;
+        divRef.current.style.maxHeight = elementHeight;
+      },
+      [numberOfLines],
+    );
 
     return (
       // eslint-disable-next-line jsx-a11y/no-static-element-interactions

--- a/src/MarkdownTextInput.web.tsx
+++ b/src/MarkdownTextInput.web.tsx
@@ -9,7 +9,7 @@ import type {
   TextInputKeyPressEventData,
   TextInputFocusEventData,
 } from 'react-native';
-import React, {useEffect, useRef, useCallback, useMemo} from 'react';
+import React, {useEffect, useRef, useCallback, useMemo,useLayoutEffect} from 'react';
 import type {CSSProperties, MutableRefObject, ReactEventHandler, FocusEventHandler, MouseEvent, KeyboardEvent, SyntheticEvent} from 'react';
 import {StyleSheet} from 'react-native';
 import * as ParseUtils from './web/parserUtils';
@@ -20,6 +20,8 @@ import './web/MarkdownTextInput.css';
 import InputHistory from './web/InputHistory';
 
 require('../parser/react-native-live-markdown-parser.js');
+
+const useClientEffect = typeof window === 'undefined' ? useEffect : useLayoutEffect;
 
 let createReactDOMStyle: (style: any) => any;
 try {
@@ -449,7 +451,7 @@ const MarkdownTextInput = React.forwardRef<TextInput, MarkdownTextInputProps>(
       divRef.current = r;
     };
 
-    useEffect(() => {
+    useClientEffect(() => {
       if (!divRef.current || processedValue === divRef.current.innerText) {
         return;
       }
@@ -464,7 +466,7 @@ const MarkdownTextInput = React.forwardRef<TextInput, MarkdownTextInputProps>(
       updateTextColor(divRef.current, value);
     }, [multiline, processedMarkdownStyle, processedValue]);
 
-    useEffect(() => {
+    useClientEffect(function adjustHeightt() {
       if (!divRef.current || !multiline) {
         return;
       }


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Details
<!-- Explanation of the change or anything fishy that is going on -->

> useLayoutEffect is a version of [useEffect](https://react.dev/reference/react/useEffect) that fires before the browser repaints the screen.

<img width="1036" alt="Screenshot 2024-02-08 at 10 34 58 AM" src="https://github.com/Expensify/react-native-live-markdown/assets/13172299/800919c5-8433-4c82-9706-b110bfe5167a">

It's ideal for cases where dimensions are derived from a DOM element and then updates some other element before react paints the screen. These seem like good use cases.

### Related Issues
<!-- Please replace GH_LINK with the link to the GitHub issue this Pull Request is related to -->
GH_LINK

close #166

### Manual Tests
<!---
Most changes should have accompanying tests. Describe the tests you added or if no tests were added an explanation about why one was not needed.
--->

I didn't add any tests, I'll try a video comparison maybe?

### Linked PRs
<!---
Please include links to any update PRs in repos that must change their package.json version.
--->