### PR TITLE
Fix deleting whole content on Firefox

### DIFF
--- a/src/web/utils/inputUtils.ts
+++ b/src/web/utils/inputUtils.ts
@@ -82,7 +82,7 @@ function parseInnerHTMLToText(target: MarkdownTextInputElement): string {
       text += node.textContent;
     } else if (node.nodeName === 'BR') {
       const parentNode = getTopParentNode(node);
-      if (parentNode && parentNode.parentElement?.contentEditable !== 'true') {
+      if (parentNode && parentNode.parentElement?.contentEditable !== 'true' && !!(node as HTMLElement).getAttribute('data-id')) {
         // Parse br elements into newlines only if their parent is not a child of the MarkdownTextInputElement (a paragraph when writing or a div when pasting).
         // It prevents adding extra newlines when entering text
         text += '\n';


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Details
<!-- Explanation of the change or anything fishy that is going on -->
This PR fixes a problem with deleting whole content inside the input, by selecting whole content and pressing `Backspace`
### Related Issues
<!-- Please replace GH_LINK with the link to the GitHub issue this Pull Request is related to -->
GH_LINK

### Manual Tests
<!---
Most changes should have accompanying tests. Describe the tests you added or if no tests were added an explanation about why one was not needed.
--->
1. Open example on FireFox browser
2. Select whole content using mouse / `Ctrl + A`
3. Press `Backspace`
4. Verify if the input is empty
### Linked PRs
<!---
Please include links to any update PRs in repos that must change their package.json version.
--->