### PR TITLE
Disable building example app from source on Android

### DIFF
--- a/example/android/settings.gradle
+++ b/example/android/settings.gradle
@@ -4,11 +4,11 @@ extensions.configure(com.facebook.react.ReactSettingsExtension){ ex -> ex.autoli
 rootProject.name = 'LiveMarkdownExample'
 include ':app'
 includeBuild('../node_modules/@react-native/gradle-plugin')
-includeBuild('../node_modules/react-native') {
-    dependencySubstitution {
-        substitute(module("com.facebook.react:react-android")).using(project(":packages:react-native:ReactAndroid"))
-        substitute(module("com.facebook.react:react-native")).using(project(":packages:react-native:ReactAndroid"))
-        substitute(module("com.facebook.react:hermes-android")).using(project(":packages:react-native:ReactAndroid:hermes-engine"))
-        substitute(module("com.facebook.react:hermes-engine")).using(project(":packages:react-native:ReactAndroid:hermes-engine"))
-    }
-}
+// includeBuild('../node_modules/react-native') {
+//     dependencySubstitution {
+//         substitute(module("com.facebook.react:react-android")).using(project(":packages:react-native:ReactAndroid"))
+//         substitute(module("com.facebook.react:react-native")).using(project(":packages:react-native:ReactAndroid"))
+//         substitute(module("com.facebook.react:hermes-android")).using(project(":packages:react-native:ReactAndroid:hermes-engine"))
+//         substitute(module("com.facebook.react:hermes-engine")).using(project(":packages:react-native:ReactAndroid:hermes-engine"))
+//     }
+// }


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Details

We no longer need to build React Native from source so let's disable it for now.

### Related Issues
<!-- Please replace GH_LINK with the link to the GitHub issue this Pull Request is related to -->
GH_LINK

### Manual Tests
<!---
Most changes should have accompanying tests. Describe the tests you added or if no tests were added an explanation about why one was not needed.
--->

### Linked PRs
<!---
Please include links to any update PRs in repos that must change their package.json version.
--->