### PR TITLE
Fix selection setting when pasting text and auto-focusing

### DIFF
--- a/src/MarkdownTextInput.web.tsx
+++ b/src/MarkdownTextInput.web.tsx
@@ -308,10 +308,7 @@ const MarkdownTextInput = React.forwardRef<TextInput, MarkdownTextInputProps>(
       [onSelectionChange, setEventProps],
     );
 
-    const updateRefSelectionVariables = useCallback((newSelection: Selection | null) => {
-      if (!newSelection) {
-        return;
-      }
+    const updateRefSelectionVariables = useCallback((newSelection: Selection) => {
       const {start, end} = newSelection;
       const markdownHTMLInput = divRef.current as HTMLInputElement;
       markdownHTMLInput.selectionStart = start;
@@ -551,7 +548,6 @@ const MarkdownTextInput = React.forwardRef<TextInput, MarkdownTextInputProps>(
       if (autoFocus) {
         divRef.current.focus();
       }
-      updateRefSelectionVariables(contentSelection.current);
     }, []);
 
     useEffect(() => {


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Details
<!-- Explanation of the change or anything fishy that is going on -->
This is follow up PR that fix setting cursor position when pasting blocks of text and autofocusing the markdown input after page loaded

### Related Issues
<!-- Please replace GH_LINK with the link to the GitHub issue this Pull Request is related to -->
GH_LINK

### Manual Tests
<!---
Most changes should have accompanying tests. Describe the tests you added or if no tests were added an explanation about why one was not needed.
--->
1. Set `autoFocus` prop and verify if after entering/refreshing the page cursor is set to the end of the text inside the input
2. Verify if cursor position is correct after pasting text into markdown input

### Linked PRs
<!---
Please include links to any update PRs in repos that must change their package.json version.
--->