### PR TITLE
Don't use `ShadowNodeFragment::Value`

### DIFF
--- a/cpp/react/renderer/components/RNLiveMarkdownSpec/MarkdownTextInputDecoratorShadowNode.cpp
+++ b/cpp/react/renderer/components/RNLiveMarkdownSpec/MarkdownTextInputDecoratorShadowNode.cpp
@@ -11,7 +11,7 @@ namespace react {
 extern const char MarkdownTextInputDecoratorViewComponentName[] =
     "MarkdownTextInputDecoratorView";
 
-const ShadowNodeFragment::Value
+const OwningShadowNodeFragment
 MarkdownTextInputDecoratorShadowNode::updateFragmentState(
     ShadowNodeFragment const &fragment,
     ShadowNodeFamily::Shared const &family) {
@@ -24,12 +24,12 @@ MarkdownTextInputDecoratorShadowNode::updateFragmentState(
   // propagated on every clone we need it to clear the reference in the registry
   // when the view is removed from window it cannot be done in the destructor,
   // as multiple shadow nodes for the same family may be created
-  return ShadowNodeFragment::Value({
+  return OwningShadowNodeFragment{
       .props = fragment.props,
       .children = fragment.children,
       .state =
           std::make_shared<const ConcreteState>(newStateData, *fragment.state),
-  });
+  };
 }
 
 } // namespace react

--- a/cpp/react/renderer/components/RNLiveMarkdownSpec/MarkdownTextInputDecoratorShadowNode.h
+++ b/cpp/react/renderer/components/RNLiveMarkdownSpec/MarkdownTextInputDecoratorShadowNode.h
@@ -11,6 +11,20 @@
 namespace facebook {
 namespace react {
 
+struct OwningShadowNodeFragment {
+  Props::Shared props;
+  ShadowNode::SharedListOfShared children;
+  State::Shared state;
+  
+  operator ShadowNodeFragment() const {
+    return ShadowNodeFragment {
+      .props = props,
+      .children = children,
+      .state = state
+    };
+  }
+};
+
 JSI_EXPORT extern const char MarkdownTextInputDecoratorViewComponentName[];
 
 class JSI_EXPORT MarkdownTextInputDecoratorShadowNode final
@@ -22,8 +36,7 @@ public:
   MarkdownTextInputDecoratorShadowNode(ShadowNodeFragment const &fragment,
                                        ShadowNodeFamily::Shared const &family,
                                        ShadowNodeTraits traits)
-      : ConcreteViewShadowNode(static_cast<ShadowNodeFragment>(
-                                   updateFragmentState(fragment, family)),
+      : ConcreteViewShadowNode(updateFragmentState(fragment, family),
                                family, traits) {}
 
   MarkdownTextInputDecoratorShadowNode(ShadowNode const &sourceShadowNode,
@@ -37,7 +50,7 @@ public:
   }
 
 private:
-  static const ShadowNodeFragment::Value
+  static const OwningShadowNodeFragment
   updateFragmentState(ShadowNodeFragment const &fragment,
                       ShadowNodeFamily::Shared const &family);
 };


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Details
`ShadowNodeFragment::Value` was removed in https://github.com/facebook/react-native/pull/43962. This PR gets rid of usage of it from the codebase.

### Related Issues
<!-- Please replace GH_LINK with the link to the GitHub issue this Pull Request is related to -->
GH_LINK

### Manual Tests
Make sure the library compiles and works on the new architecture.

### Linked PRs
<!---
Please include links to any update PRs in repos that must change their package.json version.
--->