### PR TITLE
Remove try catch from paste event listener handler

### DIFF
--- a/src/MarkdownTextInput.web.tsx
+++ b/src/MarkdownTextInput.web.tsx
@@ -491,7 +491,6 @@ const MarkdownTextInput = React.forwardRef<TextInput, MarkdownTextInputProps>(
               Object.defineProperty(event, 'target', {writable: false, value: divRef.current});
             }
             callback(event);
-            // eslint-disable-next-line no-empty
           });
         } else {
           originalAddEventListener.call(this, eventName, callback);

--- a/src/MarkdownTextInput.web.tsx
+++ b/src/MarkdownTextInput.web.tsx
@@ -486,14 +486,12 @@ const MarkdownTextInput = React.forwardRef<TextInput, MarkdownTextInputProps>(
       EventTarget.prototype.addEventListener = function (eventName, callback) {
         if (eventName === 'paste' && typeof callback === 'function') {
           originalAddEventListener.call(this, eventName, function (event) {
-            try {
-              if (divRef.current && divRef.current.contains(event.target as Node)) {
-                // pasting returns styled span elements as event.target instead of the contentEditable div. We want to keep the div as the target
-                Object.defineProperty(event, 'target', {writable: false, value: divRef.current});
-              }
-              callback(event);
-              // eslint-disable-next-line no-empty
-            } catch (e) {}
+            if (divRef.current && divRef.current.contains(event.target as Node)) {
+              // pasting returns styled span elements as event.target instead of the contentEditable div. We want to keep the div as the target
+              Object.defineProperty(event, 'target', {writable: false, value: divRef.current});
+            }
+            callback(event);
+            // eslint-disable-next-line no-empty
           });
         } else {
           originalAddEventListener.call(this, eventName, callback);


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Details
<!-- Explanation of the change or anything fishy that is going on -->

Follow up to https://github.com/Expensify/react-native-live-markdown/pull/178

### Related Issues
<!-- Please replace GH_LINK with the link to the GitHub issue this Pull Request is related to -->
[GH_LINK](https://github.com/Expensify/react-native-live-markdown/pull/178)

### Manual Tests
<!---
Most changes should have accompanying tests. Describe the tests you added or if no tests were added an explanation about why one was not needed.
--->

In your App add the following code and test if pasting text to live markdown text input doesn't throw any errors.
```javascript
document.addEventListener('paste', (e) => {
      // your code
});
```

### Linked PRs
<!---
Please include links to any update PRs in repos that must change their package.json version.
--->