### PR TITLE
fix: use setBaseAndExtent instead of removeAllRanges

### DIFF
--- a/src/MarkdownTextInput.web.tsx
+++ b/src/MarkdownTextInput.web.tsx
@@ -560,8 +560,7 @@ const MarkdownTextInput = React.forwardRef<TextInput, MarkdownTextInputProps>(
 
         const text = processedValue !== undefined ? processedValue : '';
 
-        const currentCursorPostion = contentSelection?.current && contentSelection?.current.end <= text.length ? contentSelection.current.end : text.length;
-        parseText(divRef.current, text, processedMarkdownStyle, currentCursorPostion);
+        parseText(divRef.current, text, processedMarkdownStyle, contentSelection.current?.end);
         updateTextColor(divRef.current, value);
       },
       [multiline, processedMarkdownStyle, processedValue],

--- a/src/MarkdownTextInput.web.tsx
+++ b/src/MarkdownTextInput.web.tsx
@@ -559,7 +559,9 @@ const MarkdownTextInput = React.forwardRef<TextInput, MarkdownTextInputProps>(
         }
 
         const text = processedValue !== undefined ? processedValue : '';
-        parseText(divRef.current, text, processedMarkdownStyle, text.length);
+
+        const currentCursorPostion = contentSelection?.current && contentSelection?.current.end <= text.length ? contentSelection.current.end : text.length;
+        parseText(divRef.current, text, processedMarkdownStyle, currentCursorPostion);
         updateTextColor(divRef.current, value);
       },
       [multiline, processedMarkdownStyle, processedValue],

--- a/src/web/cursorUtils.ts
+++ b/src/web/cursorUtils.ts
@@ -94,8 +94,7 @@ function setCursorPosition(target: HTMLElement, start: number, end: number | nul
 
   const selection = window.getSelection();
   if (selection) {
-    selection.removeAllRanges();
-    selection.addRange(range);
+    selection.setBaseAndExtent(range.startContainer, range.startOffset, range.endContainer, range.endOffset);
   }
 
   scrollCursorIntoView(target as HTMLInputElement);
@@ -107,8 +106,7 @@ function moveCursorToEnd(target: HTMLElement) {
   if (selection) {
     range.setStart(target, target.childNodes.length);
     range.collapse(true);
-    selection.removeAllRanges();
-    selection.addRange(range);
+    selection.setBaseAndExtent(range.startContainer, range.startOffset, range.endContainer, range.endOffset);
   }
 }
 

--- a/src/web/parserUtils.ts
+++ b/src/web/parserUtils.ts
@@ -179,12 +179,13 @@ function moveCursor(isFocused: boolean, alwaysMoveCursorToTheEnd: boolean, curso
   }
 }
 
-function parseText(target: HTMLElement, text: string, curosrPositionIndex: number | null, markdownStyle: PartialMarkdownStyle = {}, alwaysMoveCursorToTheEnd = false) {
+function parseText(target: HTMLElement, text: string, cursorPositionIndex: number | null, markdownStyle: PartialMarkdownStyle = {}, alwaysMoveCursorToTheEnd = false) {
   const targetElement = target;
 
-  let cursorPosition: number | null = curosrPositionIndex;
+  // in case the cursorPositionIndex is larger than text length, cursorPosition will be null, i.e: move the caret to the end
+  let cursorPosition: number | null = cursorPositionIndex && cursorPositionIndex <= text.length ? cursorPositionIndex : null;
   const isFocused = document.activeElement === target;
-  if (isFocused && curosrPositionIndex === null) {
+  if (isFocused && cursorPositionIndex === null) {
     const selection = CursorUtils.getCurrentCursorPosition(target);
     cursorPosition = selection ? selection.end : null;
   }


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Details
<!-- Explanation of the change or anything fishy that is going on -->

Use `selection.setBaseAndExtent` instead of `selection.removeAllRanges(); selection.addRange(range)` to avoid the keyboard on Android chrome to hide

### Related Issues
<!-- Please replace GH_LINK with the link to the GitHub issue this Pull Request is related to -->

$ https://github.com/Expensify/App/issues/41137
PROPOSAL: https://github.com/Expensify/App/issues/41137#issuecomment-2121656214


### Manual Tests
<!---
Most changes should have accompanying tests. Describe the tests you added or if no tests were added an explanation about why one was not needed.
--->

Use Android chrome and go to the main page https://127.0.0.1:8082
Tap on a report
Paste any text repeatedly and note the page

Expected: The keyboard should remain open and visible after the paste. Also, the caret position must be maintained.

### Linked PRs
<!---
Please include links to any update PRs in repos that must change their package.json version.
--->

https://github.com/Expensify/App/pull/42622