### PR TITLE
Auto focus only on mount

### DIFF
--- a/src/MarkdownTextInput.web.tsx
+++ b/src/MarkdownTextInput.web.tsx
@@ -586,7 +586,8 @@ const MarkdownTextInput = React.forwardRef<TextInput, MarkdownTextInputProps>(
       if (autoFocus) {
         divRef.current.focus();
       }
-    }, [autoFocus]);
+      // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, []);
 
     useEffect(() => {
       // update content size when the input styles change


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Details
<!-- Explanation of the change or anything fishy that is going on -->
Removed `autoFocus` from the `useEffect` deps so it only auto focus on mount.

### Related Issues
<!-- Please replace GH_LINK with the link to the GitHub issue this Pull Request is related to -->
https://github.com/Expensify/App/issues/42645

### Manual Tests
<!---
Most changes should have accompanying tests. Describe the tests you added or if no tests were added an explanation about why one was not needed.
--->
1. Add an `autoFocus` state to the example app
2. Add a new button to toggle the state
3. Press the button to toggle the state
4. If the state is true, verify the input isn't focused

Before:

https://github.com/Expensify/react-native-live-markdown/assets/50919443/74f976c0-5c3b-46d8-aeb3-80099ccba400

After:

https://github.com/Expensify/react-native-live-markdown/assets/50919443/18330d30-1e78-4a57-9b3a-909f52895b0b

