### PR TITLE
Fix red spell check line is shown frequently when typing

### DIFF
--- a/src/web/utils/cursorUtils.ts
+++ b/src/web/utils/cursorUtils.ts
@@ -45,10 +45,6 @@ function setCursorPosition(target: MarkdownTextInputElement, startIndex: number,
     selection.setBaseAndExtent(range.startContainer, range.startOffset, range.endContainer, range.endOffset);
   }
 
-  // Update the focused elements zIndex to make sure they are on top and the cursor is beeing set correctly
-  startTreeNode.element.style.zIndex = '1';
-  endTreeNode.element.style.zIndex = '1';
-
   scrollIntoView(startTreeNode);
 }
 

--- a/src/web/utils/parserUtils.ts
+++ b/src/web/utils/parserUtils.ts
@@ -247,10 +247,6 @@ function moveCursor(isFocused: boolean, alwaysMoveCursorToTheEnd: boolean, curso
   }
 }
 
-function normalizeHTMLStructure(target: MarkdownTextInputElement) {
-  return target.innerHTML.split('z-index: 1;').join('').split(' style=""').join('');
-}
-
 function updateInputStructure(
   target: MarkdownTextInputElement,
   text: string,
@@ -278,14 +274,15 @@ function updateInputStructure(
   if (text) {
     const {dom, tree} = parseRangesToHTMLNodes(text, markdownRanges, markdownStyle);
 
-    if (shouldForceDOMUpdate || normalizeHTMLStructure(targetElement) !== dom.innerHTML) {
+    if (shouldForceDOMUpdate || targetElement.innerHTML !== dom.innerHTML) {
       targetElement.innerHTML = '';
       targetElement.innerText = '';
       targetElement.innerHTML = dom.innerHTML;
     }
 
-    targetElement.tree = tree;
     updateTreeElementRefs(tree, targetElement);
+    targetElement.tree = tree;
+
     moveCursor(isFocused, alwaysMoveCursorToTheEnd, cursorPosition, targetElement);
   }
 

--- a/src/web/utils/parserUtils.ts
+++ b/src/web/utils/parserUtils.ts
@@ -1,5 +1,5 @@
 import type {HTMLMarkdownElement, MarkdownTextInputElement} from '../../MarkdownTextInput.web';
-import {addNodeToTree} from './treeUtils';
+import {addNodeToTree, updateTreeElementRefs} from './treeUtils';
 import type {NodeType, TreeNode} from './treeUtils';
 import type {PartialMarkdownStyle} from '../../styleUtils';
 import {getCurrentCursorPosition, moveCursorToEnd, setCursorPosition} from './cursorUtils';
@@ -246,6 +246,11 @@ function moveCursor(isFocused: boolean, alwaysMoveCursorToTheEnd: boolean, curso
     setCursorPosition(target, cursorPosition);
   }
 }
+
+function normalizeHTMLStructure(target: MarkdownTextInputElement) {
+  return target.innerHTML.split('z-index: 1;').join('').split(' style=""').join('');
+}
+
 function updateInputStructure(
   target: MarkdownTextInputElement,
   text: string,
@@ -273,15 +278,14 @@ function updateInputStructure(
   if (text) {
     const {dom, tree} = parseRangesToHTMLNodes(text, markdownRanges, markdownStyle);
 
-    if (shouldForceDOMUpdate || targetElement.innerHTML !== dom.innerHTML) {
+    if (shouldForceDOMUpdate || normalizeHTMLStructure(targetElement) !== dom.innerHTML) {
       targetElement.innerHTML = '';
       targetElement.innerText = '';
-      Array.from(dom.children).forEach((child) => {
-        targetElement.appendChild(child);
-      });
+      targetElement.innerHTML = dom.innerHTML;
     }
 
     targetElement.tree = tree;
+    updateTreeElementRefs(tree, targetElement);
     moveCursor(isFocused, alwaysMoveCursorToTheEnd, cursorPosition, targetElement);
   }
 

--- a/src/web/utils/treeUtils.ts
+++ b/src/web/utils/treeUtils.ts
@@ -41,6 +41,23 @@ function addNodeToTree(element: HTMLMarkdownElement, parentTreeNode: TreeNode, t
   return item;
 }
 
+function updateTreeElementRefs(treeRoot: TreeNode, element: HTMLMarkdownElement) {
+  const stack: TreeNode[] = [treeRoot];
+  while (stack.length > 0) {
+    const node = stack.pop() as TreeNode;
+    stack.push(...node.childNodes);
+
+    const currentElement = element.querySelector(`[data-id="${node.orderIndex}"]`) as HTMLMarkdownElement;
+    node.element = currentElement;
+
+    node.childNodes.forEach((child) => {
+      stack.push(child);
+    });
+  }
+
+  return treeRoot;
+}
+
 function findHTMLElementInTree(treeRoot: TreeNode, element: HTMLElement): TreeNode | null {
   if (element.hasAttribute?.('contenteditable')) {
     return treeRoot;
@@ -98,6 +115,6 @@ function getTreeNodeByIndex(treeRoot: TreeNode, index: number): TreeNode | null 
   return null;
 }
 
-export {addNodeToTree, findHTMLElementInTree, getTreeNodeByIndex};
+export {addNodeToTree, findHTMLElementInTree, getTreeNodeByIndex, updateTreeElementRefs};
 
 export type {TreeNode, NodeType};


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Details
<!-- Explanation of the change or anything fishy that is going on -->
This PR fixes the problem with too many input structure re-renders and fixes a problem with red spell check line being added too early, when still typing a word

https://github.com/user-attachments/assets/36310858-2e73-4c80-bd71-16bb265391fb




### Related Issues
<!-- Please replace GH_LINK with the link to the GitHub issue this Pull Request is related to -->
[GH_LINK](https://github.com/Expensify/App/issues/48662)

### Manual Tests
<!---
Most changes should have accompanying tests. Describe the tests you added or if no tests were added an explanation about why one was not needed.
--->
1. Open example app
2. Start typing any sentence
3. Verify if the red spell check line isn't shown while still typing a word
4. Verify if the red spell check line is being added correctly

### Linked PRs
<!---
Please include links to any update PRs in repos that must change their package.json version.
--->