### PR TITLE
Fix selection issue for text containing emoji

### DIFF
--- a/ios/RCTBaseTextInputView+Markdown.mm
+++ b/ios/RCTBaseTextInputView+Markdown.mm
@@ -27,7 +27,14 @@
 {
   RCTMarkdownUtils *markdownUtils = [self getMarkdownUtils];
   if (markdownUtils != nil) {
-    return [newText isEqualToAttributedString:oldText];
+    // Emoji characters are automatically assigned an AppleColorEmoji NSFont and the original font is moved to NSOriginalFont
+    // We need to remove these attributes before comparison
+    NSMutableAttributedString *newTextCopy = [newText mutableCopy];
+    NSMutableAttributedString *oldTextCopy = [oldText mutableCopy];
+    [newTextCopy removeAttribute:@"NSFont" range:NSMakeRange(0, newTextCopy.length)];
+    [oldTextCopy removeAttribute:@"NSFont" range:NSMakeRange(0, oldTextCopy.length)];
+    [oldTextCopy removeAttribute:@"NSOriginalFont" range:NSMakeRange(0, oldTextCopy.length)];
+    return [newTextCopy isEqualToAttributedString:oldTextCopy];
   }
 
   return [self markdown_textOf:newText equals:oldText];

--- a/ios/RCTTextInputComponentView+Markdown.mm
+++ b/ios/RCTTextInputComponentView+Markdown.mm
@@ -51,7 +51,14 @@
 {
   RCTMarkdownUtils *markdownUtils = [self getMarkdownUtils];
   if (markdownUtils != nil) {
-    return [newText isEqualToAttributedString:oldText];
+    // Emoji characters are automatically assigned an AppleColorEmoji NSFont and the original font is moved to NSOriginalFont
+    // We need to remove these attributes before comparison
+    NSMutableAttributedString *newTextCopy = [newText mutableCopy];
+    NSMutableAttributedString *oldTextCopy = [oldText mutableCopy];
+    [newTextCopy removeAttribute:@"NSFont" range:NSMakeRange(0, newTextCopy.length)];
+    [oldTextCopy removeAttribute:@"NSFont" range:NSMakeRange(0, oldTextCopy.length)];
+    [oldTextCopy removeAttribute:@"NSOriginalFont" range:NSMakeRange(0, oldTextCopy.length)];
+    return [newTextCopy isEqualToAttributedString:oldTextCopy];
   }
 
   return [self markdown__textOf:newText equals:oldText];


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Details
<!-- Explanation of the change or anything fishy that is going on -->
Emoji characters are automatically assigned an `AppleColorEmoji` `NSFont` and the original font is moved to `NSOriginalFont`.
We need to remove these attributes before comparison.

### Related Issues
<!-- Please replace GH_LINK with the link to the GitHub issue this Pull Request is related to -->
$ https://github.com/Expensify/App/issues/44495
PROPOSAL: https://github.com/Expensify/App/issues/44495#issuecomment-2197194378

### Manual Tests
<!---
Most changes should have accompanying tests. Describe the tests you added or if no tests were added an explanation about why one was not needed.
--->
1. Type text with an emoji.
2. Long press to select a word.

Expected Result:
Able to select a word.

<details>
  <summary>Screen recordings</summary>

Before:

https://github.com/Expensify/react-native-live-markdown/assets/57348009/ea8ae269-b73f-46a5-96b8-d97feafb606c

After:

https://github.com/Expensify/react-native-live-markdown/assets/57348009/e6d21184-47f5-4390-b5f1-64169fa766ed

</details>

### Linked PRs
<!---
Please include links to any update PRs in repos that must change their package.json version.
--->