### PR TITLE
docs: update ExpensiMark link

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ The style object can be passed to multiple `MarkdownTextInput` components using 
 
 ## Markdown flavors support
 
-Currently, `react-native-live-markdown` supports only [ExpensiMark](https://github.com/Expensify/expensify-common/blob/main/lib/ExpensiMark.js) flavor. We are working on CommonMark support as well as possibility to use other Markdown parsers.
+Currently, `react-native-live-markdown` supports only [ExpensiMark](https://github.com/Expensify/expensify-common/blob/main/lib/ExpensiMark.ts) flavor. We are working on CommonMark support as well as possibility to use other Markdown parsers.
 
 ## API reference
 


### PR DESCRIPTION
### Details
The README.md link to ExpensiMark was looking for an `ExpensiMark.js` file which no longer exists. Updated to `ExpensiMark.ts`

### Related Issues
n/a

### Manual Tests
n/a

### Linked PRs
n/a