### PR TITLE
Fix updating both styles at once on iOS

### DIFF
--- a/ios/MarkdownTextInputDecoratorView.mm
+++ b/ios/MarkdownTextInputDecoratorView.mm
@@ -100,7 +100,7 @@
 {
   _markdownStyle = markdownStyle;
   [_markdownUtils setMarkdownStyle:markdownStyle];
-  [_textInput textInputDidChange]; // trigger attributed text update
+  [_textInput setAttributedText:_textInput.attributedText]; // apply new styles
 }
 
 @end


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Details
<!-- Explanation of the change or anything fishy that is going on -->

This PR fixes the formatting of `MarkdownTextInput` when both `style` and `markdownStyle` are changed in a single React render on iOS.

<table>
<thead>
<tr>
<th>Before</th>
<th>After</th>
</tr>
</thead>
<tbody>
<tr>
<td><video src="https://github.com/Expensify/react-native-live-markdown/assets/20516055/c1aa600e-82b2-49de-a124-858365ff173b" /></td>
<td><video src="https://github.com/Expensify/react-native-live-markdown/assets/20516055/16695d1a-6fd5-4dd4-9763-f01e62f6e860" /></td>
</tr>
</tbody>
</table>

### Related Issues
<!-- Please replace GH_LINK with the link to the GitHub issue this Pull Request is related to -->
[GH_LINK](https://github.com/Expensify/App/issues/39348)

### Manual Tests
<!---
Most changes should have accompanying tests. Describe the tests you added or if no tests were added an explanation about why one was not needed.
--->

### Linked PRs
<!---
Please include links to any update PRs in repos that must change their package.json version.
--->