### PR TITLE
Filter built ABIs so the library compiles when building for select ABIs

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -9,6 +9,11 @@ buildscript {
   }
 }
 
+def reactNativeArchitectures() {
+  def value = project.getProperties().get("reactNativeArchitectures")
+  return value ? value.split(",") : ["armeabi-v7a", "x86", "x86_64", "arm64-v8a"]
+}
+
 def isNewArchitectureEnabled() {
   return rootProject.hasProperty("newArchEnabled") && rootProject.getProperty("newArchEnabled") == "true"
 }
@@ -59,6 +64,7 @@ android {
     externalNativeBuild {
       cmake {
         arguments "-DANDROID_STL=c++_shared", "-DANDROID_TOOLCHAIN=clang"
+        abiFilters (*reactNativeArchitectures())
       }
     }
   }


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Details
The library is always being built for all available ABIs even when the app it's being used in is only built for one. This causes it to fail on linking stage if React Native is built from source, since relevant `.so` files from React Native core don't exist. This PR adds relevant filters.

### Manual Tests
Run `yarn build:android` from the example app.