### PR TITLE
Fix `onSelectionChange` event called twice with different payload on iOS for multiline

### DIFF
--- a/ios/RCTBaseTextInputView+Markdown.m
+++ b/ios/RCTBaseTextInputView+Markdown.m
@@ -30,18 +30,16 @@
     id<RCTBackedTextInputViewProtocol> backedTextInputView = self.backedTextInputView;
     NSAttributedString *oldAttributedText = backedTextInputView.attributedText;
     NSAttributedString *newAttributedText = [markdownUtils parseMarkdown:oldAttributedText];
-    if (![newAttributedText isEqualToAttributedString:oldAttributedText]) {
-      UITextRange *range = backedTextInputView.selectedTextRange;
+    UITextRange *range = backedTextInputView.selectedTextRange;
 
-      // update attributed text without calling textInputDidChangeSelection and emitting onSelectionChange event
-      id<RCTBackedTextInputDelegate> delegate = backedTextInputView.textInputDelegate;
-      backedTextInputView.textInputDelegate = nil;
-      [backedTextInputView setAttributedText:newAttributedText];
-      backedTextInputView.textInputDelegate = delegate;
+    // update attributed text without calling textInputDidChangeSelection and emitting onSelectionChange event
+    id<RCTBackedTextInputDelegate> delegate = backedTextInputView.textInputDelegate;
+    backedTextInputView.textInputDelegate = nil;
+    [backedTextInputView setAttributedText:newAttributedText];
+    backedTextInputView.textInputDelegate = delegate;
 
-      // restore original selection
-      [backedTextInputView setSelectedTextRange:range notifyDelegate:YES];
-    }
+    // restore original selection
+    [backedTextInputView setSelectedTextRange:range notifyDelegate:YES];
   }
 
   // Call the original method

--- a/ios/RCTBaseTextInputView+Markdown.m
+++ b/ios/RCTBaseTextInputView+Markdown.m
@@ -27,10 +27,21 @@
 {
   RCTMarkdownUtils *markdownUtils = [self getMarkdownUtils];
   if (markdownUtils != nil) {
-    UITextRange *range = self.backedTextInputView.selectedTextRange;
-    NSAttributedString *attributedText = [markdownUtils parseMarkdown:self.backedTextInputView.attributedText];
-    [self.backedTextInputView setAttributedText:attributedText];
-    [self.backedTextInputView setSelectedTextRange:range notifyDelegate:YES];
+    id<RCTBackedTextInputViewProtocol> backedTextInputView = self.backedTextInputView;
+    NSAttributedString *oldAttributedText = backedTextInputView.attributedText;
+    NSAttributedString *newAttributedText = [markdownUtils parseMarkdown:oldAttributedText];
+    if (![newAttributedText isEqualToAttributedString:oldAttributedText]) {
+      UITextRange *range = backedTextInputView.selectedTextRange;
+
+      // update attributed text without calling textInputDidChangeSelection and emitting onSelectionChange event
+      id<RCTBackedTextInputDelegate> delegate = backedTextInputView.textInputDelegate;
+      backedTextInputView.textInputDelegate = nil;
+      [backedTextInputView setAttributedText:newAttributedText];
+      backedTextInputView.textInputDelegate = delegate;
+
+      // restore original selection
+      [backedTextInputView setSelectedTextRange:range notifyDelegate:YES];
+    }
   }
 
   // Call the original method

--- a/ios/RCTBaseTextInputView+Markdown.m
+++ b/ios/RCTBaseTextInputView+Markdown.m
@@ -32,13 +32,13 @@
     NSAttributedString *newAttributedText = [markdownUtils parseMarkdown:oldAttributedText];
     UITextRange *range = backedTextInputView.selectedTextRange;
 
-    // update attributed text without calling textInputDidChangeSelection and emitting onSelectionChange event
+    // update attributed text without emitting onSelectionChange event
     id<RCTBackedTextInputDelegate> delegate = backedTextInputView.textInputDelegate;
     backedTextInputView.textInputDelegate = nil;
     [backedTextInputView setAttributedText:newAttributedText];
     backedTextInputView.textInputDelegate = delegate;
 
-    // restore original selection
+    // restore original selection and emit onSelectionChange event
     [backedTextInputView setSelectedTextRange:range notifyDelegate:YES];
   }
 


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

See RCA in https://github.com/Expensify/react-native-live-markdown/issues/185#issuecomment-1945808008

### Details
<!-- Explanation of the change or anything fishy that is going on -->

https://github.com/Expensify/react-native-live-markdown/assets/20516055/b0d1d45c-88bc-4617-861f-405109fb57ee

### Related Issues
<!-- Please replace GH_LINK with the link to the GitHub issue this Pull Request is related to -->
Fixes #185.

### Manual Tests
<!---
Most changes should have accompanying tests. Describe the tests you added or if no tests were added an explanation about why one was not needed.
--->

### Linked PRs
<!---
Please include links to any update PRs in repos that must change their package.json version.
--->