### PR TITLE
Add onContentSizeChange prop

### DIFF
--- a/src/MarkdownTextInput.web.tsx
+++ b/src/MarkdownTextInput.web.tsx
@@ -70,8 +70,8 @@ type Selection = {
 };
 
 type Dimensions = {
-  height: number | null;
-  width: number | null;
+  width: number;
+  height: number;
 };
 
 let focusTimeout: NodeJS.Timeout | null = null;
@@ -171,7 +171,7 @@ const MarkdownTextInput = React.forwardRef<TextInput, MarkdownTextInputProps>(
     const contentSelection = useRef<Selection | null>(null);
     const className = `react-native-live-markdown-input-${multiline ? 'multiline' : 'singleline'}`;
     const history = useRef<InputHistory>();
-    const dimensions = React.useRef<Dimensions>({height: null, width: null});
+    const dimensions = React.useRef<Dimensions | null>(null);
 
     if (!history.current) {
       history.current = new InputHistory(100);
@@ -311,19 +311,15 @@ const MarkdownTextInput = React.forwardRef<TextInput, MarkdownTextInputProps>(
       }
 
       const hostNode = (divRef.current.firstChild as HTMLElement) ?? divRef.current;
-      const newHeight = hostNode.offsetHeight;
       const newWidth = hostNode.offsetWidth;
+      const newHeight = hostNode.offsetHeight;
 
-      if (newHeight !== dimensions.current.height || newWidth !== dimensions.current.width) {
-        dimensions.current.height = newHeight;
-        dimensions.current.width = newWidth;
+      if (newHeight !== dimensions.current?.height || newWidth !== dimensions.current.width) {
+        dimensions.current = {height: newHeight, width: newWidth};
 
         onContentSizeChange({
           nativeEvent: {
-            contentSize: {
-              height: dimensions.current.height,
-              width: dimensions.current.width,
-            },
+            contentSize: dimensions.current,
           },
         } as NativeSyntheticEvent<TextInputContentSizeChangeEventData>);
       }

--- a/src/MarkdownTextInput.web.tsx
+++ b/src/MarkdownTextInput.web.tsx
@@ -587,6 +587,8 @@ const MarkdownTextInput = React.forwardRef<TextInput, MarkdownTextInputProps>(
       }
       const currentValue = value ?? '';
       history.current.add(currentValue, currentValue.length);
+
+      handleContentSizeChange();
       // eslint-disable-next-line react-hooks/exhaustive-deps
     }, []);
 


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Details
<!-- Explanation of the change or anything fishy that is going on -->
This PR add `onContentSizeChange` prop to live markdown web implementation. This is a part of a [jumping composer issue](https://github.com/Expensify/App/issues/39267) fix

### Related Issues
<!-- Please replace GH_LINK with the link to the GitHub issue this Pull Request is related to -->
GH_LINK

### Manual Tests
<!---
Most changes should have accompanying tests. Describe the tests you added or if no tests were added an explanation about why one was not needed.
--->
1. Add `onContentSizeChange` prop function
2. Console log its event. Verify if height and width are correct
### Linked PRs
<!---
Please include links to any update PRs in repos that must change their package.json version.
--->

https://github.com/Expensify/App/issues/39267