### PR TITLE
Fix selection getting lost on Android on the new arch

### DIFF
--- a/android/src/main/new_arch/MarkdownCommitHook.cpp
+++ b/android/src/main/new_arch/MarkdownCommitHook.cpp
@@ -111,6 +111,9 @@ RootShadowNode::Unshared MarkdownCommitHook::shadowTreeWillCommit(
               std::make_shared<AndroidTextInputState>(stateData);
           // force measurement of a map buffer
           newStateData->cachedAttributedStringId = 0;
+          // setting -1 as the event counter makes sure that the update will be ignored by the java
+          // part of the code, which is what we want as we don't change the attributed string here
+          newStateData->mostRecentEventCount = -1;
 
           // clone the text input with the new state
           auto newNode = node.clone({

--- a/android/src/main/new_arch/MarkdownCommitHook.cpp
+++ b/android/src/main/new_arch/MarkdownCommitHook.cpp
@@ -111,9 +111,15 @@ RootShadowNode::Unshared MarkdownCommitHook::shadowTreeWillCommit(
               std::make_shared<AndroidTextInputState>(stateData);
           // force measurement of a map buffer
           newStateData->cachedAttributedStringId = 0;
+
           // setting -1 as the event counter makes sure that the update will be ignored by the java
           // part of the code, which is what we want as we don't change the attributed string here
-          newStateData->mostRecentEventCount = -1;
+          if (previousEventCount_.contains(nodes.textInput->getTag()) &&
+              previousEventCount_[nodes.textInput->getTag()] == stateData.mostRecentEventCount) {
+              newStateData->mostRecentEventCount = -1;
+          } else {
+              previousEventCount_[nodes.textInput->getTag()] = stateData.mostRecentEventCount;
+          }
 
           // clone the text input with the new state
           auto newNode = node.clone({

--- a/android/src/main/new_arch/MarkdownCommitHook.h
+++ b/android/src/main/new_arch/MarkdownCommitHook.h
@@ -47,6 +47,8 @@ private:
       textLayoutManagers_;
   std::unordered_map<facebook::react::Tag, folly::dynamic>
       previousDecoratorProps_;
+  std::unordered_map<facebook::react::Tag, int64_t>
+      previousEventCount_;
 };
 
 } // namespace livemarkdown


### PR DESCRIPTION
### Details

The commit hook is updating the native state of the decorated text input on every shadow tree commit to override the default measurement method. Since the attributed string with the content of the input is also kept in the state, this was causing the state of the native `ReactEditText` to be updated on every commit, which effectively meant creating a new spannable on every commit and in turn losing the selection spans.

This PR changes the update to also set the event counter to `-1` when it doesn't change between updates, which effectively makes the java part of the state updates a no-op in those cases, similarly to how it's done in the core of RN: https://github.com/facebook/react-native/blob/67392cef3c8e036adfd9f77808419221d70f8f18/packages/react-native/ReactCommon/react/renderer/components/textinput/platform/android/react/renderer/components/androidtextinput/AndroidTextInputShadowNode.cpp#L155-L163

(-1 instead of 0, like above, because 0 would be the most recent counter during the first render)

Always setting the event counter to `-1` also seemed to work fine but after quite a while of figuring out issues due to lost state updates in commit hooks, I'm not sure if we want to go that far now. It's something we may want to investigate in the future though.

### Manual Tests

This is testable in the example app, simply select some text. The handles should appear and be draggable. The text editing part should also work correctly.