### PR TITLE
Ensure caret is visible

### DIFF
--- a/src/MarkdownTextInput.web.tsx
+++ b/src/MarkdownTextInput.web.tsx
@@ -553,6 +553,7 @@ const MarkdownTextInput = React.forwardRef<TextInput, MarkdownTextInputProps>(
         const elementHeight = getElementHeight(divRef.current, inputStyles, numberOfLines);
         divRef.current.style.height = elementHeight;
         divRef.current.style.maxHeight = elementHeight;
+        CursorUtils.scrollCursorIntoView(divRef.current as HTMLInputElement);
       },
       [numberOfLines],
     );


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Details
<!-- Explanation of the change or anything fishy that is going on -->

https://github.com/Expensify/react-native-live-markdown/blob/cd42c45c0a76c4beba86e52899e196d9f176eb46/src/MarkdownTextInput.web.tsx#L441

In Chrome and Safari (mobile & PC), for long text message, even though we set the cursor position when focused, `maxHeight` hasn't taken effect yet, so the element has no overflow, causing the caret to be invisible after rendering. This change ensures that the caret is visible.


https://github.com/Expensify/react-native-live-markdown/assets/8579651/e13cf405-39a8-44ce-ba70-11516f0b4b29




### Related Issues
<!-- Please replace GH_LINK with the link to the GitHub issue this Pull Request is related to -->
https://github.com/Expensify/App/issues/26239#issuecomment-2059414561

### Manual Tests
<!---
Most changes should have accompanying tests. Describe the tests you added or if no tests were added an explanation about why one was not needed.
--->

### Linked PRs
<!---
Please include links to any update PRs in repos that must change their package.json version.
--->
https://github.com/Expensify/App/pull/40295

