### PR TITLE
Remove `NSMutableParagraphStyle` for heading

### DIFF
--- a/ios/RCTMarkdownUtils.mm
+++ b/ios/RCTMarkdownUtils.mm
@@ -147,10 +147,6 @@ using namespace facebook;
                 NSRange rangeForBackground = [inputString characterAtIndex:range.location] == '\n' ? NSMakeRange(range.location + 1, range.length - 1) : range;
                 [attributedString addAttribute:NSBackgroundColorAttributeName value:_markdownStyle.preBackgroundColor range:rangeForBackground];
                 // TODO: pass background color and ranges to layout manager
-            } else if (type == "h1") {
-                NSMutableParagraphStyle *paragraphStyle = [NSMutableParagraphStyle new];
-                NSRange rangeWithHashAndSpace = NSMakeRange(range.location - 2, range.length + 2); // we also need to include prepending "# "
-                [attributedString addAttribute:NSParagraphStyleAttributeName value:paragraphStyle range:rangeWithHashAndSpace];
             }
         }
 


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Details

This PR removes code logic that adds `NSMutableParagraphStyle` around h1 heading on iOS. This part of code is redundant as we don't set any styles on paragraphs.

Also, removing `NSMutableParagraphStyle` improves the performance when typing fast, as seen on the comparision below:

<table>
<thead>
<tr>
<th>Before</th>
<th>After</th>
</tr>
</thead>
<tbody>
<tr>
<td><video src="https://github.com/user-attachments/assets/aedbebfb-07a2-482e-8456-ba1d2ffa2ad4"></td>
<td><video src="https://github.com/user-attachments/assets/11d40d30-dfbf-4f85-8a27-51a65bb32279"></td>
</tr>
</tbody>
</table>

### Related Issues
Partially fixes https://github.com/Expensify/react-native-live-markdown/issues/417

### Manual Tests
<!---
Most changes should have accompanying tests. Describe the tests you added or if no tests were added an explanation about why one was not needed.
--->

### Linked PRs
<!---
Please include links to any update PRs in repos that must change their package.json version.
--->