### PR TITLE
Customize codeblock and inline code font size

### DIFF
--- a/android/src/main/java/com/expensify/livemarkdown/MarkdownStyle.java
+++ b/android/src/main/java/com/expensify/livemarkdown/MarkdownStyle.java
@@ -34,6 +34,8 @@ public class MarkdownStyle {
 
   private final String mCodeFontFamily;
 
+  private final float mCodeFontSize;
+
   @ColorInt
   private final int mCodeColor;
 
@@ -41,6 +43,8 @@ public class MarkdownStyle {
   private final int mCodeBackgroundColor;
 
   private final String mPreFontFamily;
+
+  private final float mPreFontSize;
 
   @ColorInt
   private final int mPreColor;
@@ -70,9 +74,11 @@ public class MarkdownStyle {
     mBlockquoteMarginLeft = parseFloat(map, "blockquote", "marginLeft");
     mBlockquotePaddingLeft = parseFloat(map, "blockquote", "paddingLeft");
     mCodeFontFamily = parseString(map, "code", "fontFamily");
+    mCodeFontSize = parseFloat(map, "code", "fontSize");
     mCodeColor = parseColor(map, "code", "color", context);
     mCodeBackgroundColor = parseColor(map, "code", "backgroundColor", context);
     mPreFontFamily = parseString(map, "pre", "fontFamily");
+    mPreFontSize = parseFloat(map, "pre", "fontSize");
     mPreColor = parseColor(map, "pre", "color", context);
     mPreBackgroundColor = parseColor(map, "pre", "backgroundColor", context);
     mMentionHereColor = parseColor(map, "mentionHere", "color", context);
@@ -147,6 +153,10 @@ public class MarkdownStyle {
     return mCodeFontFamily;
   }
 
+  public float getCodeFontSize() {
+    return mCodeFontSize;
+  }
+
   @ColorInt
   public int getCodeColor() {
     return mCodeColor;
@@ -159,6 +169,10 @@ public class MarkdownStyle {
 
   public String getPreFontFamily() {
     return mPreFontFamily;
+  }
+
+  public float getPreFontSize() {
+    return mPreFontSize;
   }
 
   @ColorInt

--- a/android/src/main/java/com/expensify/livemarkdown/MarkdownUtils.java
+++ b/android/src/main/java/com/expensify/livemarkdown/MarkdownUtils.java
@@ -137,11 +137,13 @@ public class MarkdownUtils {
         break;
       case "code":
         setSpan(ssb, new MarkdownFontFamilySpan(mMarkdownStyle.getCodeFontFamily(), mAssetManager), start, end);
+        setSpan(ssb, new MarkdownFontSizeSpan(mMarkdownStyle.getCodeFontSize()), start, end);
         setSpan(ssb, new MarkdownForegroundColorSpan(mMarkdownStyle.getCodeColor()), start, end);
         setSpan(ssb, new MarkdownBackgroundColorSpan(mMarkdownStyle.getCodeBackgroundColor()), start, end);
         break;
       case "pre":
         setSpan(ssb, new MarkdownFontFamilySpan(mMarkdownStyle.getPreFontFamily(), mAssetManager), start, end);
+        setSpan(ssb, new MarkdownFontSizeSpan(mMarkdownStyle.getPreFontSize()), start, end);
         setSpan(ssb, new MarkdownForegroundColorSpan(mMarkdownStyle.getPreColor()), start, end);
         setSpan(ssb, new MarkdownBackgroundColorSpan(mMarkdownStyle.getPreBackgroundColor()), start, end);
         break;

--- a/ios/RCTMarkdownStyle.h
+++ b/ios/RCTMarkdownStyle.h
@@ -15,9 +15,11 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic) CGFloat blockquoteMarginLeft;
 @property (nonatomic) CGFloat blockquotePaddingLeft;
 @property (nonatomic) NSString *codeFontFamily;
+@property (nonatomic) CGFloat codeFontSize;
 @property (nonatomic) UIColor *codeColor;
 @property (nonatomic) UIColor *codeBackgroundColor;
 @property (nonatomic) NSString *preFontFamily;
+@property (nonatomic) CGFloat preFontSize;
 @property (nonatomic) UIColor *preColor;
 @property (nonatomic) UIColor *preBackgroundColor;
 @property (nonatomic) UIColor *mentionHereColor;

--- a/ios/RCTMarkdownStyle.mm
+++ b/ios/RCTMarkdownStyle.mm
@@ -27,10 +27,12 @@
     _blockquotePaddingLeft = style.blockquote.paddingLeft;
 
     _codeFontFamily = RCTNSStringFromString(style.code.fontFamily);
+    _codeFontSize = style.code.fontSize;
     _codeColor = RCTUIColorFromSharedColor(style.code.color);
     _codeBackgroundColor = RCTUIColorFromSharedColor(style.code.backgroundColor);
 
     _preFontFamily = RCTNSStringFromString(style.pre.fontFamily);
+    _preFontSize = style.pre.fontSize;
     _preColor = RCTUIColorFromSharedColor(style.pre.color);
     _preBackgroundColor = RCTUIColorFromSharedColor(style.pre.backgroundColor);
 
@@ -63,10 +65,12 @@
     _blockquotePaddingLeft = [RCTConvert CGFloat:json[@"blockquote"][@"paddingLeft"]];
 
     _codeFontFamily = [RCTConvert NSString:json[@"code"][@"fontFamily"]];
+    _codeFontSize = [RCTConvert CGFloat:json[@"code"][@"fontSize"]];
     _codeColor = [RCTConvert UIColor:json[@"code"][@"color"]];
     _codeBackgroundColor = [RCTConvert UIColor:json[@"code"][@"backgroundColor"]];
 
     _preFontFamily = [RCTConvert NSString:json[@"pre"][@"fontFamily"]];
+    _preFontSize = [RCTConvert CGFloat:json[@"pre"][@"fontSize"]];
     _preColor = [RCTConvert UIColor:json[@"pre"][@"color"]];
     _preBackgroundColor = [RCTConvert UIColor:json[@"pre"][@"backgroundColor"]];
 

--- a/ios/RCTMarkdownUtils.mm
+++ b/ios/RCTMarkdownUtils.mm
@@ -72,9 +72,19 @@
       } else if ([type isEqualToString:@"italic"]) {
         font = [RCTFont updateFont:font withStyle:@"italic"];
       } else if ([type isEqualToString:@"code"]) {
-        font = [RCTFont updateFont:font withFamily:_markdownStyle.codeFontFamily];
+        font = [RCTFont updateFont:font withFamily:_markdownStyle.codeFontFamily
+                                              size:[NSNumber numberWithFloat:_markdownStyle.codeFontSize]
+                                            weight:nil
+                                             style:nil
+                                           variant:nil
+                                   scaleMultiplier:0];
       } else if ([type isEqualToString:@"pre"]) {
-        font = [RCTFont updateFont:font withFamily:_markdownStyle.preFontFamily];
+        font = [RCTFont updateFont:font withFamily:_markdownStyle.preFontFamily
+                                              size:[NSNumber numberWithFloat:_markdownStyle.preFontSize]
+                                            weight:nil
+                                             style:nil
+                                           variant:nil
+                                   scaleMultiplier:0];
       } else if ([type isEqualToString:@"h1"]) {
         font = [RCTFont updateFont:font withFamily:nil
                                               size:[NSNumber numberWithFloat:_markdownStyle.h1FontSize]

--- a/src/MarkdownTextInputDecoratorViewNativeComponent.ts
+++ b/src/MarkdownTextInputDecoratorViewNativeComponent.ts
@@ -24,11 +24,13 @@ interface MarkdownStyle {
   };
   code: {
     fontFamily: string;
+    fontSize: Float;
     color: ColorValue;
     backgroundColor: ColorValue;
   };
   pre: {
     fontFamily: string;
+    fontSize: Float;
     color: ColorValue;
     backgroundColor: ColorValue;
   };

--- a/src/styleUtils.ts
+++ b/src/styleUtils.ts
@@ -34,11 +34,13 @@ function makeDefaultMarkdownStyle(): MarkdownStyle {
     },
     code: {
       fontFamily: FONT_FAMILY_MONOSPACE,
+      fontSize: 20,
       color: 'black',
       backgroundColor: 'lightgray',
     },
     pre: {
       fontFamily: FONT_FAMILY_MONOSPACE,
+      fontSize: 20,
       color: 'black',
       backgroundColor: 'lightgray',
     },


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Details

This PR allows to customize font size of codeblock and inline code in `MarkdownTextInput`.

<table>
<thead>
<tr>
<th>Android</th>
<th>iOS</th>
<th>Web</th>
</tr>
</thead>
<tbody>
<tr>
<td><img width="319" alt="Screenshot 2024-04-03 at 12 50 30" src="https://github.com/Expensify/react-native-live-markdown/assets/20516055/ab31c413-ee51-4577-9b35-ed13db0304ca"></td>
<td><img width="319" alt="Screenshot 2024-04-03 at 12 51 17" src="https://github.com/Expensify/react-native-live-markdown/assets/20516055/809fa56e-4f39-4bef-8c03-14eb78f4c780"></td>
<td><img width="319" alt="Screenshot 2024-04-03 at 12 55 36" src="https://github.com/Expensify/react-native-live-markdown/assets/20516055/1a5a8ea8-7970-42e7-ada9-c28e6c2e045f"></td>
</tr>
</tbody>
</table>


### Related Issues
<!-- Please replace GH_LINK with the link to the GitHub issue this Pull Request is related to -->

### Manual Tests
<!---
Most changes should have accompanying tests. Describe the tests you added or if no tests were added an explanation about why one was not needed.
--->

Change `code.fontSize` or `pre.fontSize` to 30 in `makeDefaultMarkdownStyle` or `markdownStyle`.

### Linked PRs
<!---
Please include links to any update PRs in repos that must change their package.json version.
--->