### PR TITLE
Fix event targets returned by paste eventListeners

### DIFF
--- a/src/MarkdownTextInput.web.tsx
+++ b/src/MarkdownTextInput.web.tsx
@@ -473,6 +473,28 @@ const MarkdownTextInput = React.forwardRef<TextInput, MarkdownTextInputProps>(
       divRef.current.style.maxHeight = elementHeight;
     }, [numberOfLines]);
 
+    useEffect(() => {
+      // update event listeners events objects
+      const originalAddEventListener = EventTarget.prototype.addEventListener;
+      EventTarget.prototype.addEventListener = function (eventName, callback) {
+        if (eventName === 'paste') {
+          originalAddEventListener.call(this, eventName, function (event) {
+            try {
+              if (divRef.current && divRef.current.contains(event.target as Node)) {
+                Object.defineProperty(event, 'target', {writable: false, value: divRef.current});
+              }
+              if (typeof callback === 'function') {
+                callback(event);
+              }
+              // eslint-disable-next-line no-empty
+            } catch (e) {}
+          });
+        } else {
+          originalAddEventListener.call(this, eventName, callback);
+        }
+      };
+    }, []);
+
     return (
       // eslint-disable-next-line jsx-a11y/no-static-element-interactions
       <div

--- a/src/MarkdownTextInput.web.tsx
+++ b/src/MarkdownTextInput.web.tsx
@@ -477,15 +477,14 @@ const MarkdownTextInput = React.forwardRef<TextInput, MarkdownTextInputProps>(
       // update event listeners events objects
       const originalAddEventListener = EventTarget.prototype.addEventListener;
       EventTarget.prototype.addEventListener = function (eventName, callback) {
-        if (eventName === 'paste') {
+        if (eventName === 'paste' && typeof callback === 'function') {
           originalAddEventListener.call(this, eventName, function (event) {
             try {
               if (divRef.current && divRef.current.contains(event.target as Node)) {
+                // pasting returns styled span elements as event.target instead of the contentEditable div. We want to keep the div as the target
                 Object.defineProperty(event, 'target', {writable: false, value: divRef.current});
               }
-              if (typeof callback === 'function') {
-                callback(event);
-              }
+              callback(event);
               // eslint-disable-next-line no-empty
             } catch (e) {}
           });


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Details
<!-- Explanation of the change or anything fishy that is going on -->
This PR fixes the problem with different event targets depending on markdown input content.

### Related Issues
<!-- Please replace GH_LINK with the link to the GitHub issue this Pull Request is related to -->
https://github.com/Expensify/react-native-live-markdown/issues/177

### Manual Tests
<!---
Most changes should have accompanying tests. Describe the tests you added or if no tests were added an explanation about why one was not needed.
--->
After adding `document.addEventListener('paste', yourFunction);` check if event.target is always equal to MarkdownTextInput ref.

### Linked PRs
<!---
Please include links to any update PRs in repos that must change their package.json version.
--->

https://github.com/Expensify/App/issues/36269