### PR TITLE
Diacritics fix

### DIFF
--- a/src/MarkdownTextInput.web.tsx
+++ b/src/MarkdownTextInput.web.tsx
@@ -499,13 +499,16 @@ const MarkdownTextInput = React.forwardRef<TextInput, MarkdownTextInputProps>(
     }, []);
 
     useEffect(() => {
-      document.documentElement.style.setProperty('--placeholder-color', placeholderTextColor as string);
       // focus the input on mount if autoFocus is set
       if (!(divRef.current && autoFocus)) {
         return;
       }
       divRef.current.focus();
     }, []);
+
+    useEffect(() => {
+      document.documentElement.style.setProperty('--placeholder-color', placeholderTextColor as string);
+    }, [placeholderTextColor]);
 
     const startComposition = useCallback(() => {
       compositionRef.current = true;

--- a/src/MarkdownTextInput.web.tsx
+++ b/src/MarkdownTextInput.web.tsx
@@ -258,6 +258,12 @@ const MarkdownTextInput = React.forwardRef<TextInput, MarkdownTextInputProps>(
       return e;
     }, []);
 
+    // Placeholder text color logic
+    const updateTextColor = useCallback((node: HTMLDivElement, text: string) => {
+      // eslint-disable-next-line no-param-reassign -- we need to change the style of the node, so we need to modify it
+      node.style.color = String(placeholder && (text === '' || text === '\n') ? placeholderTextColor : flattenedStyle.color || 'black');
+    }, []);
+
     const handleOnChangeText = useCallback(
       (e: SyntheticEvent<HTMLDivElement>) => {
         if (!divRef.current || !(e.target instanceof HTMLElement)) {
@@ -265,6 +271,7 @@ const MarkdownTextInput = React.forwardRef<TextInput, MarkdownTextInputProps>(
         }
 
         if (compositionRef.current) {
+          updateTextColor(divRef.current, e.target.innerText);
           compositionRef.current = false;
           return;
         }
@@ -281,6 +288,7 @@ const MarkdownTextInput = React.forwardRef<TextInput, MarkdownTextInputProps>(
           default:
             text = parseText(divRef.current, e.target.innerText, processedMarkdownStyle).text;
         }
+        updateTextColor(divRef.current, e.target.innerText);
 
         if (onChange) {
           const event = e as unknown as NativeSyntheticEvent<any>;
@@ -437,7 +445,13 @@ const MarkdownTextInput = React.forwardRef<TextInput, MarkdownTextInputProps>(
         (r as unknown as TextInput).isFocused = () => document.activeElement === r;
         (r as unknown as TextInput).clear = () => {
           r.innerText = '';
+          updateTextColor(r, '');
         };
+
+        if (value === '' || value === undefined) {
+          // update to placeholder color when value is empty
+          updateTextColor(r, r.innerText);
+        }
       }
 
       if (ref) {
@@ -464,6 +478,7 @@ const MarkdownTextInput = React.forwardRef<TextInput, MarkdownTextInputProps>(
 
         const text = processedValue !== undefined ? processedValue : '';
         parseText(divRef.current, text, processedMarkdownStyle, text.length);
+        updateTextColor(divRef.current, value);
       },
       [multiline, processedMarkdownStyle, processedValue],
     );
@@ -505,10 +520,6 @@ const MarkdownTextInput = React.forwardRef<TextInput, MarkdownTextInputProps>(
       }
       divRef.current.focus();
     }, []);
-
-    useEffect(() => {
-      document.documentElement.style.setProperty('--placeholder-color', placeholderTextColor as string);
-    }, [placeholderTextColor]);
 
     const startComposition = useCallback(() => {
       compositionRef.current = true;

--- a/src/MarkdownTextInput.web.tsx
+++ b/src/MarkdownTextInput.web.tsx
@@ -9,7 +9,7 @@ import type {
   TextInputKeyPressEventData,
   TextInputFocusEventData,
 } from 'react-native';
-import React, {useEffect, useRef, useCallback, useMemo, useLayoutEffect} from 'react';
+import React, {useEffect, useRef, useCallback, useMemo, useLayoutEffect, useState} from 'react';
 import type {CSSProperties, MutableRefObject, ReactEventHandler, FocusEventHandler, MouseEvent, KeyboardEvent, SyntheticEvent} from 'react';
 import {StyleSheet} from 'react-native';
 import * as ParseUtils from './web/parserUtils';
@@ -156,6 +156,7 @@ const MarkdownTextInput = React.forwardRef<TextInput, MarkdownTextInputProps>(
     },
     ref,
   ) => {
+    const [isComposition, setIsComposition] = useState(false);
     const divRef = useRef<HTMLDivElement | null>(null);
     const currentlyFocusedField = useRef<HTMLDivElement | null>(null);
     const contentSelection = useRef<Selection | null>(null);
@@ -269,6 +270,11 @@ const MarkdownTextInput = React.forwardRef<TextInput, MarkdownTextInputProps>(
           return;
         }
 
+        if (isComposition) {
+          setIsComposition(false);
+          return;
+        }
+
         let text = '';
         const nativeEvent = e.nativeEvent as MarkdownNativeEvent;
         switch (nativeEvent.inputType) {
@@ -294,7 +300,7 @@ const MarkdownTextInput = React.forwardRef<TextInput, MarkdownTextInputProps>(
           onChangeText(normalizedText);
         }
       },
-      [multiline, onChange, onChangeText, setEventProps, processedMarkdownStyle],
+      [multiline, isComposition, onChange, onChangeText, setEventProps, processedMarkdownStyle],
     );
 
     const handleKeyPress = useCallback(
@@ -529,6 +535,7 @@ const MarkdownTextInput = React.forwardRef<TextInput, MarkdownTextInputProps>(
         autoCapitalize={autoCapitalize}
         className={className}
         onKeyDown={handleKeyPress}
+        onCompositionStart={() => setIsComposition(true)}
         onKeyUp={updateSelection}
         onInput={handleOnChangeText}
         onSelect={handleSelectionChange}

--- a/src/MarkdownTextInput.web.tsx
+++ b/src/MarkdownTextInput.web.tsx
@@ -156,7 +156,7 @@ const MarkdownTextInput = React.forwardRef<TextInput, MarkdownTextInputProps>(
     },
     ref,
   ) => {
-    const compositionRef = useRef<boolean | null>(null);
+    const compositionRef = useRef<boolean>(false);
     const divRef = useRef<HTMLDivElement | null>(null);
     const currentlyFocusedField = useRef<HTMLDivElement | null>(null);
     const contentSelection = useRef<Selection | null>(null);
@@ -520,9 +520,9 @@ const MarkdownTextInput = React.forwardRef<TextInput, MarkdownTextInputProps>(
       divRef.current.focus();
     }, []);
 
-    const startComposition = () => {
+    const startComposition = useCallback(() => {
       compositionRef.current = true;
-    };
+    }, []);
 
     return (
       // eslint-disable-next-line jsx-a11y/no-static-element-interactions

--- a/src/MarkdownTextInput.web.tsx
+++ b/src/MarkdownTextInput.web.tsx
@@ -9,7 +9,7 @@ import type {
   TextInputKeyPressEventData,
   TextInputFocusEventData,
 } from 'react-native';
-import React, {useEffect, useRef, useCallback, useMemo, useLayoutEffect, useState} from 'react';
+import React, {useEffect, useRef, useCallback, useMemo, useLayoutEffect} from 'react';
 import type {CSSProperties, MutableRefObject, ReactEventHandler, FocusEventHandler, MouseEvent, KeyboardEvent, SyntheticEvent} from 'react';
 import {StyleSheet} from 'react-native';
 import * as ParseUtils from './web/parserUtils';
@@ -156,7 +156,7 @@ const MarkdownTextInput = React.forwardRef<TextInput, MarkdownTextInputProps>(
     },
     ref,
   ) => {
-    const [isComposition, setIsComposition] = useState(false);
+    const compositionRef = useRef<boolean | null>(null);
     const divRef = useRef<HTMLDivElement | null>(null);
     const currentlyFocusedField = useRef<HTMLDivElement | null>(null);
     const contentSelection = useRef<Selection | null>(null);
@@ -270,8 +270,8 @@ const MarkdownTextInput = React.forwardRef<TextInput, MarkdownTextInputProps>(
           return;
         }
 
-        if (isComposition) {
-          setIsComposition(false);
+        if (compositionRef.current) {
+          compositionRef.current = false;
           return;
         }
 
@@ -300,7 +300,7 @@ const MarkdownTextInput = React.forwardRef<TextInput, MarkdownTextInputProps>(
           onChangeText(normalizedText);
         }
       },
-      [multiline, isComposition, onChange, onChangeText, setEventProps, processedMarkdownStyle],
+      [multiline, onChange, onChangeText, setEventProps, processedMarkdownStyle],
     );
 
     const handleKeyPress = useCallback(
@@ -520,6 +520,10 @@ const MarkdownTextInput = React.forwardRef<TextInput, MarkdownTextInputProps>(
       divRef.current.focus();
     }, []);
 
+    const startComposition = () => {
+      compositionRef.current = true;
+    };
+
     return (
       // eslint-disable-next-line jsx-a11y/no-static-element-interactions
       <div
@@ -535,7 +539,7 @@ const MarkdownTextInput = React.forwardRef<TextInput, MarkdownTextInputProps>(
         autoCapitalize={autoCapitalize}
         className={className}
         onKeyDown={handleKeyPress}
-        onCompositionStart={() => setIsComposition(true)}
+        onCompositionStart={startComposition}
         onKeyUp={updateSelection}
         onInput={handleOnChangeText}
         onSelect={handleSelectionChange}

--- a/src/MarkdownTextInput.web.tsx
+++ b/src/MarkdownTextInput.web.tsx
@@ -258,12 +258,6 @@ const MarkdownTextInput = React.forwardRef<TextInput, MarkdownTextInputProps>(
       return e;
     }, []);
 
-    // Placeholder text color logic
-    const updateTextColor = useCallback((node: HTMLDivElement, text: string) => {
-      // eslint-disable-next-line no-param-reassign -- we need to change the style of the node, so we need to modify it
-      node.style.color = String(placeholder && (text === '' || text === '\n') ? placeholderTextColor : flattenedStyle.color || 'black');
-    }, []);
-
     const handleOnChangeText = useCallback(
       (e: SyntheticEvent<HTMLDivElement>) => {
         if (!divRef.current || !(e.target instanceof HTMLElement)) {
@@ -287,7 +281,6 @@ const MarkdownTextInput = React.forwardRef<TextInput, MarkdownTextInputProps>(
           default:
             text = parseText(divRef.current, e.target.innerText, processedMarkdownStyle).text;
         }
-        updateTextColor(divRef.current, e.target.innerText);
 
         if (onChange) {
           const event = e as unknown as NativeSyntheticEvent<any>;
@@ -444,13 +437,7 @@ const MarkdownTextInput = React.forwardRef<TextInput, MarkdownTextInputProps>(
         (r as unknown as TextInput).isFocused = () => document.activeElement === r;
         (r as unknown as TextInput).clear = () => {
           r.innerText = '';
-          updateTextColor(r, '');
         };
-
-        if (value === '' || value === undefined) {
-          // update to placeholder color when value is empty
-          updateTextColor(r, r.innerText);
-        }
       }
 
       if (ref) {
@@ -477,7 +464,6 @@ const MarkdownTextInput = React.forwardRef<TextInput, MarkdownTextInputProps>(
 
         const text = processedValue !== undefined ? processedValue : '';
         parseText(divRef.current, text, processedMarkdownStyle, text.length);
-        updateTextColor(divRef.current, value);
       },
       [multiline, processedMarkdownStyle, processedValue],
     );
@@ -513,6 +499,7 @@ const MarkdownTextInput = React.forwardRef<TextInput, MarkdownTextInputProps>(
     }, []);
 
     useEffect(() => {
+      document.documentElement.style.setProperty('--placeholder-color', placeholderTextColor as string);
       // focus the input on mount if autoFocus is set
       if (!(divRef.current && autoFocus)) {
         return;

--- a/src/web/MarkdownTextInput.css
+++ b/src/web/MarkdownTextInput.css
@@ -21,5 +21,4 @@
   pointer-events: none;
   display: block; /* For Firefox */
   content: attr(placeholder);
-  color: var(--placeholder-color);
 }

--- a/src/web/MarkdownTextInput.css
+++ b/src/web/MarkdownTextInput.css
@@ -21,4 +21,5 @@
   pointer-events: none;
   display: block; /* For Firefox */
   content: attr(placeholder);
+  color: var(--placeholder-color);
 }


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Details
<!-- Explanation of the change or anything fishy that is going on -->
This PR fixes diacritics not working on every browser

### Related Issues
<!-- Please replace GH_LINK with the link to the GitHub issue this Pull Request is related to -->
https://github.com/Expensify/App/issues/36942

### Manual Tests
<!---
Most changes should have accompanying tests. Describe the tests you added or if no tests were added an explanation about why one was not needed.
--->

1. Try adding a diacritic in the text input i.e. Option+u and then "a" - this should result in "ä"
2. You can now try different cases like doing it in nested blocks, at the beginning of a word, in the middle of it, or by itself.

### Linked PRs
<!---
Please include links to any update PRs in repos that must change their package.json version.
--->