### PR TITLE
Fix "setSpan ends beyond length" crash on Android

### DIFF
--- a/android/src/main/java/com/expensify/livemarkdown/MarkdownUtils.java
+++ b/android/src/main/java/com/expensify/livemarkdown/MarkdownUtils.java
@@ -94,7 +94,7 @@ public class MarkdownUtils {
         int length = range.getInt("length");
         int depth = range.optInt("depth", 1);
         int end = start + length;
-        if (length == 0 || end > ssb.length()) {
+        if (length == 0 || end > input.length()) {
           continue;
         }
         applyRange(ssb, type, start, end, depth);

--- a/android/src/main/java/com/expensify/livemarkdown/MarkdownUtils.java
+++ b/android/src/main/java/com/expensify/livemarkdown/MarkdownUtils.java
@@ -94,6 +94,9 @@ public class MarkdownUtils {
         int length = range.getInt("length");
         int depth = range.optInt("depth", 1);
         int end = start + length;
+        if (length == 0 || end > ssb.length()) {
+          continue;
+        }
         applyRange(ssb, type, start, end, depth);
       }
     } catch (JSONException e) {


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Details
This PR fixes the following crash on Android:

<img width="428" alt="Screenshot 2024-07-02 at 15 49 31" src="https://github.com/Expensify/react-native-live-markdown/assets/20516055/54fc41a4-b927-4016-9ad3-44c3f9af58e1">

### Related Issues
<!-- Please replace GH_LINK with the link to the GitHub issue this Pull Request is related to -->
GH_LINK

### Manual Tests
<!---
Most changes should have accompanying tests. Describe the tests you added or if no tests were added an explanation about why one was not needed.
--->

### Linked PRs
<!---
Please include links to any update PRs in repos that must change their package.json version.
--->