### PR TITLE
Fix blockquote paddings and remove `backedTextInputView`

### DIFF
--- a/ios/MarkdownLayoutManager.mm
+++ b/ios/MarkdownLayoutManager.mm
@@ -21,8 +21,8 @@
       }
     }];
     if (isBlockquote) {
-      CGFloat paddingLeft = markdownUtils.backedTextInputView.textContainerInset.left;
-      CGFloat paddingTop = markdownUtils.backedTextInputView.textContainerInset.top;
+      CGFloat paddingLeft = origin.x;
+      CGFloat paddingTop = origin.y;
       CGFloat y = paddingTop + rect.origin.y;
       CGFloat width = markdownUtils.markdownStyle.blockquoteBorderWidth;
       CGFloat height = rect.size.height;

--- a/ios/RCTMarkdownUtils.h
+++ b/ios/RCTMarkdownUtils.h
@@ -7,7 +7,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 @property (nonatomic) RCTMarkdownStyle *markdownStyle;
 @property (nonatomic) NSMutableArray<NSDictionary *> *blockquoteRangesAndLevels;
-@property (weak, nonatomic) UIView<RCTBackedTextInputViewProtocol> *backedTextInputView;
 
 - (NSAttributedString *)parseMarkdown:(nullable NSAttributedString *)input withAttributes:(nullable NSDictionary<NSAttributedStringKey, id>*)attributes;
 


### PR DESCRIPTION
### Details
Completely removes `backedTextInputView` and changes where it gets padding from for blockquotes. It was broken by #199.

### Manual Tests
This is a visual change. You can see that the grey block is misaligned without this.