### PR TITLE
Fix iOS build cache reuse

### DIFF
--- a/.github/workflows/build-ios.yml
+++ b/.github/workflows/build-ios.yml
@@ -52,7 +52,7 @@ jobs:
             example/ios/Pods
             ~/Library/Caches/CocoaPods
             ~/.cocoapods
-          key: build-ios-pods-${{ hashFiles('example/ios/Podfile.lock') }}
+          key: build-ios-pods-${{ hashFiles('example/node_modules/react-native/package.json') }}
           restore-keys: build-ios-pods-
 
       - name: Install Pods
@@ -69,7 +69,7 @@ jobs:
         uses: actions/cache@v4
         with:
           path: ~/Library/Developer/Xcode/DerivedData
-          key: build-ios-derived-data-${{ hashFiles('example/ios/Podfile.lock') }}
+          key: build-ios-derived-data-${{ hashFiles('example/node_modules/react-native/package.json') }}
           restore-keys: build-ios-derived-data-
 
       - name: Build app


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Details
This PR changes the cache key used for restoring iOS dependencies (Pods) and build artifacts (DerivedData).

Currently, the cache key includes a hash calculated from `example/ios/Podfile.lock`. Unfortunately, this file changes very frequently as we automatically bump patch version after each merged PR which results in updating the caches on each PR which is time-consuming.

Most likely, the only scenario where we should drop the caches is when we bump `react-native` version in our example app and that's exactly what this PR does.

### Related Issues
<!-- Please replace GH_LINK with the link to the GitHub issue this Pull Request is related to -->
GH_LINK

### Manual Tests
<!---
Most changes should have accompanying tests. Describe the tests you added or if no tests were added an explanation about why one was not needed.
--->

### Linked PRs
<!---
Please include links to any update PRs in repos that must change their package.json version.
--->