### PR TITLE
Move `MarkdownType` and `MarkdownRange` to commonTypes.ts

### DIFF
--- a/src/__tests__/webParser.test.tsx
+++ b/src/__tests__/webParser.test.tsx
@@ -1,7 +1,6 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import {expect} from '@jest/globals';
 import {parseRangesToHTMLNodes} from '../web/utils/parserUtils';
-import type {MarkdownRange} from '../web/utils/parserUtils';
 
 require('../../parser/react-native-live-markdown-parser.js');
 
@@ -16,8 +15,7 @@ const toBeParsedAsHTML = function (actual: string, expectedHTML: string) {
     throw new Error('Actual value must be a string');
   }
   let expected = expectedHTML;
-  const ranges = global.parseExpensiMarkToRanges(actual);
-  const markdownRanges = ranges as MarkdownRange[];
+  const markdownRanges = global.parseExpensiMarkToRanges(actual);
 
   const actualDOM = parseRangesToHTMLNodes(actual, markdownRanges, {}, true).dom;
   const actualHTML = actualDOM.innerHTML;

--- a/src/commonTypes.ts
+++ b/src/commonTypes.ts
@@ -1,0 +1,10 @@
+type MarkdownType = 'bold' | 'italic' | 'strikethrough' | 'emoji' | 'mention-here' | 'mention-user' | 'mention-report' | 'link' | 'code' | 'pre' | 'blockquote' | 'h1' | 'syntax';
+
+interface MarkdownRange {
+  type: MarkdownType;
+  start: number;
+  length: number;
+  depth?: number;
+}
+
+export type {MarkdownType, MarkdownRange};

--- a/src/web/utils/parserUtils.ts
+++ b/src/web/utils/parserUtils.ts
@@ -4,15 +4,7 @@ import type {NodeType, TreeNode} from './treeUtils';
 import type {PartialMarkdownStyle} from '../../styleUtils';
 import {getCurrentCursorPosition, moveCursorToEnd, setCursorPosition} from './cursorUtils';
 import {addStyleToBlock} from './blockUtils';
-
-type MarkdownType = 'bold' | 'italic' | 'strikethrough' | 'emoji' | 'link' | 'code' | 'pre' | 'blockquote' | 'h1' | 'syntax' | 'mention-here' | 'mention-user' | 'mention-report';
-
-type MarkdownRange = {
-  type: MarkdownType;
-  start: number;
-  length: number;
-  depth?: number;
-};
+import type {MarkdownRange} from '../../commonTypes';
 
 type Paragraph = {
   text: string;
@@ -271,8 +263,7 @@ function updateInputStructure(
     const selection = getCurrentCursorPosition(target);
     cursorPosition = selection ? selection.start : null;
   }
-  const ranges = global.parseExpensiMarkToRanges(text);
-  const markdownRanges: MarkdownRange[] = ranges as MarkdownRange[];
+  const markdownRanges = global.parseExpensiMarkToRanges(text);
   if (!text || targetElement.innerHTML === '<br>' || (targetElement && targetElement.innerHTML === '\n')) {
     targetElement.innerHTML = '';
     targetElement.innerText = '';
@@ -298,5 +289,3 @@ function updateInputStructure(
 }
 
 export {updateInputStructure, parseRangesToHTMLNodes};
-
-export type {MarkdownRange, MarkdownType};

--- a/src/web/utils/treeUtils.ts
+++ b/src/web/utils/treeUtils.ts
@@ -1,5 +1,5 @@
 import type {HTMLMarkdownElement} from '../../MarkdownTextInput.web';
-import type {MarkdownRange, MarkdownType} from './parserUtils';
+import type {MarkdownRange, MarkdownType} from '../../commonTypes';
 
 type NodeType = MarkdownType | 'line' | 'text' | 'br' | 'root';
 

--- a/types/global.d.ts
+++ b/types/global.d.ts
@@ -1,15 +1,8 @@
+import type {MarkdownRange} from '../src/commonTypes';
+
 export {};
-
-type MarkdownType = 'bold' | 'italic' | 'strikethrough' | 'emoji' | 'mention-here' | 'mention-user' | 'mention-report' | 'link' | 'code' | 'pre' | 'blockquote' | 'h1' | 'syntax';
-
-type MarkdownRange = {
-  type: MarkdownType;
-  start: number;
-  length: number;
-  depth?: number;
-};
 
 declare global {
   // eslint-disable-next-line no-var
-  var parseExpensiMarkToRanges: (markdown: string) => MarkdownMarkdownRange[];
+  var parseExpensiMarkToRanges: (markdown: string) => MarkdownRange[];
 }


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Details

Follow-up to https://github.com/Expensify/react-native-live-markdown/pull/464.

This PR removes duplicate declarations of `MarkdownType` and `MarkdownRange` types and moves them to `commonTypes.ts`.

I also fixed the incorrect type `MarkdownMarkdownRange` in `global.d.ts` that most likely happened during web refactor which now lets me remove some casts.

I skipped making changes to `parser/index.ts` since this file will be removed in https://github.com/Expensify/react-native-live-markdown/pull/439.

<!-- Explanation of the change or anything fishy that is going on -->

### Related Issues
<!-- Please replace GH_LINK with the link to the GitHub issue this Pull Request is related to -->
GH_LINK

### Manual Tests
<!---
Most changes should have accompanying tests. Describe the tests you added or if no tests were added an explanation about why one was not needed.
--->

### Linked PRs
<!---
Please include links to any update PRs in repos that must change their package.json version.
--->