### PR TITLE
Fix Shift + Enter on Safari

### DIFF
--- a/src/MarkdownTextInput.web.tsx
+++ b/src/MarkdownTextInput.web.tsx
@@ -368,25 +368,21 @@ const MarkdownTextInput = React.forwardRef<TextInput, MarkdownTextInputProps>(
 
         if (
           e.key === 'Enter' &&
-          !e.shiftKey &&
           // Do not call submit if composition is occuring.
           !isComposing &&
           !e.isDefaultPrevented()
         ) {
           // prevent "Enter" from inserting a newline or submitting a form
           e.preventDefault();
-          if ((blurOnSubmit || !multiline) && onSubmitEditing) {
+          if (!e.shiftKey && (blurOnSubmit || !multiline) && onSubmitEditing) {
             onSubmitEditing(event as unknown as NativeSyntheticEvent<TextInputSubmitEditingEventData>);
-          } else {
-            e.preventDefault();
+          } else if (multiline) {
             //   We need to change normal behavior of "Enter" key to insert a line breaks, to prevent wrapping contentEditable text in <div> tags.
             //  Thanks to that in every situation we have proper amount of new lines in our parsed text. Without it pressing enter in empty lines will add 2 more new lines.
-            if (multiline) {
-              document.execCommand('insertLineBreak');
-            }
+            document.execCommand('insertLineBreak');
           }
 
-          if ((shouldBlurOnSubmit && hostNode !== null) || !multiline) {
+          if (!e.shiftKey && ((shouldBlurOnSubmit && hostNode !== null) || !multiline)) {
             setTimeout(() => divRef.current && divRef.current.blur(), 0);
           }
         }


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Details
<!-- Explanation of the change or anything fishy that is going on -->
This PR changes the default behavior of Shift + Enter to be the same as when clicking Enter. Thanks to that we have control over what happens after inserting new line and `contenteditable` work the same  on all browsers

### Related Issues
<!-- Please replace GH_LINK with the link to the GitHub issue this Pull Request is related to -->
GH_LINK

### Manual Tests
<!---
Most changes should have accompanying tests. Describe the tests you added or if no tests were added an explanation about why one was not needed.
--->
1. Open example app on Safari
2. Delete whole text
3. Start entering new lines using Shift + Enter
4. Verify if cursor is correctly positioned

### Linked PRs
<!---
Please include links to any update PRs in repos that must change their package.json version.
--->