### PR TITLE
Fix undoing pasted text into the input

### DIFF
--- a/src/MarkdownTextInput.web.tsx
+++ b/src/MarkdownTextInput.web.tsx
@@ -546,6 +546,13 @@ const MarkdownTextInput = React.forwardRef<TextInput, MarkdownTextInputProps>(
       updateSelection(null, {start: selection.start, end: selection.end || selection.start});
     }, [selection, updateSelection]);
 
+    useEffect(() => {
+      if (history.current?.history.length !== 0) {
+        return;
+      }
+      history.current.add(value ?? '', (value ?? '').length);
+    }, []);
+
     return (
       // eslint-disable-next-line jsx-a11y/no-static-element-interactions
       <div

--- a/src/MarkdownTextInput.web.tsx
+++ b/src/MarkdownTextInput.web.tsx
@@ -550,7 +550,8 @@ const MarkdownTextInput = React.forwardRef<TextInput, MarkdownTextInputProps>(
       if (history.current?.history.length !== 0) {
         return;
       }
-      history.current.add(value ?? '', (value ?? '').length);
+      const currentValue = value ?? '';
+      history.current.add(currentValue, currentValue.length);
       // eslint-disable-next-line react-hooks/exhaustive-deps
     }, []);
 

--- a/src/MarkdownTextInput.web.tsx
+++ b/src/MarkdownTextInput.web.tsx
@@ -551,6 +551,7 @@ const MarkdownTextInput = React.forwardRef<TextInput, MarkdownTextInputProps>(
         return;
       }
       history.current.add(value ?? '', (value ?? '').length);
+      // eslint-disable-next-line react-hooks/exhaustive-deps
     }, []);
 
     return (


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Details
<!-- Explanation of the change or anything fishy that is going on -->
This issue fixes a situation where the initial value of the input doesn't get saved into `InputHistory`, because of this it's not possible to undo the previous action

### Related Issues
<!-- Please replace GH_LINK with the link to the GitHub issue this Pull Request is related to -->
[GH_LINK](https://github.com/Expensify/App/issues/39255)

### Manual Tests
<!---
Most changes should have accompanying tests. Describe the tests you added or if no tests were added an explanation about why one was not needed.
--->

To test this remove the default value provided for our example.
1. Copy some longer text
2. Paste this text into input
3. Try to undo it with `CMD + Z`

### Linked PRs
<!---
Please include links to any update PRs in repos that must change their package.json version.
--->