### PR TITLE
Fix "Out of bounds" crash on iOS

### DIFF
--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -1053,13 +1053,13 @@ PODS:
     - React-jsi (= 0.73.4)
     - React-logger (= 0.73.4)
     - React-perflogger (= 0.73.4)
-  - RNLiveMarkdown (0.1.92):
+  - RNLiveMarkdown (0.1.96):
     - glog
     - hermes-engine
     - RCT-Folly (= 2022.05.16.00)
     - React-Core
-    - RNLiveMarkdown/common (= 0.1.92)
-  - RNLiveMarkdown/common (0.1.92):
+    - RNLiveMarkdown/common (= 0.1.96)
+  - RNLiveMarkdown/common (0.1.96):
     - glog
     - hermes-engine
     - RCT-Folly (= 2022.05.16.00)
@@ -1278,7 +1278,7 @@ SPEC CHECKSUMS:
   React-runtimescheduler: ed48e5faac6751e66ee1261c4bd01643b436f112
   React-utils: 6e5ad394416482ae21831050928ae27348f83487
   ReactCommon: 840a955d37b7f3358554d819446bffcf624b2522
-  RNLiveMarkdown: c04da6410e95af38ccb615b8de8bb4eefc9f6e2c
+  RNLiveMarkdown: ffa97e63f100bd32fad2f6f3b689031188761578
   SocketRocket: f32cd54efbe0f095c4d7594881e52619cfe80b17
   Yoga: 64cd2a583ead952b0315d5135bf39e053ae9be70
 

--- a/ios/RCTMarkdownUtils.mm
+++ b/ios/RCTMarkdownUtils.mm
@@ -65,6 +65,10 @@ using namespace facebook;
             const auto &length = static_cast<int>(item.getProperty(rt, "length").asNumber());
             const auto &depth = item.hasProperty(rt, "depth") ? static_cast<int>(item.getProperty(rt, "depth").asNumber()) : 1;
 
+            if (length == 0 || location + length > attributedString.length) {
+                continue;
+            }
+
             NSRange range = NSMakeRange(location, length);
 
             if (type == "bold" || type == "italic" || type == "code" || type == "pre" || type == "h1" || type == "emoji") {


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Details

This PR fixes the following crash on iOS
```
NSMutableRLEArray objectAtIndex:effectiveRange:: Out of bounds
```
when returning improper ranges, in particular:

1. when passing a range with zero length, e.g. `{ start: 10, length: 0, type: 'code' }`

![Screenshot 2024-07-02 at 10 18 43](https://github.com/Expensify/react-native-live-markdown/assets/20516055/0951de32-5a7a-4c9b-bc92-c3730af250db)

2. when passing a range that is longer than the string itself, e.g. `{ start: 0, length: 9999, type: 'bold' }`

<img width="506" alt="Screenshot 2024-07-02 at 10 19 26" src="https://github.com/Expensify/react-native-live-markdown/assets/20516055/ae07b549-c976-4fcd-a775-3c0f860de9b9">

### Related Issues
<!-- Please replace GH_LINK with the link to the GitHub issue this Pull Request is related to -->
GH_LINK

### Manual Tests
<!---
Most changes should have accompanying tests. Describe the tests you added or if no tests were added an explanation about why one was not needed.
--->

### Linked PRs
<!---
Please include links to any update PRs in repos that must change their package.json version.
--->