### PR TITLE
Fix scrolling down when entering a newline

### DIFF
--- a/src/MarkdownTextInput.web.tsx
+++ b/src/MarkdownTextInput.web.tsx
@@ -15,7 +15,6 @@ import {StyleSheet} from 'react-native';
 import * as ParseUtils from './web/parserUtils';
 import * as CursorUtils from './web/cursorUtils';
 import * as StyleUtils from './styleUtils';
-import * as BrowserUtils from './web/browserUtils';
 import type * as MarkdownTextInputDecoratorViewNativeComponent from './MarkdownTextInputDecoratorViewNativeComponent';
 import './web/MarkdownTextInput.css';
 import InputHistory from './web/InputHistory';
@@ -381,14 +380,7 @@ const MarkdownTextInput = React.forwardRef<TextInput, MarkdownTextInputProps>(
             //   We need to change normal behavior of "Enter" key to insert a line breaks, to prevent wrapping contentEditable text in <div> tags.
             //  Thanks to that in every situation we have proper amount of new lines in our parsed text. Without it pressing enter in empty lines will add 2 more new lines.
             document.execCommand('insertLineBreak');
-
-            const range = window.getSelection();
-            if (range && !BrowserUtils.isFirefox) {
-              const scrollMarkerNode = document.createElement('div');
-              range.getRangeAt(0).insertNode(scrollMarkerNode);
-              scrollMarkerNode.scrollIntoView();
-              scrollMarkerNode.remove();
-            }
+            CursorUtils.scrollCursorIntoView(divRef.current as HTMLInputElement);
           }
 
           if (!e.shiftKey && ((shouldBlurOnSubmit && hostNode !== null) || !multiline)) {

--- a/src/web/cursorUtils.ts
+++ b/src/web/cursorUtils.ts
@@ -51,6 +51,8 @@ function setCursorPosition(target: HTMLElement, start: number, end: number | nul
     selection.removeAllRanges();
     selection.addRange(range);
   }
+
+  scrollCursorIntoView(target as HTMLInputElement);
 }
 
 function moveCursorToEnd(target: HTMLElement) {
@@ -85,4 +87,13 @@ function removeSelection() {
   }
 }
 
-export {getCurrentCursorPosition, moveCursorToEnd, setCursorPosition, removeSelection};
+function scrollCursorIntoView(target: HTMLInputElement) {
+  if (target.selectionStart === null || !target.value) {
+    return;
+  }
+  const lineHeight = target.scrollHeight / target.value.split('\n').length;
+  const linesFromTop = target.value.substring(0, target.selectionStart + 1).split('\n').length;
+  target.scrollTo(0, lineHeight * (linesFromTop - 1));
+}
+
+export {getCurrentCursorPosition, moveCursorToEnd, setCursorPosition, removeSelection, scrollCursorIntoView};


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Details
<!-- Explanation of the change or anything fishy that is going on -->
This PR fix the problem with input not scrolling into view the cursor after entering the new line using `Enter` or `Shift + Enter`

### Related Issues
<!-- Please replace GH_LINK with the link to the GitHub issue this Pull Request is related to -->
GH_LINK

### Manual Tests
<!---
Most changes should have accompanying tests. Describe the tests you added or if no tests were added an explanation about why one was not needed.
--->
1. Set static input height
2. Add some text so you can scroll text inside markdown input
3. On the end of the input start entering newlines. Verify on all browsers if input is scrolling down so the cursor in newline is fully visible

### Linked PRs
<!---
Please include links to any update PRs in repos that must change their package.json version.
--->