### PR TITLE
fix: find the caret domrect with largest bottom value

### DIFF
--- a/src/web/cursorUtils.ts
+++ b/src/web/cursorUtils.ts
@@ -148,12 +148,12 @@ function scrollCursorIntoView(target: HTMLInputElement) {
   const caretRects = selection.getRangeAt(0).getClientRects();
 
   // we'll find the caretRect from the DOMRectList above with the largest bottom value
-  let caretRect = caretRects[0];
-  if (caretRect) {
+  let currentCaretRect = caretRects[0];
+  if (currentCaretRect) {
     for (let i = 1; i < caretRects.length; i++) {
-      const ithCaretRect = caretRects[i];
-      if (ithCaretRect && ithCaretRect.bottom > caretRect.bottom) {
-        caretRect = ithCaretRect;
+      const caretRect = caretRects[i];
+      if (caretRect && caretRect.bottom > currentCaretRect.bottom) {
+        currentCaretRect = caretRect;
       }
     }
   }
@@ -164,11 +164,11 @@ function scrollCursorIntoView(target: HTMLInputElement) {
   const paddingTop = parseFloat(window.getComputedStyle(target).paddingTop);
   const borderTop = parseFloat(window.getComputedStyle(target).borderTopWidth);
 
-  if (caretRect && !(caretRect.top >= editableRect.top + paddingTop + borderTop && caretRect.bottom <= editableRect.bottom - 2 * (paddingTop - borderTop))) {
-    const topToCaret = caretRect.top - editableRect.top;
+  if (currentCaretRect && !(currentCaretRect.top >= editableRect.top + paddingTop + borderTop && currentCaretRect.bottom <= editableRect.bottom - 2 * (paddingTop - borderTop))) {
+    const topToCaret = currentCaretRect.top - editableRect.top;
     const inputHeight = editableRect.height;
     // Chrome Rects don't include padding & border, so we're adding them manually
-    const inputOffset = caretRect.height - inputHeight + paddingTop + borderTop + (BrowserUtils.isChromium ? 0 : 4 * (paddingTop + borderTop));
+    const inputOffset = currentCaretRect.height - inputHeight + paddingTop + borderTop + (BrowserUtils.isChromium ? 0 : 4 * (paddingTop + borderTop));
 
     target.scrollTo(0, topToCaret + target.scrollTop + inputOffset);
   }

--- a/src/web/cursorUtils.ts
+++ b/src/web/cursorUtils.ts
@@ -145,7 +145,19 @@ function scrollCursorIntoView(target: HTMLInputElement) {
     return;
   }
 
-  const caretRect = selection.getRangeAt(0).getClientRects()[0];
+  const caretRects = selection.getRangeAt(0).getClientRects();
+
+  // we'll find the caretRect from the DOMRectList above with the largest bottom value
+  let caretRect = caretRects[0];
+  if (caretRect) {
+    for (let i = 1; i < caretRects.length; i++) {
+      const ithCaretRect = caretRects[i];
+      if (ithCaretRect && ithCaretRect.bottom > caretRect.bottom) {
+        caretRect = ithCaretRect;
+      }
+    }
+  }
+
   const editableRect = target.getBoundingClientRect();
 
   // Adjust for padding and border


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Details
<!-- Explanation of the change or anything fishy that is going on -->

### Related Issues
<!-- Please replace GH_LINK with the link to the GitHub issue this Pull Request is related to -->

$ https://github.com/Expensify/App/issues/46389
PROPOSAL: https://github.com/Expensify/App/issues/46389#issuecomment-2255658889

### Manual Tests
<!---
Most changes should have accompanying tests. Describe the tests you added or if no tests were added an explanation about why one was not needed.
--->

1. Add `overflow` and `maxHeight` attribute in: https://github.com/Expensify/react-native-live-markdown/blob/main/example/src/App.tsx#L190-L196
2. Run example web app
3. Insert multiple-line text until a scroll bar is shown on the right
4. On a new line insert a markdown text (eg. bold)
5. Hit the enter key on the keyboard

Verify that: the text input should scroll automatically down to reveal the new line.


### Linked PRs
<!---
Please include links to any update PRs in repos that must change their package.json version.
--->