### PR TITLE
fix: IOU - one character descriptions are not saved

### DIFF
--- a/src/MarkdownTextInput.web.tsx
+++ b/src/MarkdownTextInput.web.tsx
@@ -62,6 +62,7 @@ interface MarkdownTextInputProps extends TextInputProps {
 
 interface MarkdownNativeEvent extends Event {
   inputType: string;
+  data: string;
 }
 
 type Selection = {
@@ -337,14 +338,14 @@ const MarkdownTextInput = React.forwardRef<TextInput, MarkdownTextInputProps>(
         }
         const changedText = e.target.innerText;
 
-        if (compositionRef.current) {
-          updateTextColor(divRef.current, changedText);
+        const nativeEvent = e.nativeEvent as MarkdownNativeEvent;
+        if (compositionRef.current && (nativeEvent.inputType !== 'insertCompositionText' || nativeEvent.data !== '*')) {
+          updateTextColor(divRef.current, e.target.innerText);
           compositionRef.current = false;
           return;
         }
 
         let text = '';
-        const nativeEvent = e.nativeEvent as MarkdownNativeEvent;
         switch (nativeEvent.inputType) {
           case 'historyUndo':
             text = undo(divRef.current);

--- a/src/MarkdownTextInput.web.tsx
+++ b/src/MarkdownTextInput.web.tsx
@@ -339,8 +339,8 @@ const MarkdownTextInput = React.forwardRef<TextInput, MarkdownTextInputProps>(
         const changedText = e.target.innerText;
 
         const nativeEvent = e.nativeEvent as MarkdownNativeEvent;
-        if (compositionRef.current && (nativeEvent.inputType !== 'insertCompositionText' || nativeEvent.data !== '*')) {
-          updateTextColor(divRef.current, e.target.innerText);
+        if (compositionRef.current && (nativeEvent.inputType === 'insertCompositionText' || nativeEvent.data !== '*')) {
+          updateTextColor(divRef.current, changedText);
           compositionRef.current = false;
           return;
         }


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->
@sobitneupane @BartoszGrajdek

### Details
<!-- Explanation of the change or anything fishy that is going on -->
This PR avoid the incorrect behavior of the keyboard during auto-complete on Android mWeb.
The main changes are:
Add a condition, when the startComposition event trigger, whether the type of text change is 'insertCompositionText'. If confirmed, then execute the logic of Composition.


### Related Issues
<!-- Please replace GH_LINK with the link to the GitHub issue this Pull Request is related to -->

[Issues IOU - one character descriptions are not saved](https://github.com/Expensify/App/issues/40799#top)
[Proposal](https://github.com/Expensify/App/issues/40799#issuecomment-2075206243)

### Manual Tests
<!---
Most changes should have accompanying tests. Describe the tests you added or if no tests were added an explanation about why one was not needed.
--->
On Android mWeb

1. Navigate to staging.new.expensify.com
2. Click on FAB > Submit expense > Manual
3. Input an amount
4. Select a user
5. Click on "Description"
"The system keyboard must be set to predictive text mode, or what's called autocomplete mode. Just type a few characters."
6. Click save when the system's predictive text is active.


### Linked PRs
<!---
Please include links to any update PRs in repos that must change their package.json version.
--->

### Tested
1. Mac Chrome/Safari

https://github.com/Expensify/react-native-live-markdown/assets/13301734/c13b79ec-e01e-4088-935f-038291ffd83e

2. Android mWeb


https://github.com/Expensify/react-native-live-markdown/assets/13301734/dc1d3f1d-b718-4945-b2df-40538392f200


