### PR TITLE
Fix onPaste event

### DIFF
--- a/src/MarkdownTextInput.web.tsx
+++ b/src/MarkdownTextInput.web.tsx
@@ -521,8 +521,11 @@ const MarkdownTextInput = React.forwardRef<TextInput, MarkdownTextInputProps>(
 
     const handlePaste = useCallback((e) => {
       pasteRef.current = true;
-      e.preventDefault();
+      if (e.isDefaultPrevented()) {
+        return;
+      }
 
+      e.preventDefault();
       const clipboardData = e.clipboardData;
       const text = clipboardData.getData('text/plain');
       document.execCommand('insertText', false, text);


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Details
<!-- Explanation of the change or anything fishy that is going on -->
This PR is a part of a pasting doubled content in LM input, that was introduced in #369. We are adding the ability to not use our custom pasting logic when the default behavior is prevented. The whole fix can be found [here](https://github.com/Expensify/App/compare/main...software-mansion-labs:expensify-app-fork:%40Skalakid/bump-react-native-live-markdown) 
### Related Issues
<!-- Please replace GH_LINK with the link to the GitHub issue this Pull Request is related to -->
GH_LINK

### Manual Tests
<!---
Most changes should have accompanying tests. Describe the tests you added or if no tests were added an explanation about why one was not needed.
--->

### Linked PRs
<!---
Please include links to any update PRs in repos that must change their package.json version.
--->