### PR TITLE
fix: check if its first render before updating from props

### DIFF
--- a/ios/MarkdownCommitHook.mm
+++ b/ios/MarkdownCommitHook.mm
@@ -141,30 +141,31 @@ RootShadowNode::Unshared MarkdownCommitHook::shadowTreeWillCommit(
                     stateData.attributedStringBox);
 
             // Handles the first render, where the text stored in props is
-            // different than the one stored in state The one in state is empty,
-            // while the one in props is passed from JS If we don't update the
-            // state here, we'll end up with a one-default-line-sized text
-            // input. A better condition to do that can be probably chosen, but
-            // this seems to work
-            auto plainString =
-                std::string([[nsAttributedString string] UTF8String]);
-            if (plainString != textInputProps.text) {
-              // creates new AttributedString from props, adapted from
-              // TextInputShadowNode (ios one, text inputs are
-              // platform-specific)
-              auto attributedString = AttributedString{};
-              attributedString.appendFragment(AttributedString::Fragment{
-                  textInputProps.text, defaultTextAttributes});
+            // different than the one stored in state. The one in state is empty,
+            // while the one in props is passed from JS. If we don't update the
+            // state here, we'll end up with a one-default-line-sized text input
+            if (textInputState.getRevision() == State::initialRevisionValue) {
+                auto plainStringFromState =
+                    std::string([[nsAttributedString string] UTF8String]);
 
-              auto attachments = BaseTextShadowNode::Attachments{};
-              BaseTextShadowNode::buildAttributedString(
-                  defaultTextAttributes, *nodes.textInput, attributedString,
-                  attachments);
+                if (plainStringFromState != textInputProps.text) {
+                // creates new AttributedString from props, adapted from
+                // TextInputShadowNode (ios one, text inputs are
+                // platform-specific)
+                auto attributedString = AttributedString{};
+                attributedString.appendFragment(AttributedString::Fragment{
+                    textInputProps.text, defaultTextAttributes});
 
-              // convert the newly created attributed string to
-              // NSAttributedString
-              nsAttributedString = RCTNSAttributedStringFromAttributedStringBox(
-                  AttributedStringBox{attributedString});
+                auto attachments = BaseTextShadowNode::Attachments{};
+                BaseTextShadowNode::buildAttributedString(
+                    defaultTextAttributes, *nodes.textInput, attributedString,
+                    attachments);
+
+                // convert the newly created attributed string to
+                // NSAttributedString
+                nsAttributedString = RCTNSAttributedStringFromAttributedStringBox(
+                    AttributedStringBox{attributedString});
+                }
             }
 
             // apply markdown


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Details
<!-- Explanation of the change or anything fishy that is going on -->

See: https://github.com/Expensify/App/issues/43983#issuecomment-2210501859

It's possible that the props aren't updated yet on the JS side, while the native state already is. In that case we'd drop the native state for a stale prop value which is incorrect. So we should make sure to only run this code on the first render.

### Related Issues
<!-- Please replace GH_LINK with the link to the GitHub issue this Pull Request is related to -->
https://github.com/Expensify/App/issues/43983
https://github.com/Expensify/App/issues/44185

### Manual Tests
<!---
Most changes should have accompanying tests. Describe the tests you added or if no tests were added an explanation about why one was not needed.
--->

I think its hard to add a specific test for this change.
I verified that the condition is executed on the first render.

### Linked PRs
<!---
Please include links to any update PRs in repos that must change their package.json version.
--->

I don't understand this point 😅 