### PR TITLE
Fix cursor selection event on the web

### DIFF
--- a/WebExample/__tests__/utils.ts
+++ b/WebExample/__tests__/utils.ts
@@ -11,7 +11,13 @@ const setupInput = async (page: Page, action?: 'clear' | 'reset') => {
 };
 
 const getCursorPosition = async (elementHandle: Locator) => {
-  const inputSelectionHandle = await elementHandle.evaluateHandle((div: HTMLInputElement) => ({start: div.selectionStart, end: div.selectionEnd}));
+  const inputSelectionHandle = await elementHandle.evaluateHandle(
+    (
+      div: HTMLInputElement & {
+        selection: {start: number; end: number};
+      },
+    ) => div.selection,
+  );
   const selection = await inputSelectionHandle.jsonValue();
   return selection;
 };

--- a/src/MarkdownTextInput.web.tsx
+++ b/src/MarkdownTextInput.web.tsx
@@ -242,11 +242,11 @@ const MarkdownTextInput = React.forwardRef<TextInput, MarkdownTextInputProps>(
     }, []);
 
     const updateSelection = useCallback(
-      (e: SyntheticEvent<HTMLDivElement>) => {
+      (e: SyntheticEvent<HTMLDivElement>, predefinedSelection: Selection | null = null) => {
         if (!divRef.current) {
           return;
         }
-        const newSelection = getCurrentCursorPosition(divRef.current);
+        const newSelection = predefinedSelection || getCurrentCursorPosition(divRef.current);
 
         if (newSelection && (!contentSelection.current || contentSelection.current.start !== newSelection.start || contentSelection.current.end !== newSelection.end)) {
           updateRefSelectionVariables(newSelection);
@@ -315,6 +315,10 @@ const MarkdownTextInput = React.forwardRef<TextInput, MarkdownTextInputProps>(
         }
         const {text, cursorPosition} = newInputUpdate;
         updateTextColor(divRef.current, text);
+        updateSelection(e, {
+          start: cursorPosition ?? 0,
+          end: cursorPosition ?? 0,
+        });
 
         if (onChange) {
           const event = e as unknown as NativeSyntheticEvent<{
@@ -359,7 +363,7 @@ const MarkdownTextInput = React.forwardRef<TextInput, MarkdownTextInputProps>(
 
         handleContentSizeChange();
       },
-      [updateTextColor, onChange, onChangeText, handleContentSizeChange, undo, redo, parseText, processedMarkdownStyle, setEventProps],
+      [updateTextColor, updateSelection, onChange, onChangeText, handleContentSizeChange, undo, redo, parseText, processedMarkdownStyle, setEventProps],
     );
 
     const insertText = useCallback(

--- a/src/web/utils/cursorUtils.ts
+++ b/src/web/utils/cursorUtils.ts
@@ -45,6 +45,10 @@ function setCursorPosition(target: MarkdownTextInputElement, startIndex: number,
     selection.setBaseAndExtent(range.startContainer, range.startOffset, range.endContainer, range.endOffset);
   }
 
+  // Update the focused elements zIndex to make sure they are on top and the cursor is beeing set correctly
+  startTreeNode.element.style.zIndex = '1';
+  endTreeNode.element.style.zIndex = '1';
+
   scrollIntoView(startTreeNode);
 }
 


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Details
<!-- Explanation of the change or anything fishy that is going on -->
This PR contain follow up fixes to the bugs reported in E/App under the Live Markdown refactor PR. It changes and simplifies the selection event logic, so all cases when user selects the text are caught. To achieve this we had to remove standard `selectionStart` and `selectionEnd` props and replace them with custom `selection.start` and `selection.end`. Setting `selectionStart` and `selectionEnd` values breaks the native `onSelect` event handler
### Related Issues
<!-- Please replace GH_LINK with the link to the GitHub issue this Pull Request is related to -->
[GH_LINK](https://github.com/Expensify/App/pull/45150#issuecomment-2302793044)

### Manual Tests
<!---
Most changes should have accompanying tests. Describe the tests you added or if no tests were added an explanation about why one was not needed.
--->
1. Open example app on mobile Safari
2. Write some text
3. Double tap the word
4. Click `Cut`
5. Verify if text was cut
6. Check if cursor position is correct while using the Live Markdown Input on web

### Linked PRs
<!---
Please include links to any update PRs in repos that must change their package.json version.
--->

https://github.com/Expensify/App/pull/45150