### PR TITLE
Fix: correct content height in TextKit 1 compatibility mode

### DIFF
--- a/ios/MarkdownTextInputDecoratorView.mm
+++ b/ios/MarkdownTextInputDecoratorView.mm
@@ -72,6 +72,14 @@
     _textView = (RCTUITextView *)_backedTextInputView;
     [_textView setMarkdownUtils:_markdownUtils];
     NSLayoutManager *layoutManager = _textView.layoutManager; // switching to TextKit 1 compatibility mode
+
+    // Correct content height in TextKit 1 compatibility mode. (See https://github.com/Expensify/App/issues/41567)
+    // Consider removing this fix if it is no longer needed after migrating to TextKit 2.
+    CGSize contentSize = _textView.contentSize;
+    CGRect textBounds = [layoutManager usedRectForTextContainer:_textView.textContainer];
+    contentSize.height = textBounds.size.height + _textView.textContainerInset.top + _textView.textContainerInset.bottom;
+    [_textView setContentSize:contentSize];
+
     layoutManager.allowsNonContiguousLayout = NO; // workaround for onScroll issue
     object_setClass(layoutManager, [MarkdownLayoutManager class]);
     [layoutManager setValue:_markdownUtils forKey:@"markdownUtils"];


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Details
<!-- Explanation of the change or anything fishy that is going on -->
The input is sometimes not scrollable on iOS.

### Related Issues
<!-- Please replace GH_LINK with the link to the GitHub issue this Pull Request is related to -->
$ https://github.com/Expensify/App/issues/41567
PROPOSAL: https://github.com/Expensify/App/issues/41567#issuecomment-2137792675

### Manual Tests
<!---
Most changes should have accompanying tests. Describe the tests you added or if no tests were added an explanation about why one was not needed.
--->
1. Open New Expensify and log in
2. Tap FAB > Assign task
3. Enter any title and add a long comment
4. On the confirmation screen open the the description and scroll down
5. Finish creating a task
6. Open the created task and tap the description
7. Scroll down

Expected Result:
User is able to scroll down the task description.

### Linked PRs
<!---
Please include links to any update PRs in repos that must change their package.json version.
--->