### PR TITLE
Expose React Native minor version in buildscripts

### DIFF
--- a/RNLiveMarkdown.podspec
+++ b/RNLiveMarkdown.podspec
@@ -1,5 +1,9 @@
 require "json"
 
+react_native_node_modules_dir = ENV['REACT_NATIVE_NODE_MODULES_DIR'] || File.join(File.dirname(`cd "#{Pod::Config.instance.installation_root.to_s}" && node --print "require.resolve('react-native/package.json')"`), '..')
+react_native_json = JSON.parse(File.read(File.join(react_native_node_modules_dir, 'react-native/package.json')))
+react_native_minor_version = react_native_json['version'].split('.')[1].to_i
+
 package = JSON.parse(File.read(File.join(__dir__, "package.json")))
 folly_compiler_flags = '-DFOLLY_NO_CONFIG -DFOLLY_MOBILE=1 -DFOLLY_USE_LIBCPP=1 -Wno-comma -Wno-shorten-64-to-32'
 
@@ -19,6 +23,10 @@ Pod::Spec.new do |s|
   s.resources = "parser/react-native-live-markdown-parser.js"
 
   s.dependency "hermes-engine"
+
+  s.xcconfig = {
+    "OTHER_CFLAGS" => "$(inherited) -DREACT_NATIVE_MINOR_VERSION=#{react_native_minor_version}"
+  }
 
   install_modules_dependencies(s)
 

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -32,6 +32,11 @@ def getExtOrIntegerDefault(name) {
   return rootProject.ext.has(name) ? rootProject.ext.get(name) : (project.properties["LiveMarkdown_" + name]).toInteger()
 }
 
+def safeAppExtGet(prop, fallback) {
+  def appProject = rootProject.allprojects.find { it.plugins.hasPlugin('com.android.application') }
+  appProject?.ext?.has(prop) ? appProject.ext.get(prop) : fallback
+}
+
 def supportsNamespace() {
   def parsed = com.android.Version.ANDROID_GRADLE_PLUGIN_VERSION.tokenize('.')
   def major = parsed[0].toInteger()
@@ -39,6 +44,40 @@ def supportsNamespace() {
 
   // Namespace support was added in 7.3.0
   return (major == 7 && minor >= 3) || major >= 8
+}
+
+def resolveReactNativeDirectory() {
+  def reactNativeLocation = safeAppExtGet("REACT_NATIVE_NODE_MODULES_DIR", null)
+  if (reactNativeLocation != null) {
+    return file(reactNativeLocation)
+  }
+
+  // monorepo workaround
+  // react-native can be hoisted or in project's own node_modules
+  def reactNativeFromProjectNodeModules = file("${rootProject.projectDir}/../node_modules/react-native")
+  if (reactNativeFromProjectNodeModules.exists()) {
+    return reactNativeFromProjectNodeModules
+  }
+
+  def reactNativeFromLiveMarkdownMonorepo = file("${projectDir}/../../../node_modules/react-native")
+  if (reactNativeFromLiveMarkdownMonorepo.exists()) {
+    return reactNativeFromLiveMarkdownMonorepo
+  }
+
+  def reactNativeFromNodeModulesWithLiveMarkdown = file("${projectDir}/../../react-native")
+  if (reactNativeFromNodeModulesWithLiveMarkdown.exists()) {
+    return reactNativeFromNodeModulesWithLiveMarkdown
+  }
+
+  throw new GradleException("[react-native-live-markdown] Unable to resolve react-native location in node_modules. Your app should define `REACT_NATIVE_NODE_MODULES_DIR` extension property in `app/build.gradle` with a path to react-native in node_modules.")
+}
+
+def getReactNativeMinorVersion() {
+  def reactNativeRootDir = resolveReactNativeDirectory()
+  def reactNativeProperties = new Properties()
+  file("$reactNativeRootDir/ReactAndroid/gradle.properties").withInputStream { reactNativeProperties.load(it) }
+  def reactNativeVersion = reactNativeProperties.getProperty("VERSION_NAME")
+  return reactNativeVersion.split("\\.")[1].toInteger()
 }
 
 android {
@@ -57,13 +96,17 @@ android {
   defaultConfig {
     minSdkVersion getExtOrIntegerDefault("minSdkVersion")
     targetSdkVersion getExtOrIntegerDefault("targetSdkVersion")
+
+    buildConfigField "int", "REACT_NATIVE_MINOR_VERSION", getReactNativeMinorVersion().toString()
     buildConfigField "boolean", "IS_NEW_ARCHITECTURE_ENABLED", isNewArchitectureEnabled().toString()
-    
+
     consumerProguardFiles "proguard-rules.pro"
-    
+
     externalNativeBuild {
       cmake {
-        arguments "-DANDROID_STL=c++_shared", "-DANDROID_TOOLCHAIN=clang"
+        arguments "-DANDROID_STL=c++_shared",
+          "-DANDROID_TOOLCHAIN=clang",
+          "-DREACT_NATIVE_MINOR_VERSION=${getReactNativeMinorVersion()}"
         abiFilters (*reactNativeArchitectures())
       }
     }

--- a/android/src/main/cpp/CMakeLists.txt
+++ b/android/src/main/cpp/CMakeLists.txt
@@ -6,6 +6,8 @@ set(CMAKE_VERBOSE_MAKEFILE on)
 
 add_compile_options(-fvisibility=hidden -fexceptions -frtti)
 
+string(APPEND CMAKE_CXX_FLAGS " -DREACT_NATIVE_MINOR_VERSION=${REACT_NATIVE_MINOR_VERSION}")
+
 file(GLOB livemarkdown_SRC CONFIGURE_DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/*.cpp)
 
 add_library(${CMAKE_PROJECT_NAME} SHARED ${livemarkdown_SRC})

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -1164,7 +1164,7 @@ PODS:
     - React-logger (= 0.74.5)
     - React-perflogger (= 0.74.5)
     - React-utils (= 0.74.5)
-  - RNLiveMarkdown (0.1.120):
+  - RNLiveMarkdown (0.1.125):
     - DoubleConversion
     - glog
     - hermes-engine
@@ -1184,9 +1184,9 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
-    - RNLiveMarkdown/common (= 0.1.120)
+    - RNLiveMarkdown/common (= 0.1.125)
     - Yoga
-  - RNLiveMarkdown/common (0.1.120):
+  - RNLiveMarkdown/common (0.1.125):
     - DoubleConversion
     - glog
     - hermes-engine
@@ -1440,7 +1440,7 @@ SPEC CHECKSUMS:
   React-runtimescheduler: cfbe85c3510c541ec6dc815c7729b41304b67961
   React-utils: f242eb7e7889419d979ca0e1c02ccc0ea6e43b29
   ReactCommon: f7da14a8827b72704169a48c929bcde802698361
-  RNLiveMarkdown: 72025b6781bce19183ff7ca02fc7a440aa1bede6
+  RNLiveMarkdown: 79d67ef1cc94b3fdb3baab3a50a5f19054746085
   SocketRocket: abac6f5de4d4d62d24e11868d7a2f427e0ef940d
   Yoga: 2246eea72aaf1b816a68a35e6e4b74563653ae09
 


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Details
This PR exposes the following values:
* `react_native_minor_version` in `RNLiveMarkdown.podspec`
* `getReactNativeMinorVersion()` in `build.gradle`
* `BuildConfig.REACT_NATIVE_MINOR_VERSION` in Java sources
* `REACT_NATIVE_MINOR_VERSION` in `CMakeLists.txt`
* `REACT_NATIVE_MINOR_VERSION` in C++ sources

### Related Issues
<!-- Please replace GH_LINK with the link to the GitHub issue this Pull Request is related to -->
GH_LINK

### Manual Tests
<!---
Most changes should have accompanying tests. Describe the tests you added or if no tests were added an explanation about why one was not needed.
--->

### Linked PRs
<!---
Please include links to any update PRs in repos that must change their package.json version.
--->