### PR TITLE
fix(web): onChange event start negative

### DIFF
--- a/src/MarkdownTextInput.web.tsx
+++ b/src/MarkdownTextInput.web.tsx
@@ -418,7 +418,7 @@ const MarkdownTextInput = React.forwardRef<TextInput, MarkdownTextInputProps>(
           if (inputType === 'deleteContentBackward') {
             // When the user does a backspace delete he expects the content before the cursor to be removed.
             // For this the start value needs to be adjusted (its as if the selection was before the text that we want to delete)
-            start -= before;
+            start = Math.max(start - before, 0);
           }
 
           event.nativeEvent.count = count;


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Details
<!-- Explanation of the change or anything fishy that is going on -->

In this PR I added ranges to the onChange event:

- https://github.com/Expensify/react-native-live-markdown/pull/412

I forgot to clamp start to never become negative.

### Related Issues
<!-- Please replace GH_LINK with the link to the GitHub issue this Pull Request is related to -->
https://github.com/Expensify/App/issues/37896

### Manual Tests
<!---
Most changes should have accompanying tests. Describe the tests you added or if no tests were added an explanation about why one was not needed.
--->

### Linked PRs
<!---
Please include links to any update PRs in repos that must change their package.json version.
--->

https://github.com/Expensify/App/pull/44285