### PR TITLE
fix: case element height equal 0

### DIFF
--- a/src/MarkdownTextInput.web.tsx
+++ b/src/MarkdownTextInput.web.tsx
@@ -117,10 +117,10 @@ function getElementHeight(node: HTMLDivElement, styles: CSSProperties, numberOfL
       node.parentElement.appendChild(tempElement);
       const height = tempElement.clientHeight;
       node.parentElement.removeChild(tempElement);
-      return `${height}px`;
+      return height ? `${height}px` : 'auto';
     }
   }
-  return `${styles.height}px` || 'auto';
+  return styles.height ? `${styles.height}px` : 'auto';
 }
 
 const MarkdownTextInput = React.forwardRef<TextInput, MarkdownTextInputProps>(


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Details
<!-- Explanation of the change or anything fishy that is going on -->
Currently, we didn't check if the height is positive before returning the value. The height could be 0 if the parent element was not fully rendered in the DOM yet.

So on layout change, when we use the method to get the element height [here](https://github.com/Expensify/react-native-live-markdown/blob/c7595572ff4f2a4b8c95a6110a05de62b2d8dbe4/src/MarkdownTextInput.web.tsx#L524) to use as maxHeight, we're getting 0 as the height

To fix this:  if the height is 0, we should return auto as the height

This is similar to the logic when numberOfLines is not defined [here](https://github.com/Expensify/react-native-live-markdown/blob/c7595572ff4f2a4b8c95a6110a05de62b2d8dbe4/src/MarkdownTextInput.web.tsx#L123) . There's a bug there also, the condition after || will never be triggered, it should be `styles.height ? '${styles.height}px' : 'auto'.`

### Related Issues
<!-- Please replace GH_LINK with the link to the GitHub issue this Pull Request is related to -->
GH_LINK

### Manual Tests
<!---
Most changes should have accompanying tests. Describe the tests you added or if no tests were added an explanation about why one was not needed.
--->


### Linked PRs
<!---
Please include links to any update PRs in repos that must change their package.json version.
--->