### PR TITLE
Fix errors when compiling with Swift file on iOS lower than 14

### DIFF
--- a/RNLiveMarkdown.podspec
+++ b/RNLiveMarkdown.podspec
@@ -30,6 +30,5 @@ Pod::Spec.new do |s|
   s.subspec "common" do |ss|
     ss.source_files         = "cpp/**/*.{cpp,h}"
     ss.header_dir           = "RNLiveMarkdown"
-    ss.pod_target_xcconfig  = { "HEADER_SEARCH_PATHS" => "\"$(PODS_TARGET_SRCROOT)/cpp\"" }
   end
 end

--- a/cpp/react/renderer/components/RNLiveMarkdownSpec/MarkdownTextInputDecoratorState.h
+++ b/cpp/react/renderer/components/RNLiveMarkdownSpec/MarkdownTextInputDecoratorState.h
@@ -1,4 +1,5 @@
 #pragma once
+#if defined(RCT_NEW_ARCH_ENABLED) || defined(ANDROID)
 
 #include <react/renderer/core/ShadowNodeFamily.h>
 
@@ -32,3 +33,5 @@ public:
 
 } // namespace react
 } // namespace facebook
+
+#endif

--- a/cpp/react/renderer/components/RNLiveMarkdownSpec/MarkdownTextInputDecoratorViewComponentDescriptor.h
+++ b/cpp/react/renderer/components/RNLiveMarkdownSpec/MarkdownTextInputDecoratorViewComponentDescriptor.h
@@ -1,4 +1,5 @@
 #pragma once
+#if defined(RCT_NEW_ARCH_ENABLED) || defined(ANDROID)
 
 #include "MarkdownTextInputDecoratorShadowNode.h"
 #include <react/debug/react_native_assert.h>
@@ -15,3 +16,5 @@ public:
 
 } // namespace react
 } // namespace facebook
+
+#endif


### PR DESCRIPTION
### Details
If a Swift file was added to the project with podspec target set to iOS 13 and lower, the app wouldn't compile and would throw `file not found` errors.