### PR TITLE
Unable pasting photos and styled text

### DIFF
--- a/src/MarkdownTextInput.web.tsx
+++ b/src/MarkdownTextInput.web.tsx
@@ -336,7 +336,6 @@ const MarkdownTextInput = React.forwardRef<TextInput, MarkdownTextInputProps>(
           return;
         }
         const changedText = e.target.innerText;
-
         if (compositionRef.current) {
           updateTextColor(divRef.current, changedText);
           compositionRef.current = false;
@@ -513,8 +512,13 @@ const MarkdownTextInput = React.forwardRef<TextInput, MarkdownTextInputProps>(
       [onClick, updateSelection],
     );
 
-    const handlePaste = useCallback(() => {
+    const handlePaste = useCallback((e) => {
       pasteRef.current = true;
+      e.preventDefault();
+
+      const clipboardData = e.clipboardData;
+      const text = clipboardData.getData('text/plain');
+      document.execCommand('insertText', false, text);
     }, []);
 
     const startComposition = useCallback(() => {


### PR DESCRIPTION
### Details
The default paste behaviour is overridden by inserting a `text/plain' value.