### PR TITLE
Add selection variables to web implementation

### DIFF
--- a/example/src/App.tsx
+++ b/example/src/App.tsx
@@ -62,6 +62,7 @@ function getRandomColor() {
 export default function App() {
   const [value, setValue] = React.useState(DEFAULT_TEXT);
   const [markdownStyle, setMarkdownStyle] = React.useState({});
+  const [selection, setSelection] = React.useState({start: 0, end: 0});
 
   // TODO: use MarkdownTextInput ref instead of TextInput ref
   const ref = React.useRef<TextInput>(null);
@@ -98,6 +99,10 @@ export default function App() {
         ref={ref}
         markdownStyle={markdownStyle}
         placeholder="Type here..."
+        onSelectionChange={(e) => {
+          setSelection({...e.nativeEvent.selection});
+        }}
+        selection={selection}
       />
       {/* <Text>TextInput singleline</Text>
       <TextInput
@@ -153,6 +158,16 @@ export default function App() {
             },
           })
         }
+      />
+      <Button
+        title="Change selection"
+        onPress={() => {
+          if (!ref.current) {
+            return;
+          }
+          ref.current.focus();
+          setSelection({start: 0, end: 20});
+        }}
       />
     </View>
   );

--- a/example/src/App.tsx
+++ b/example/src/App.tsx
@@ -99,9 +99,7 @@ export default function App() {
         ref={ref}
         markdownStyle={markdownStyle}
         placeholder="Type here..."
-        onSelectionChange={(e) => {
-          setSelection(e.nativeEvent.selection);
-        }}
+        onSelectionChange={(e) => setSelection(e.nativeEvent.selection)}
         selection={selection}
       />
       {/* <Text>TextInput singleline</Text>

--- a/example/src/App.tsx
+++ b/example/src/App.tsx
@@ -100,7 +100,7 @@ export default function App() {
         markdownStyle={markdownStyle}
         placeholder="Type here..."
         onSelectionChange={(e) => {
-          setSelection({...e.nativeEvent.selection});
+          setSelection(e.nativeEvent.selection);
         }}
         selection={selection}
       />

--- a/src/MarkdownTextInput.web.tsx
+++ b/src/MarkdownTextInput.web.tsx
@@ -307,11 +307,12 @@ const MarkdownTextInput = React.forwardRef<TextInput, MarkdownTextInputProps>(
       const currentSelection = CursorUtils.getCurrentCursorPosition(divRef.current);
 
       if (contentSelection.current.start !== currentSelection.start || contentSelection.current.end !== currentSelection.end) {
-        const markdownHTMLInput = divRef.current as HTMLInputElement;
-        markdownHTMLInput.selectionStart = currentSelection.start;
-        markdownHTMLInput.selectionEnd = currentSelection.end;
-        contentSelection.current = currentSelection;
-
+        if (contentSelection.current.start >= 0 && contentSelection.current.end >= 0) {
+          const markdownHTMLInput = divRef.current as HTMLInputElement;
+          markdownHTMLInput.selectionStart = currentSelection.start;
+          markdownHTMLInput.selectionEnd = currentSelection.end;
+          contentSelection.current = currentSelection;
+        }
         if (e) {
           handleSelectionChange(e);
         }

--- a/src/MarkdownTextInput.web.tsx
+++ b/src/MarkdownTextInput.web.tsx
@@ -321,10 +321,9 @@ const MarkdownTextInput = React.forwardRef<TextInput, MarkdownTextInputProps>(
       const newSelection = CursorUtils.getCurrentCursorPosition(divRef.current);
 
       if (newSelection && (contentSelection.current.start !== newSelection.start || contentSelection.current.end !== newSelection.end)) {
-        if (contentSelection.current.start >= 0 && contentSelection.current.end >= 0) {
-          updateRefSelectionVariables(newSelection);
-          contentSelection.current = newSelection;
-        }
+        updateRefSelectionVariables(newSelection);
+        contentSelection.current = newSelection;
+
         if (e) {
           handleSelectionChange(e);
         }

--- a/src/MarkdownTextInput.web.tsx
+++ b/src/MarkdownTextInput.web.tsx
@@ -322,7 +322,7 @@ const MarkdownTextInput = React.forwardRef<TextInput, MarkdownTextInputProps>(
 
       if (newSelection && (contentSelection.current.start !== newSelection.start || contentSelection.current.end !== newSelection.end)) {
         if (contentSelection.current.start >= 0 && contentSelection.current.end >= 0) {
-          updateRefSelectionVariables(contentSelection.current);
+          updateRefSelectionVariables(newSelection);
           contentSelection.current = newSelection;
         }
         if (e) {

--- a/src/MarkdownTextInput.web.tsx
+++ b/src/MarkdownTextInput.web.tsx
@@ -300,6 +300,12 @@ const MarkdownTextInput = React.forwardRef<TextInput, MarkdownTextInputProps>(
       [onSelectionChange, setEventProps],
     );
 
+    const updateRefSelectionVariables = useCallback((start: number, end: number) => {
+      const markdownHTMLInput = divRef.current as HTMLInputElement;
+      markdownHTMLInput.selectionStart = start;
+      markdownHTMLInput.selectionEnd = end;
+    }, []);
+
     const updateSelection = useCallback((e: SyntheticEvent<HTMLDivElement> | null = null) => {
       if (!divRef.current) {
         return;
@@ -308,9 +314,7 @@ const MarkdownTextInput = React.forwardRef<TextInput, MarkdownTextInputProps>(
 
       if (contentSelection.current.start !== currentSelection.start || contentSelection.current.end !== currentSelection.end) {
         if (contentSelection.current.start >= 0 && contentSelection.current.end >= 0) {
-          const markdownHTMLInput = divRef.current as HTMLInputElement;
-          markdownHTMLInput.selectionStart = currentSelection.start;
-          markdownHTMLInput.selectionEnd = currentSelection.end;
+          updateRefSelectionVariables(contentSelection.current.start, contentSelection.current.end);
           contentSelection.current = currentSelection;
         }
         if (e) {
@@ -519,11 +523,14 @@ const MarkdownTextInput = React.forwardRef<TextInput, MarkdownTextInputProps>(
     }, []);
 
     useEffect(() => {
-      // focus the input on mount if autoFocus is set
-      if (!(divRef.current && autoFocus)) {
+      if (!divRef.current) {
         return;
       }
-      divRef.current.focus();
+      // focus the input on mount if autoFocus is set
+      if (autoFocus) {
+        divRef.current.focus();
+      }
+      updateRefSelectionVariables(contentSelection.current.start, contentSelection.current.end);
     }, []);
 
     useEffect(() => {

--- a/src/MarkdownTextInput.web.tsx
+++ b/src/MarkdownTextInput.web.tsx
@@ -422,6 +422,7 @@ const MarkdownTextInput = React.forwardRef<TextInput, MarkdownTextInputProps>(
     const handleBlur: FocusEventHandler<HTMLDivElement> = useCallback(
       (event) => {
         const e = event as unknown as NativeSyntheticEvent<TextInputFocusEventData>;
+        CursorUtils.removeSelection();
         currentlyFocusedField.current = null;
         if (onBlur) {
           setEventProps(e);

--- a/src/MarkdownTextInput.web.tsx
+++ b/src/MarkdownTextInput.web.tsx
@@ -160,7 +160,7 @@ const MarkdownTextInput = React.forwardRef<TextInput, MarkdownTextInputProps>(
     const divRef = useRef<HTMLDivElement | null>(null);
     const currentlyFocusedField = useRef<HTMLDivElement | null>(null);
     const valueLength = value ? value.length : 0;
-    const contentSelection = useRef<Selection>({start: valueLength, end: valueLength});
+    const currentSelection = useRef<Selection>({start: valueLength, end: valueLength});
     const className = `react-native-live-markdown-input-${multiline ? 'multiline' : 'singleline'}`;
     const history = useRef<InputHistory>();
     if (!history.current) {
@@ -292,8 +292,8 @@ const MarkdownTextInput = React.forwardRef<TextInput, MarkdownTextInputProps>(
       (event) => {
         const e = event as unknown as NativeSyntheticEvent<TextInputSelectionChangeEventData>;
         setEventProps(e);
-        if (onSelectionChange && contentSelection.current) {
-          e.nativeEvent.selection = contentSelection.current;
+        if (onSelectionChange && currentSelection.current) {
+          e.nativeEvent.selection = currentSelection.current;
           onSelectionChange(e);
         }
       },
@@ -313,10 +313,10 @@ const MarkdownTextInput = React.forwardRef<TextInput, MarkdownTextInputProps>(
       }
       const newSelection = CursorUtils.getCurrentCursorPosition(divRef.current);
 
-      if (newSelection && (contentSelection.current.start !== newSelection.start || contentSelection.current.end !== newSelection.end)) {
-        if (contentSelection.current.start >= 0 && contentSelection.current.end >= 0) {
-          updateRefSelectionVariables(contentSelection.current);
-          contentSelection.current = newSelection;
+      if (newSelection && (currentSelection.current.start !== newSelection.start || currentSelection.current.end !== newSelection.end)) {
+        if (currentSelection.current.start >= 0 && currentSelection.current.end >= 0) {
+          updateRefSelectionVariables(currentSelection.current);
+          currentSelection.current = newSelection;
         }
         if (e) {
           handleSelectionChange(e);
@@ -394,8 +394,8 @@ const MarkdownTextInput = React.forwardRef<TextInput, MarkdownTextInputProps>(
         const hostNode = e.target as unknown as HTMLDivElement;
         currentlyFocusedField.current = hostNode;
         setEventProps(e);
-        if (divRef.current && contentSelection.current) {
-          CursorUtils.setCursorPosition(divRef.current, contentSelection.current.end || contentSelection.current.start);
+        if (divRef.current && currentSelection.current) {
+          CursorUtils.setCursorPosition(divRef.current, currentSelection.current.end || currentSelection.current.start);
         }
 
         if (onFocus) {
@@ -531,11 +531,11 @@ const MarkdownTextInput = React.forwardRef<TextInput, MarkdownTextInputProps>(
       if (autoFocus) {
         divRef.current.focus();
       }
-      updateRefSelectionVariables(contentSelection.current);
+      updateRefSelectionVariables(currentSelection.current);
     }, []);
 
     useEffect(() => {
-      if (!divRef.current || !selection || !(selection.start !== contentSelection.current.start || selection.end !== contentSelection.current.end)) {
+      if (!divRef.current || !selection || !(selection.start !== currentSelection.current.start || selection.end !== currentSelection.current.end)) {
         return;
       }
       CursorUtils.setCursorPosition(divRef.current, selection.start, selection.end);
@@ -579,8 +579,8 @@ const styles = StyleSheet.create({
     // @ts-expect-error it works on web
     boxSizing: 'border-box',
     whiteSpace: 'pre-wrap',
-    overflowY: 'scroll',
-    overflowX: 'scroll',
+    overflowY: 'auto',
+    overflowX: 'auto',
     overflowWrap: 'break-word',
   },
   disabledInputStyles: {

--- a/src/MarkdownTextInput.web.tsx
+++ b/src/MarkdownTextInput.web.tsx
@@ -312,7 +312,7 @@ const MarkdownTextInput = React.forwardRef<TextInput, MarkdownTextInputProps>(
       }
       const currentSelection = CursorUtils.getCurrentCursorPosition(divRef.current);
 
-      if (contentSelection.current.start !== currentSelection.start || contentSelection.current.end !== currentSelection.end) {
+      if (currentSelection && (contentSelection.current.start !== currentSelection.start || contentSelection.current.end !== currentSelection.end)) {
         if (contentSelection.current.start >= 0 && contentSelection.current.end >= 0) {
           updateRefSelectionVariables(contentSelection.current.start, contentSelection.current.end);
           contentSelection.current = currentSelection;

--- a/src/MarkdownTextInput.web.tsx
+++ b/src/MarkdownTextInput.web.tsx
@@ -175,7 +175,7 @@ const MarkdownTextInput = React.forwardRef<TextInput, MarkdownTextInputProps>(
     const setEventProps = useCallback((e: NativeSyntheticEvent<any>) => {
       if (divRef.current) {
         const text = normalizeValue(divRef.current.innerText || '');
-        if (e.target && typeof e.target !== 'number') {
+        if (e.target) {
           // TODO: change the logic here so every event have value property
           (e.target as unknown as HTMLInputElement).value = text;
         }
@@ -535,7 +535,7 @@ const MarkdownTextInput = React.forwardRef<TextInput, MarkdownTextInputProps>(
     }, []);
 
     useEffect(() => {
-      if (!divRef.current || !selection || !(selection.start !== currentSelection.current.start || selection.end !== currentSelection.current.end)) {
+      if (!divRef.current || !selection || (selection.start === currentSelection.current.start && selection.end === currentSelection.current.end)) {
         return;
       }
       CursorUtils.setCursorPosition(divRef.current, selection.start, selection.end);

--- a/src/MarkdownTextInput.web.tsx
+++ b/src/MarkdownTextInput.web.tsx
@@ -300,7 +300,8 @@ const MarkdownTextInput = React.forwardRef<TextInput, MarkdownTextInputProps>(
       [onSelectionChange, setEventProps],
     );
 
-    const updateRefSelectionVariables = useCallback((start: number, end: number) => {
+    const updateRefSelectionVariables = useCallback((newSelection: Selection) => {
+      const {start, end} = newSelection;
       const markdownHTMLInput = divRef.current as HTMLInputElement;
       markdownHTMLInput.selectionStart = start;
       markdownHTMLInput.selectionEnd = end;
@@ -310,12 +311,12 @@ const MarkdownTextInput = React.forwardRef<TextInput, MarkdownTextInputProps>(
       if (!divRef.current) {
         return;
       }
-      const currentSelection = CursorUtils.getCurrentCursorPosition(divRef.current);
+      const newSelection = CursorUtils.getCurrentCursorPosition(divRef.current);
 
-      if (currentSelection && (contentSelection.current.start !== currentSelection.start || contentSelection.current.end !== currentSelection.end)) {
+      if (newSelection && (contentSelection.current.start !== newSelection.start || contentSelection.current.end !== newSelection.end)) {
         if (contentSelection.current.start >= 0 && contentSelection.current.end >= 0) {
-          updateRefSelectionVariables(contentSelection.current.start, contentSelection.current.end);
-          contentSelection.current = currentSelection;
+          updateRefSelectionVariables(contentSelection.current);
+          contentSelection.current = newSelection;
         }
         if (e) {
           handleSelectionChange(e);
@@ -530,7 +531,7 @@ const MarkdownTextInput = React.forwardRef<TextInput, MarkdownTextInputProps>(
       if (autoFocus) {
         divRef.current.focus();
       }
-      updateRefSelectionVariables(contentSelection.current.start, contentSelection.current.end);
+      updateRefSelectionVariables(contentSelection.current);
     }, []);
 
     useEffect(() => {

--- a/src/MarkdownTextInput.web.tsx
+++ b/src/MarkdownTextInput.web.tsx
@@ -160,7 +160,7 @@ const MarkdownTextInput = React.forwardRef<TextInput, MarkdownTextInputProps>(
     const divRef = useRef<HTMLDivElement | null>(null);
     const currentlyFocusedField = useRef<HTMLDivElement | null>(null);
     const valueLength = value ? value.length : 0;
-    const currentSelection = useRef<Selection>({start: valueLength, end: valueLength});
+    const contentSelection = useRef<Selection>({start: valueLength, end: valueLength});
     const className = `react-native-live-markdown-input-${multiline ? 'multiline' : 'singleline'}`;
     const history = useRef<InputHistory>();
     if (!history.current) {
@@ -292,8 +292,8 @@ const MarkdownTextInput = React.forwardRef<TextInput, MarkdownTextInputProps>(
       (event) => {
         const e = event as unknown as NativeSyntheticEvent<TextInputSelectionChangeEventData>;
         setEventProps(e);
-        if (onSelectionChange && currentSelection.current) {
-          e.nativeEvent.selection = currentSelection.current;
+        if (onSelectionChange && contentSelection.current) {
+          e.nativeEvent.selection = contentSelection.current;
           onSelectionChange(e);
         }
       },
@@ -313,10 +313,10 @@ const MarkdownTextInput = React.forwardRef<TextInput, MarkdownTextInputProps>(
       }
       const newSelection = CursorUtils.getCurrentCursorPosition(divRef.current);
 
-      if (newSelection && (currentSelection.current.start !== newSelection.start || currentSelection.current.end !== newSelection.end)) {
-        if (currentSelection.current.start >= 0 && currentSelection.current.end >= 0) {
-          updateRefSelectionVariables(currentSelection.current);
-          currentSelection.current = newSelection;
+      if (newSelection && (contentSelection.current.start !== newSelection.start || contentSelection.current.end !== newSelection.end)) {
+        if (contentSelection.current.start >= 0 && contentSelection.current.end >= 0) {
+          updateRefSelectionVariables(contentSelection.current);
+          contentSelection.current = newSelection;
         }
         if (e) {
           handleSelectionChange(e);
@@ -394,8 +394,8 @@ const MarkdownTextInput = React.forwardRef<TextInput, MarkdownTextInputProps>(
         const hostNode = e.target as unknown as HTMLDivElement;
         currentlyFocusedField.current = hostNode;
         setEventProps(e);
-        if (divRef.current && currentSelection.current) {
-          CursorUtils.setCursorPosition(divRef.current, currentSelection.current.end || currentSelection.current.start);
+        if (divRef.current && contentSelection.current) {
+          CursorUtils.setCursorPosition(divRef.current, contentSelection.current.end || contentSelection.current.start);
         }
 
         if (onFocus) {
@@ -531,11 +531,11 @@ const MarkdownTextInput = React.forwardRef<TextInput, MarkdownTextInputProps>(
       if (autoFocus) {
         divRef.current.focus();
       }
-      updateRefSelectionVariables(currentSelection.current);
+      updateRefSelectionVariables(contentSelection.current);
     }, []);
 
     useEffect(() => {
-      if (!divRef.current || !selection || (selection.start === currentSelection.current.start && selection.end === currentSelection.current.end)) {
+      if (!divRef.current || !selection || (selection.start === contentSelection.current.start && selection.end === contentSelection.current.end)) {
         return;
       }
       CursorUtils.setCursorPosition(divRef.current, selection.start, selection.end);

--- a/src/MarkdownTextInput.web.tsx
+++ b/src/MarkdownTextInput.web.tsx
@@ -300,7 +300,7 @@ const MarkdownTextInput = React.forwardRef<TextInput, MarkdownTextInputProps>(
       [onSelectionChange, setEventProps],
     );
 
-    const updateSelection = useCallback((e) => {
+    const updateSelection = useCallback((e: SyntheticEvent<HTMLDivElement> | null = null) => {
       if (!divRef.current) {
         return;
       }
@@ -311,8 +311,10 @@ const MarkdownTextInput = React.forwardRef<TextInput, MarkdownTextInputProps>(
         markdownHTMLInput.selectionStart = currentSelection.start;
         markdownHTMLInput.selectionEnd = currentSelection.end;
         contentSelection.current = currentSelection;
-        // console.log(selection);
-        handleSelectionChange(e);
+
+        if (e) {
+          handleSelectionChange(e);
+        }
       }
     }, []);
 
@@ -350,7 +352,7 @@ const MarkdownTextInput = React.forwardRef<TextInput, MarkdownTextInputProps>(
           onKeyPress(event);
         }
 
-        updateSelection(event);
+        updateSelection(event as unknown as SyntheticEvent<HTMLDivElement, Event>);
 
         if (
           e.key === 'Enter' &&
@@ -387,7 +389,7 @@ const MarkdownTextInput = React.forwardRef<TextInput, MarkdownTextInputProps>(
         currentlyFocusedField.current = hostNode;
         setEventProps(e);
         if (divRef.current && contentSelection.current) {
-          CursorUtils.setCursorPosition(divRef.current, contentSelection.current.end, !multiline);
+          CursorUtils.setCursorPosition(divRef.current, contentSelection.current.end || contentSelection.current.start);
         }
 
         if (onFocus) {
@@ -526,7 +528,8 @@ const MarkdownTextInput = React.forwardRef<TextInput, MarkdownTextInputProps>(
       if (!divRef.current || !selection || !(selection.start !== contentSelection.current.start || selection.end !== contentSelection.current.end)) {
         return;
       }
-      CursorUtils.setCursorPosition(divRef.current, selection.start, !multiline);
+      CursorUtils.setCursorPosition(divRef.current, selection.start, selection.end);
+      updateSelection();
     }, [selection]);
 
     return (

--- a/src/web/cursorUtils.ts
+++ b/src/web/cursorUtils.ts
@@ -46,10 +46,10 @@ function setCursorPosition(target: HTMLElement, start: number, end: number | nul
     range.collapse(true);
   }
 
-  const sel = window.getSelection();
-  if (sel) {
-    sel.removeAllRanges();
-    sel.addRange(range);
+  const selection = window.getSelection();
+  if (selection) {
+    selection.removeAllRanges();
+    selection.addRange(range);
   }
 }
 
@@ -65,27 +65,23 @@ function moveCursorToEnd(target: HTMLElement) {
 }
 
 function getCurrentCursorPosition(target: HTMLElement) {
-  const sel = window.getSelection();
-
-  if (sel && sel.rangeCount > 0) {
-    const range = sel.getRangeAt(0);
+  const selection = window.getSelection();
+  if (selection && selection.rangeCount > 0) {
+    const range = selection.getRangeAt(0);
     const preSelectionRange = range.cloneRange();
     preSelectionRange.selectNodeContents(target);
     preSelectionRange.setEnd(range.startContainer, range.startOffset);
     const start = preSelectionRange.toString().length;
-
-    return {
-      start,
-      end: start + range.toString().length,
-    };
+    const end = start + range.toString().length;
+    return {start, end};
   }
   return {start: -1, end: -1};
 }
 
 function removeSelection() {
-  const sel = window.getSelection();
-  if (sel) {
-    sel.removeAllRanges();
+  const selection = window.getSelection();
+  if (selection) {
+    selection.removeAllRanges();
   }
 }
 

--- a/src/web/cursorUtils.ts
+++ b/src/web/cursorUtils.ts
@@ -1,20 +1,22 @@
+function findTextNodes(textNodes: Text[], node: ChildNode) {
+  if (node.nodeType === 3) {
+    textNodes.push(node as Text);
+  } else {
+    for (let i = 0, len = node.childNodes.length; i < len; ++i) {
+      const childNode = node.childNodes[i];
+      if (childNode) {
+        findTextNodes(textNodes, childNode);
+      }
+    }
+  }
+}
+
 function setCursorPosition(target: HTMLElement, start: number, end: number | null = null) {
   const range = document.createRange();
   range.selectNodeContents(target);
 
   const textNodes: Text[] = [];
-  (function findTextNodes(node: ChildNode) {
-    if (node.nodeType === 3) {
-      textNodes.push(node as Text);
-    } else {
-      for (let i = 0, len = node.childNodes.length; i < len; ++i) {
-        const childNode = node.childNodes[i];
-        if (childNode) {
-          findTextNodes(childNode);
-        }
-      }
-    }
-  })(target);
+  findTextNodes(textNodes, target);
 
   let charCount = 0;
   let startNode: Text | null = null;
@@ -80,4 +82,11 @@ function getCurrentCursorPosition(target: HTMLElement) {
   return {start: -1, end: -1};
 }
 
-export {getCurrentCursorPosition, moveCursorToEnd, setCursorPosition};
+function removeSelection() {
+  const sel = window.getSelection();
+  if (sel) {
+    sel.removeAllRanges();
+  }
+}
+
+export {getCurrentCursorPosition, moveCursorToEnd, setCursorPosition, removeSelection};

--- a/src/web/cursorUtils.ts
+++ b/src/web/cursorUtils.ts
@@ -62,31 +62,22 @@ function moveCursorToEnd(target: HTMLElement) {
   }
 }
 
-function getIndexedPosition(target: HTMLElement, range: Range, isStart: boolean) {
-  const marker = document.createTextNode('\0');
-  const rangeClone = range.cloneRange();
-
-  rangeClone.collapse(isStart);
-
-  rangeClone.insertNode(marker);
-  const position = target.innerText.indexOf('\0');
-  if (marker.parentNode) {
-    marker.parentNode.removeChild(marker);
-  }
-
-  return position;
-}
-
 function getCurrentCursorPosition(target: HTMLElement) {
-  const selection = document.getSelection();
-  if (!selection || selection.rangeCount === 0) {
-    return {start: target.innerText.length, end: target.innerText.length};
-  }
+  const sel = window.getSelection();
 
-  const range = selection.getRangeAt(0);
-  const start = getIndexedPosition(target, range, true);
-  const end = getIndexedPosition(target, range, false);
-  return {start, end};
+  if (sel && sel.rangeCount > 0) {
+    const range = sel.getRangeAt(0);
+    const preSelectionRange = range.cloneRange();
+    preSelectionRange.selectNodeContents(target);
+    preSelectionRange.setEnd(range.startContainer, range.startOffset);
+    const start = preSelectionRange.toString().length;
+
+    return {
+      start,
+      end: start + range.toString().length,
+    };
+  }
+  return {start: -1, end: -1};
 }
 
 export {getCurrentCursorPosition, moveCursorToEnd, setCursorPosition};

--- a/src/web/cursorUtils.ts
+++ b/src/web/cursorUtils.ts
@@ -1,8 +1,8 @@
 function findTextNodes(textNodes: Text[], node: ChildNode) {
-  if (node.nodeType === 3) {
+  if (node.nodeType === Node.TEXT_NODE) {
     textNodes.push(node as Text);
   } else {
-    for (let i = 0, len = node.childNodes.length; i < len; ++i) {
+    for (let i = 0, length = node.childNodes.length; i < length; ++i) {
       const childNode = node.childNodes[i];
       if (childNode) {
         findTextNodes(textNodes, childNode);
@@ -66,16 +66,16 @@ function moveCursorToEnd(target: HTMLElement) {
 
 function getCurrentCursorPosition(target: HTMLElement) {
   const selection = window.getSelection();
-  if (selection && selection.rangeCount > 0) {
-    const range = selection.getRangeAt(0);
-    const preSelectionRange = range.cloneRange();
-    preSelectionRange.selectNodeContents(target);
-    preSelectionRange.setEnd(range.startContainer, range.startOffset);
-    const start = preSelectionRange.toString().length;
-    const end = start + range.toString().length;
-    return {start, end};
+  if (!selection || (selection && selection.rangeCount === 0)) {
+    return null;
   }
-  return null;
+  const range = selection.getRangeAt(0);
+  const preSelectionRange = range.cloneRange();
+  preSelectionRange.selectNodeContents(target);
+  preSelectionRange.setEnd(range.startContainer, range.startOffset);
+  const start = preSelectionRange.toString().length;
+  const end = start + range.toString().length;
+  return {start, end};
 }
 
 function removeSelection() {

--- a/src/web/cursorUtils.ts
+++ b/src/web/cursorUtils.ts
@@ -75,7 +75,7 @@ function getCurrentCursorPosition(target: HTMLElement) {
     const end = start + range.toString().length;
     return {start, end};
   }
-  return {start: -1, end: -1};
+  return null;
 }
 
 function removeSelection() {

--- a/src/web/parserUtils.ts
+++ b/src/web/parserUtils.ts
@@ -166,7 +166,8 @@ function parseText(target: HTMLElement, text: string, curosrPositionIndex: numbe
   let cursorPosition: number | null = curosrPositionIndex;
   const isFocused = document.activeElement === target;
   if (isFocused && curosrPositionIndex === null) {
-    cursorPosition = CursorUtils.getCurrentCursorPosition(target).start;
+    const selection = CursorUtils.getCurrentCursorPosition(target);
+    cursorPosition = selection ? selection.end : null;
   }
   const ranges = global.parseExpensiMarkToRanges(text);
 
@@ -182,7 +183,7 @@ function parseText(target: HTMLElement, text: string, curosrPositionIndex: numbe
   }
 
   if (isFocused) {
-    if (alwaysMoveCursorToTheEnd || (cursorPosition !== null && cursorPosition < 0)) {
+    if (alwaysMoveCursorToTheEnd || cursorPosition === null) {
       CursorUtils.moveCursorToEnd(target);
     } else if (cursorPosition !== null) {
       CursorUtils.setCursorPosition(target, cursorPosition);

--- a/src/web/parserUtils.ts
+++ b/src/web/parserUtils.ts
@@ -160,14 +160,7 @@ function parseRangesToHTMLNodes(text: string, ranges: MarkdownRange[], markdownS
   return root;
 }
 
-function parseText(
-  target: HTMLElement,
-  text: string,
-  curosrPositionIndex: number | null,
-  markdownStyle: PartialMarkdownStyle = {},
-  disableNewLinesInCursorPositioning = false,
-  alwaysMoveCursorToTheEnd = false,
-) {
+function parseText(target: HTMLElement, text: string, curosrPositionIndex: number | null, markdownStyle: PartialMarkdownStyle = {}, alwaysMoveCursorToTheEnd = false) {
   const targetElement = target;
 
   let cursorPosition: number | null = curosrPositionIndex;
@@ -191,7 +184,7 @@ function parseText(
   if (alwaysMoveCursorToTheEnd) {
     CursorUtils.moveCursorToEnd(target);
   } else if (isFocused && cursorPosition !== null) {
-    CursorUtils.setCursorPosition(target, cursorPosition, disableNewLinesInCursorPositioning);
+    CursorUtils.setCursorPosition(target, cursorPosition);
   }
 
   return {text: target.innerText, cursorPosition: cursorPosition || 0};

--- a/src/web/parserUtils.ts
+++ b/src/web/parserUtils.ts
@@ -181,10 +181,12 @@ function parseText(target: HTMLElement, text: string, curosrPositionIndex: numbe
     target.appendChild(dom);
   }
 
-  if (alwaysMoveCursorToTheEnd) {
-    CursorUtils.moveCursorToEnd(target);
-  } else if (isFocused && cursorPosition !== null) {
-    CursorUtils.setCursorPosition(target, cursorPosition);
+  if (isFocused) {
+    if (alwaysMoveCursorToTheEnd || (cursorPosition !== null && cursorPosition < 0)) {
+      CursorUtils.moveCursorToEnd(target);
+    } else if (cursorPosition !== null) {
+      CursorUtils.setCursorPosition(target, cursorPosition);
+    }
   }
 
   return {text: target.innerText, cursorPosition: cursorPosition || 0};


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Details
<!-- Explanation of the change or anything fishy that is going on -->
This PR:
- adds `selection` prop support on web
- fixes `selectionStart` and `selectionEnd` variables behavior inside MarkdownTextInput ref on web
- fixes selection detection on web 

### Related Issues
<!-- Please replace GH_LINK with the link to the GitHub issue this Pull Request is related to -->
[GH_LINK](https://github.com/Expensify/App/issues/36199)

### Manual Tests
<!---
Most changes should have accompanying tests. Describe the tests you added or if no tests were added an explanation about why one was not needed.
--->
1. Start writing in MarkdownTextInput on web
2. Verify if cursor position is correct when writing casually
3. Verify if text replacement works properly. Select some text and start writing 
4. Verify if after pasting text or emojis cursor is being set in correct position
5. Add `onSelectionChange` handler to MarkdownTextInput and verify if event returns correct selection start value
6. Add `ref` to MarkdownTextInput and verify if `ref.selectionStart` and `ref.selectionEnd` returns correct  selection end value

### Linked PRs
<!---
Please include links to any update PRs in repos that must change their package.json version.
--->

