### PR TITLE
Fix crash on Fabric iOS caused by concurrent runtime access

### DIFF
--- a/ios/RCTMarkdownUtils.mm
+++ b/ios/RCTMarkdownUtils.mm
@@ -28,6 +28,9 @@ using namespace facebook;
         }
 
         static std::shared_ptr<jsi::Runtime> runtime;
+        static std::mutex runtimeMutex;
+        auto lock = std::lock_guard<std::mutex>(runtimeMutex);
+
         if (runtime == nullptr) {
             NSString *path = [[NSBundle mainBundle] pathForResource:@"react-native-live-markdown-parser" ofType:@"js"];
             assert(path != nil && "[react-native-live-markdown] Markdown parser bundle not found");


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Details

This PR fixes the following EXC_BAD_ACCESS crash on Fabric iOS:

<img width="1624" alt="Screenshot 2024-07-05 at 12 13 50" src="https://github.com/Expensify/react-native-live-markdown/assets/20516055/80bf2633-c159-4edf-a2d6-affdf32ef985">

### Related Issues
<!-- Please replace GH_LINK with the link to the GitHub issue this Pull Request is related to -->
GH_LINK

### Manual Tests
<!---
Most changes should have accompanying tests. Describe the tests you added or if no tests were added an explanation about why one was not needed.
--->

### Linked PRs
<!---
Please include links to any update PRs in repos that must change their package.json version.
--->