### PR TITLE
Diff-based text replacing

### DIFF
--- a/src/web/parserUtils.ts
+++ b/src/web/parserUtils.ts
@@ -185,9 +185,13 @@ function parseText(
 
     const rootSpan = targetElement.firstChild as HTMLElement | null;
     if (!rootSpan || rootSpan.innerHTML !== dom.innerHTML) {
-      targetElement.innerHTML = '';
-      targetElement.innerText = '';
-      target.appendChild(dom);
+      if (rootSpan) {
+        rootSpan.replaceWith(dom);
+      } else {
+        targetElement.innerHTML = '';
+        targetElement.innerText = '';
+        target.appendChild(dom);
+      }
 
       if (alwaysMoveCursorToTheEnd) {
         CursorUtils.moveCursorToEnd(target);

--- a/src/web/parserUtils.ts
+++ b/src/web/parserUtils.ts
@@ -172,13 +172,10 @@ function moveCursor(isFocused: boolean, alwaysMoveCursorToTheEnd: boolean, curso
   }
 }
 
-type Window = {
-  chrome: unknown;
-};
+const isChromium = 'chrome' in window;
 
 function parseText(target: HTMLElement, text: string, curosrPositionIndex: number | null, markdownStyle: PartialMarkdownStyle = {}, alwaysMoveCursorToTheEnd = false) {
   const targetElement = target;
-  const isChromium = (window as unknown as Window).chrome;
 
   let cursorPosition: number | null = curosrPositionIndex;
   const isFocused = document.activeElement === target;

--- a/src/web/parserUtils.ts
+++ b/src/web/parserUtils.ts
@@ -179,8 +179,6 @@ function parseText(
 
   const markdownRanges: MarkdownRange[] = ranges as MarkdownRange[];
 
-  let appended = false;
-
   // We don't want to parse text with single '\n', because contentEditable represents it as invisible <br />
   if (!!text && text !== '\n') {
     const dom = parseRangesToHTMLNodes(text, markdownRanges, markdownStyle);
@@ -191,8 +189,6 @@ function parseText(
       targetElement.innerText = '';
       target.appendChild(dom);
 
-      appended = true;
-
       if (alwaysMoveCursorToTheEnd) {
         CursorUtils.moveCursorToEnd(target);
       } else if (isFocused && cursorPosition !== null) {
@@ -201,7 +197,7 @@ function parseText(
     }
   }
 
-  return {text: appended ? text : target.innerText, cursorPosition: cursorPosition || 0};
+  return {text: target.innerText, cursorPosition: cursorPosition || 0};
 }
 
 export {parseText, parseRangesToHTMLNodes};

--- a/src/web/parserUtils.ts
+++ b/src/web/parserUtils.ts
@@ -179,22 +179,29 @@ function parseText(
 
   const markdownRanges: MarkdownRange[] = ranges as MarkdownRange[];
 
-  targetElement.innerHTML = '';
-  targetElement.innerText = '';
+  let appended = false;
 
   // We don't want to parse text with single '\n', because contentEditable represents it as invisible <br />
   if (!!text && text !== '\n') {
     const dom = parseRangesToHTMLNodes(text, markdownRanges, markdownStyle);
-    target.appendChild(dom);
+
+    // eslint-disable-next-line es/no-optional-chaining
+    if ((targetElement.firstChild as HTMLElement | null)?.innerHTML !== dom.innerHTML) {
+      targetElement.innerHTML = '';
+      targetElement.innerText = '';
+      target.appendChild(dom);
+
+      appended = true;
+
+      if (alwaysMoveCursorToTheEnd) {
+        CursorUtils.moveCursorToEnd(target);
+      } else if (isFocused && cursorPosition !== null) {
+        CursorUtils.setCursorPosition(target, cursorPosition, disableNewLinesInCursorPositioning);
+      }
+    }
   }
 
-  if (alwaysMoveCursorToTheEnd) {
-    CursorUtils.moveCursorToEnd(target);
-  } else if (isFocused && cursorPosition !== null) {
-    CursorUtils.setCursorPosition(target, cursorPosition, disableNewLinesInCursorPositioning);
-  }
-
-  return {text: target.innerText, cursorPosition: cursorPosition || 0};
+  return {text: appended ? text : target.innerText, cursorPosition: cursorPosition || 0};
 }
 
 export {parseText, parseRangesToHTMLNodes};

--- a/src/web/parserUtils.ts
+++ b/src/web/parserUtils.ts
@@ -183,8 +183,8 @@ function parseText(
   if (!!text && text !== '\n') {
     const dom = parseRangesToHTMLNodes(text, markdownRanges, markdownStyle);
 
-    // eslint-disable-next-line es/no-optional-chaining
-    if ((targetElement.firstChild as HTMLElement | null)?.innerHTML !== dom.innerHTML) {
+    const rootSpan = targetElement.firstChild as HTMLElement | null;
+    if (!rootSpan || rootSpan.innerHTML !== dom.innerHTML) {
       targetElement.innerHTML = '';
       targetElement.innerText = '';
       target.appendChild(dom);

--- a/src/web/parserUtils.ts
+++ b/src/web/parserUtils.ts
@@ -185,13 +185,9 @@ function parseText(
 
     const rootSpan = targetElement.firstChild as HTMLElement | null;
     if (!rootSpan || rootSpan.innerHTML !== dom.innerHTML) {
-      if (rootSpan) {
-        rootSpan.replaceWith(dom);
-      } else {
-        targetElement.innerHTML = '';
-        targetElement.innerText = '';
-        target.appendChild(dom);
-      }
+      targetElement.innerHTML = '';
+      targetElement.innerText = '';
+      target.appendChild(dom);
 
       if (alwaysMoveCursorToTheEnd) {
         CursorUtils.moveCursorToEnd(target);

--- a/src/web/parserUtils.ts
+++ b/src/web/parserUtils.ts
@@ -189,12 +189,17 @@ function parseText(target: HTMLElement, text: string, curosrPositionIndex: numbe
   const ranges = global.parseExpensiMarkToRanges(text);
 
   const markdownRanges: MarkdownRange[] = ranges as MarkdownRange[];
+  const rootSpan = targetElement.firstChild as HTMLElement | null;
+
+  if (targetElement.innerHTML === '<br>' || (rootSpan && rootSpan.innerHTML === '\n')) {
+    targetElement.innerHTML = '';
+    targetElement.innerText = '';
+  }
 
   // We don't want to parse text with single '\n', because contentEditable represents it as invisible <br />
-  if (!!text && text !== '\n') {
+  if (text) {
     const dom = parseRangesToHTMLNodes(text, markdownRanges, markdownStyle);
 
-    const rootSpan = targetElement.firstChild as HTMLElement | null;
     if (!rootSpan || rootSpan.innerHTML !== dom.innerHTML) {
       targetElement.innerHTML = '';
       targetElement.innerText = '';


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Details
<!-- Explanation of the change or anything fishy that is going on -->
This PR fixes a couple of problems mainly:
Text replacement issue on MacOS (chrome & safari, not supported on Firefox) 
Spell-check on Chrome & safari (another PR will solve this issue on Firefox)

### Related Issues
<!-- Please replace GH_LINK with the link to the GitHub issue this Pull Request is related to -->
https://github.com/Expensify/App/issues/36188
https://github.com/Expensify/App/issues/36193

### Manual Tests
<!---
Most changes should have accompanying tests. Describe the tests you added or if no tests were added an explanation about why one was not needed.
--->
For text replacement:
1. Make sure that you have a text replacement available on your mac more info [here](https://support.apple.com/en-am/guide/mac-help/mh35735/mac) - I have ,,cu" set up to be replaced with "see you"
2. In your text input add some text like ,,hello world"
3. Now try to add the text replacement i.e. I tried writing "current", in the bug mentioned it was replaced by "see yourrent", check if that's not happening anymore

For spellcheck:
1. Try writing a word like "apple", while you're writing it shouldn't be underlined with a red curly line
2. Now write an incorrect word like "appl" - depending on your browser spellcheck happens at different times, but overall it shouldn't happen while you're continuously writing a word

### Linked PRs
<!---
Please include links to any update PRs in repos that must change their package.json version.
--->