### PR TITLE
fix: revert the functionality to restore cursor in value update hook

### DIFF
--- a/src/MarkdownTextInput.web.tsx
+++ b/src/MarkdownTextInput.web.tsx
@@ -535,7 +535,7 @@ const MarkdownTextInput = React.forwardRef<TextInput & WithRestoreSelectionAbili
           updateTextColor(r, '');
         };
 
-        (r as any).restoreSelectionPosition = () => {
+        (r as unknown as WithRestoreSelectionAbility).restoreSelectionPosition = () => {
           if (contentSelection.current) {
             CursorUtils.setCursorPosition(r, contentSelection.current.start, contentSelection.current.end);
           } else {

--- a/src/MarkdownTextInput.web.tsx
+++ b/src/MarkdownTextInput.web.tsx
@@ -134,11 +134,7 @@ function getElementHeight(node: HTMLDivElement, styles: CSSProperties, numberOfL
   return styles.height ? `${styles.height}px` : 'auto';
 }
 
-type WithRestoreSelectionAbility = {
-  restoreSelectionPosition?: () => void;
-};
-
-const MarkdownTextInput = React.forwardRef<TextInput & WithRestoreSelectionAbility, MarkdownTextInputProps>(
+const MarkdownTextInput = React.forwardRef<TextInput, MarkdownTextInputProps>(
   (
     {
       accessibilityLabel,
@@ -533,15 +529,6 @@ const MarkdownTextInput = React.forwardRef<TextInput & WithRestoreSelectionAbili
         (r as unknown as TextInput).clear = () => {
           r.innerText = '';
           updateTextColor(r, '');
-        };
-
-        (r as unknown as WithRestoreSelectionAbility).restoreSelectionPosition = () => {
-          if (contentSelection.current) {
-            CursorUtils.setCursorPosition(r, contentSelection.current.start, contentSelection.current.end);
-          } else {
-            const valueLength = value ? value.length : r.innerText.length;
-            CursorUtils.setCursorPosition(r, valueLength, null);
-          }
         };
 
         if (value === '' || value === undefined) {

--- a/src/MarkdownTextInput.web.tsx
+++ b/src/MarkdownTextInput.web.tsx
@@ -134,7 +134,11 @@ function getElementHeight(node: HTMLDivElement, styles: CSSProperties, numberOfL
   return styles.height ? `${styles.height}px` : 'auto';
 }
 
-const MarkdownTextInput = React.forwardRef<TextInput, MarkdownTextInputProps>(
+type WithRestoreSelectionAbility = {
+  restoreSelectionPosition: () => void;
+};
+
+const MarkdownTextInput = React.forwardRef<TextInput & WithRestoreSelectionAbility, MarkdownTextInputProps>(
   (
     {
       accessibilityLabel,

--- a/src/MarkdownTextInput.web.tsx
+++ b/src/MarkdownTextInput.web.tsx
@@ -364,11 +364,6 @@ const MarkdownTextInput = React.forwardRef<TextInput, MarkdownTextInputProps>(
             text = parseText(divRef.current, changedText, processedMarkdownStyle).text;
         }
 
-        const selectionAfterTextChange = CursorUtils.getCurrentCursorPosition(divRef.current);
-        if (selectionAfterTextChange) {
-          contentSelection.current = selectionAfterTextChange;
-        }
-
         if (pasteRef?.current) {
           pasteRef.current = false;
           updateSelection(e);
@@ -536,6 +531,15 @@ const MarkdownTextInput = React.forwardRef<TextInput, MarkdownTextInputProps>(
           updateTextColor(r, '');
         };
 
+        (r as any).restoreSelectionPosition = () => {
+          if (contentSelection.current) {
+            CursorUtils.setCursorPosition(r, contentSelection.current.start, contentSelection.current.end);
+          } else {
+            const valueLength = value ? value.length : r.innerText.length;
+            CursorUtils.setCursorPosition(r, valueLength, null);
+          }
+        };
+
         if (value === '' || value === undefined) {
           // update to placeholder color when value is empty
           updateTextColor(r, r.innerText);
@@ -566,7 +570,7 @@ const MarkdownTextInput = React.forwardRef<TextInput, MarkdownTextInputProps>(
 
         const text = processedValue !== undefined ? processedValue : '';
 
-        parseText(divRef.current, text, processedMarkdownStyle, contentSelection.current?.end);
+        parseText(divRef.current, text, processedMarkdownStyle, text.length);
         updateTextColor(divRef.current, value);
       },
       [multiline, processedMarkdownStyle, processedValue],

--- a/src/MarkdownTextInput.web.tsx
+++ b/src/MarkdownTextInput.web.tsx
@@ -135,7 +135,7 @@ function getElementHeight(node: HTMLDivElement, styles: CSSProperties, numberOfL
 }
 
 type WithRestoreSelectionAbility = {
-  restoreSelectionPosition: () => void;
+  restoreSelectionPosition?: () => void;
 };
 
 const MarkdownTextInput = React.forwardRef<TextInput & WithRestoreSelectionAbility, MarkdownTextInputProps>(


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Details
<!-- Explanation of the change or anything fishy that is going on -->

- revert the use of contentSelection to restore cursor pos during text update to cursor jumping around funny since contentSelection ref value can get outdated.
- create func to restore cursor in the ref object

### Related Issues
<!-- Please replace GH_LINK with the link to the GitHub issue this Pull Request is related to -->

RCA: https://github.com/Expensify/App/issues/43312#issuecomment-2156740534
Solution: https://github.com/Expensify/App/issues/41137#issuecomment-2156739474 

### Manual Tests
<!---
Most changes should have accompanying tests. Describe the tests you added or if no tests were added an explanation about why one was not needed.
--->

### Linked PRs
<!---
Please include links to any update PRs in repos that must change their package.json version.
--->