### PR TITLE
Caret positioning & scrolling on `enter`

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -45,6 +45,8 @@ module.exports = {
     'import/no-unresolved': 'error',
     'import/consistent-type-specifier-style': ['error', 'prefer-top-level'],
     'no-use-before-define': 'off',
+    'es/no-nullish-coalescing-operators': 'off',
+    'es/no-optional-chaining': 'off',
     '@typescript-eslint/no-use-before-define': 'off', // TODO consider enabling this (currently it reports styles defined at the bottom of the file)
     '@typescript-eslint/no-unused-vars': ['error', { argsIgnorePattern: '^_' }],
     '@typescript-eslint/consistent-type-imports': [


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Details
<!-- Explanation of the change or anything fishy that is going on -->
This PR fixes weird cursor / scrolling behaviour where you press `enter` and input doesn't scroll or is scrolling incorrectly

### Related Issues
<!-- Please replace GH_LINK with the link to the GitHub issue this Pull Request is related to -->
[GH_LINK](https://github.com/Expensify/react-native-live-markdown/issues/224)

### Manual Tests
<!---
Most changes should have accompanying tests. Describe the tests you added or if no tests were added an explanation about why one was not needed.
--->
Test in 2 scenarios:
1. Default example app 
2. With defined `numberOfLines` in `example/src/App.tsx`

Check how scrolling/cursor behaves when you:
1. Add `enter` in front of line of text / markdown block
2. Add `enter` after line of text / markdown block
3. Add `enter` at the end of input
4. Add `enter` at the beginning of input

### Linked PRs
<!---
Please include links to any update PRs in repos that must change their package.json version.
--->
https://github.com/Expensify/App/pull/38152