### PR TITLE
Restore backed text view in MarkdownUtils

### DIFF
--- a/ios/MarkdownTextInputDecoratorView.mm
+++ b/ios/MarkdownTextInputDecoratorView.mm
@@ -58,7 +58,7 @@
   UIView<RCTBackedTextInputViewProtocol> *backedTextInputView = _textInput.backedTextInputView;
 #endif /* RCT_NEW_ARCH_ENABLED */
 
-  _markdownUtils = [[RCTMarkdownUtils alloc] init];
+  _markdownUtils = [[RCTMarkdownUtils alloc] initWithBackedTextInputView:backedTextInputView];
   react_native_assert(_markdownStyle != nil);
   [_markdownUtils setMarkdownStyle:_markdownStyle];
 

--- a/ios/RCTMarkdownUtils.h
+++ b/ios/RCTMarkdownUtils.h
@@ -9,6 +9,8 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic) NSMutableArray<NSDictionary *> *blockquoteRangesAndLevels;
 @property (weak, nonatomic) UIView<RCTBackedTextInputViewProtocol> *backedTextInputView;
 
+- (instancetype)initWithBackedTextInputView:(UIView<RCTBackedTextInputViewProtocol> *)backedTextInputView;
+
 - (NSAttributedString *)parseMarkdown:(nullable NSAttributedString *)input withAttributes:(nullable NSDictionary<NSAttributedStringKey, id>*)attributes;
 
 @end

--- a/ios/RCTMarkdownUtils.mm
+++ b/ios/RCTMarkdownUtils.mm
@@ -11,6 +11,14 @@
   __weak RCTMarkdownStyle *_prevMarkdownStyle;
 }
 
+- (instancetype)initWithBackedTextInputView:(UIView<RCTBackedTextInputViewProtocol> *)backedTextInputView
+{
+  if (self = [super init]) {
+    _backedTextInputView = backedTextInputView;
+  }
+  return self;
+}
+
 - (NSAttributedString *)parseMarkdown:(nullable NSAttributedString *)input withAttributes:(nullable NSDictionary<NSAttributedStringKey,id> *)attributes
 {
     @synchronized (self) {


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Details
Restores setting backed text view in MarkdownUtils which was removed in https://github.com/Expensify/react-native-live-markdown/pull/199

### Manual Tests
I'll be honest, I have no idea where to look for the effects of this change. I don't see a difference in codeblocks after changing it back, so it may simply not work or I don't know what to look for.