### PR TITLE
Add selectionStart and selectionEnd variables to markdown input ref 

### DIFF
--- a/src/MarkdownTextInput.web.tsx
+++ b/src/MarkdownTextInput.web.tsx
@@ -176,7 +176,6 @@ const MarkdownTextInput = React.forwardRef<TextInput, MarkdownTextInputProps>(
       markdownHTMLInput.selectionStart = selection.start;
       markdownHTMLInput.selectionEnd = selection.end;
       contentSelection.current = selection;
-      return selection;
     }, []);
 
     const parseText = useCallback(
@@ -357,17 +356,13 @@ const MarkdownTextInput = React.forwardRef<TextInput, MarkdownTextInputProps>(
       [onKeyPress],
     );
 
-    const handleKeyUp = useCallback(() => {
-      updateSelection();
-    }, []);
-
     const handleSelectionChange: ReactEventHandler<HTMLDivElement> = useCallback(
       (event) => {
         const e = event as unknown as NativeSyntheticEvent<TextInputSelectionChangeEventData>;
         setEventProps(e);
-        const selection = updateSelection();
-        if (onSelectionChange && selection) {
-          e.nativeEvent.selection = selection;
+        updateSelection();
+        if (onSelectionChange && contentSelection.current) {
+          e.nativeEvent.selection = contentSelection.current;
           onSelectionChange(e);
         }
       },
@@ -499,7 +494,7 @@ const MarkdownTextInput = React.forwardRef<TextInput, MarkdownTextInputProps>(
         autoCapitalize={autoCapitalize}
         className={className}
         onKeyDown={handleKeyPress}
-        onKeyUp={handleKeyUp}
+        onKeyUp={updateSelection}
         onInput={handleOnChangeText}
         onSelect={handleSelectionChange}
         onClick={handleClick}

--- a/src/MarkdownTextInput.web.tsx
+++ b/src/MarkdownTextInput.web.tsx
@@ -189,6 +189,8 @@ const MarkdownTextInput = React.forwardRef<TextInput, MarkdownTextInputProps>(
           history.current.debouncedAdd(parsedText.text, parsedText.cursorPosition);
         }
 
+        updateSelection();
+
         return parsedText;
       },
       [multiline],

--- a/src/MarkdownTextInput.web.tsx
+++ b/src/MarkdownTextInput.web.tsx
@@ -172,9 +172,10 @@ const MarkdownTextInput = React.forwardRef<TextInput, MarkdownTextInputProps>(
         return;
       }
       const selection = CursorUtils.getCurrentCursorPosition(divRef.current);
+      const markdownHTMLInput = divRef.current as HTMLInputElement;
+      markdownHTMLInput.selectionStart = selection.start;
+      markdownHTMLInput.selectionEnd = selection.end;
       contentSelection.current = selection;
-      (divRef.current as HTMLInputElement).selectionStart = selection.start;
-      (divRef.current as HTMLInputElement).selectionEnd = selection.end;
       return selection;
     }, []);
 


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Details
<!-- Explanation of the change or anything fishy that is going on -->
This PR fixes how our markdown text input tracks text selection and adds `selectionStart` and `selectionEnd` variables to input ref.

### Related Issues
<!-- Please replace GH_LINK with the link to the GitHub issue this Pull Request is related to -->
https://github.com/Expensify/react-native-live-markdown/issues/173

### Manual Tests
<!---
Most changes should have accompanying tests. Describe the tests you added or if no tests were added an explanation about why one was not needed.
--->
Using reproduction code from the linked issue start changing the text selection. Verify in console if it returns correct values. Next, position your cursor at the beginning of the markdown text input and after clicking `arrow up`, verify if focus is changed into RN text input that is above

### Linked PRs
<!---
Please include links to any update PRs in repos that must change their package.json version.
--->
https://github.com/Expensify/App/issues/36173