### PR TITLE
Fix replacing default element in undo history

### DIFF
--- a/src/MarkdownTextInput.web.tsx
+++ b/src/MarkdownTextInput.web.tsx
@@ -219,7 +219,7 @@ const MarkdownTextInput = React.forwardRef<TextInput, MarkdownTextInputProps>(
     const processedMarkdownStyle = useMemo(() => {
       const newMarkdownStyle = processMarkdownStyle(markdownStyle);
       if (divRef.current) {
-        parseText(divRef.current, divRef.current.innerText, newMarkdownStyle);
+        parseText(divRef.current, divRef.current.innerText, newMarkdownStyle, null, false);
       }
       return newMarkdownStyle;
     }, [markdownStyle, parseText]);

--- a/src/web/InputHistory.ts
+++ b/src/web/InputHistory.ts
@@ -49,6 +49,9 @@ export default class InputHistory {
     if (this.currentText === null) {
       this.timeout = null;
       this.add(text, cursorPosition);
+      if (this.historyIndex === 0) {
+        return;
+      }
     } else {
       this.items[this.historyIndex] = {text, cursorPosition};
     }

--- a/src/web/InputHistory.ts
+++ b/src/web/InputHistory.ts
@@ -49,9 +49,6 @@ export default class InputHistory {
     if (this.currentText === null) {
       this.timeout = null;
       this.add(text, cursorPosition);
-      if (this.historyIndex === 0) {
-        return;
-      }
     } else {
       this.items[this.historyIndex] = {text, cursorPosition};
     }
@@ -71,7 +68,7 @@ export default class InputHistory {
   }
 
   add(text: string, cursorPosition: number): void {
-    if (this.items.length > 0) {
+    if (this.historyIndex > 0 && this.items.length > 0) {
       const currentItem = this.items[this.historyIndex];
       if (currentItem && text === currentItem.text) {
         return;

--- a/src/web/InputHistory.ts
+++ b/src/web/InputHistory.ts
@@ -68,7 +68,7 @@ export default class InputHistory {
   }
 
   add(text: string, cursorPosition: number): void {
-    if (this.historyIndex > 0 && this.items.length > 0) {
+    if (this.items.length > 0) {
       const currentItem = this.items[this.historyIndex];
       if (currentItem && text === currentItem.text) {
         return;


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Details
<!-- Explanation of the change or anything fishy that is going on -->
This PR fixes the bug when pasting text into composer before the page fully loads and the default history item is replaced

### Related Issues
<!-- Please replace GH_LINK with the link to the GitHub issue this Pull Request is related to -->
https://github.com/Expensify/App/issues/39255

### Manual Tests
<!---
Most changes should have accompanying tests. Describe the tests you added or if no tests were added an explanation about why one was not needed.
--->
> [!NOTE]  
> Issues are mostly reproducible in E/App

#### Unable to undo pasted text issue
1. Reload the app
2. Paste text *quickly* into auto-focused markdown input
3. Undo it by clicking `Ctrl + Z`
4. Verify if the text was undone and if you can redo the changes

#### Wrong history index after repeating paste and undo
1. Open the app
2. Paste text into
3. Undo it by clicking `Ctrl + Z`
4. Paste text into
5. Undo it by clicking `Ctrl + Z`, verify if the text was undone
6. Go to step 2 and repeat


### Linked PRs
<!---
Please include links to any update PRs in repos that must change their package.json version.
--->
https://github.com/Expensify/react-native-live-markdown/pull/342