### PR TITLE
feat: add count/before/start info to `onChange` event

### DIFF
--- a/src/MarkdownTextInput.web.tsx
+++ b/src/MarkdownTextInput.web.tsx
@@ -260,7 +260,7 @@ const MarkdownTextInput = React.forwardRef<TextInput, MarkdownTextInputProps>(
     );
 
     const redo = useCallback(
-      (target: HTMLDivElement) => {
+      (target: HTMLDivElement): ParseTextResult => {
         if (!history.current) {
           return {
             text: '',

--- a/src/web/cursorUtils.ts
+++ b/src/web/cursorUtils.ts
@@ -2,6 +2,10 @@ import * as BrowserUtils from './browserUtils';
 
 let prevTextLength: number | undefined;
 
+function getPrevTextLength() {
+  return prevTextLength;
+}
+
 function findTextNodes(textNodes: Text[], node: ChildNode) {
   if (node.nodeType === Node.TEXT_NODE) {
     textNodes.push(node as Text);
@@ -158,4 +162,4 @@ function scrollCursorIntoView(target: HTMLInputElement) {
   }
 }
 
-export {getCurrentCursorPosition, moveCursorToEnd, setCursorPosition, setPrevText, removeSelection, scrollCursorIntoView};
+export {getCurrentCursorPosition, moveCursorToEnd, setCursorPosition, setPrevText, removeSelection, scrollCursorIntoView, getPrevTextLength};


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Details
<!-- Explanation of the change or anything fishy that is going on -->

As part of an effort to fix a long standing bug in expensify / react-native's text input I need to update the web implementation to work as the react-native's native change:

Goal: align with:
- https://github.com/facebook/react-native/pull/45248

In this PR the `onChange` event is send with the range in which the new changes occurred. The range is encoded as three values:

- `start`: The position in the new text where the changes started occuring
- `count`: The length of the newly changed text
- `before`: The length of the text before the changes.

Here are a few examples to better understand this:

- Initial: "Hello"
- Update to: "Hello**!**"
- `start`: 5 (end of Hello)
- `count`: 1 (the `!` was added)
- `before`: 0 (no text was replaced)

Second example:
- Initial: "Hello"
- Update to: "He0o"
- `start`: 2 (after the `e`)
- `count`: 1 (the `0` was added)
- `before`: 2 (the text replaced `ll` had a length of `2`)

This PR adds the same range info when we fire a `onChange` event.

### Related Issues
<!-- Please replace GH_LINK with the link to the GitHub issue this Pull Request is related to -->
https://github.com/Expensify/App/issues/37896

### Manual Tests
<!---
Most changes should have accompanying tests. Describe the tests you added or if no tests were added an explanation about why one was not needed.
--->

Still need to add (will do tmrw) - can I maybe get a code review first?

### Linked PRs
<!---
Please include links to any update PRs in repos that must change their package.json version.
--->

- https://github.com/Expensify/App/pull/44285