### PR TITLE
Fix selection positioning when typing fast

### DIFF
--- a/src/MarkdownTextInput.web.tsx
+++ b/src/MarkdownTextInput.web.tsx
@@ -158,6 +158,7 @@ const MarkdownTextInput = React.forwardRef<TextInput, MarkdownTextInputProps>(
     ref,
   ) => {
     const compositionRef = useRef<boolean>(false);
+    const pasteRef = useRef<boolean>(false);
     const divRef = useRef<HTMLDivElement | null>(null);
     const currentlyFocusedField = useRef<HTMLDivElement | null>(null);
     const contentSelection = useRef<Selection | null>(null);
@@ -319,7 +320,10 @@ const MarkdownTextInput = React.forwardRef<TextInput, MarkdownTextInputProps>(
           default:
             text = parseText(divRef.current, e.target.innerText, processedMarkdownStyle).text;
         }
-        updateSelection(e);
+        if (pasteRef?.current) {
+          pasteRef.current = false;
+          updateSelection(e);
+        }
         updateTextColor(divRef.current, e.target.innerText);
 
         if (onChange) {
@@ -460,6 +464,10 @@ const MarkdownTextInput = React.forwardRef<TextInput, MarkdownTextInputProps>(
       [onClick, updateSelection],
     );
 
+    const handlePaste = () => {
+      pasteRef.current = true;
+    };
+
     const startComposition = useCallback(() => {
       compositionRef.current = true;
     }, []);
@@ -559,6 +567,7 @@ const MarkdownTextInput = React.forwardRef<TextInput, MarkdownTextInputProps>(
         onClick={handleClick}
         onFocus={handleFocus}
         onBlur={handleBlur}
+        onPaste={handlePaste}
         placeholder={heightSafePlaceholder}
         spellCheck={spellCheck}
         dir={dir}

--- a/src/MarkdownTextInput.web.tsx
+++ b/src/MarkdownTextInput.web.tsx
@@ -464,9 +464,9 @@ const MarkdownTextInput = React.forwardRef<TextInput, MarkdownTextInputProps>(
       [onClick, updateSelection],
     );
 
-    const handlePaste = () => {
+    const handlePaste = useCallback(() => {
       pasteRef.current = true;
-    };
+    }, []);
 
     const startComposition = useCallback(() => {
       compositionRef.current = true;


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Details
<!-- Explanation of the change or anything fishy that is going on -->
This PR fixes a problem where the selection gets improperly updated when there's multiple events occurring at once

### Related Issues
<!-- Please replace GH_LINK with the link to the GitHub issue this Pull Request is related to -->
[GH_LINK](https://github.com/Expensify/App/issues/39360)

### Manual Tests
<!---
Most changes should have accompanying tests. Describe the tests you added or if no tests were added an explanation about why one was not needed.
--->
It's difficult to test it manually in our current example setup, but a good representation of it could be done using Expensify App when you type really fast. 

It used to update the selection with a stale state resulting in cursor moving backwards a character, now this problem shouldn't happen anymore

### Linked PRs
<!---
Please include links to any update PRs in repos that must change their package.json version.
--->