### PR TITLE
Add missing C++ namespaces

### DIFF
--- a/cpp/react/renderer/components/RNLiveMarkdownSpec/MarkdownShadowFamilyRegistry.cpp
+++ b/cpp/react/renderer/components/RNLiveMarkdownSpec/MarkdownShadowFamilyRegistry.cpp
@@ -2,6 +2,9 @@
 
 #include "MarkdownShadowFamilyRegistry.h"
 
+namespace expensify {
+namespace livemarkdown {
+
 std::set<facebook::react::ShadowNodeFamily::Shared>
     MarkdownShadowFamilyRegistry::familiesToUpdate_;
 std::set<facebook::react::Tag> MarkdownShadowFamilyRegistry::forcedUpdates_;
@@ -54,5 +57,8 @@ bool MarkdownShadowFamilyRegistry::shouldForceUpdate(facebook::react::Tag tag) {
   }
   return false;
 }
+
+} // namespace livemarkdown
+} // namespace expensify
 
 #endif

--- a/cpp/react/renderer/components/RNLiveMarkdownSpec/MarkdownShadowFamilyRegistry.h
+++ b/cpp/react/renderer/components/RNLiveMarkdownSpec/MarkdownShadowFamilyRegistry.h
@@ -6,6 +6,9 @@
 #include <mutex>
 #include <set>
 
+namespace expensify {
+namespace livemarkdown {
+
 // A registry to store pointers to the ShadowNodeFamilies of markdown
 // decorators. The only place we can _legally_ access the family of shadow node
 // is in the constructor and we need it inside commit hook. To achieve it, we
@@ -31,5 +34,8 @@ private:
   static std::set<facebook::react::Tag> forcedUpdates_;
   static std::mutex mutex_;
 };
+
+} // namespace livemarkdown
+} // namespace expensify
 
 #endif

--- a/cpp/react/renderer/components/RNLiveMarkdownSpec/MarkdownTextInputDecoratorShadowNode.cpp
+++ b/cpp/react/renderer/components/RNLiveMarkdownSpec/MarkdownTextInputDecoratorShadowNode.cpp
@@ -5,6 +5,8 @@
 #include "MarkdownShadowFamilyRegistry.h"
 #include "MarkdownTextInputDecoratorShadowNode.h"
 
+using namespace expensify::livemarkdown;
+
 namespace facebook {
 namespace react {
 

--- a/cpp/react/renderer/components/RNLiveMarkdownSpec/MarkdownTextInputDecoratorShadowNode.h
+++ b/cpp/react/renderer/components/RNLiveMarkdownSpec/MarkdownTextInputDecoratorShadowNode.h
@@ -8,6 +8,8 @@
 #include <react/renderer/components/RNLiveMarkdownSpec/Props.h>
 #include <react/renderer/components/view/ConcreteViewShadowNode.h>
 
+using namespace expensify::livemarkdown;
+
 namespace facebook {
 namespace react {
 

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -1497,7 +1497,7 @@ PODS:
     - React-logger (= 0.75.2)
     - React-perflogger (= 0.75.2)
     - React-utils (= 0.75.2)
-  - RNLiveMarkdown (0.1.128):
+  - RNLiveMarkdown (0.1.135):
     - DoubleConversion
     - glog
     - hermes-engine
@@ -1517,9 +1517,9 @@ PODS:
     - ReactCodegen
     - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
-    - RNLiveMarkdown/common (= 0.1.128)
+    - RNLiveMarkdown/common (= 0.1.135)
     - Yoga
-  - RNLiveMarkdown/common (0.1.128):
+  - RNLiveMarkdown/common (0.1.135):
     - DoubleConversion
     - glog
     - hermes-engine
@@ -1805,10 +1805,10 @@ SPEC CHECKSUMS:
   React-utils: 81a715d9c0a2a49047e77a86f3a2247408540deb
   ReactCodegen: 60973d382704c793c605b9be0fc7f31cb279442f
   ReactCommon: 6ef348087d250257c44c0204461c03f036650e9b
-  RNLiveMarkdown: 44cc9af8742cfd5355733d29fa54e64e4edf0f0d
+  RNLiveMarkdown: 77f3338039cf98111a753256849b90567a41fc53
   SocketRocket: abac6f5de4d4d62d24e11868d7a2f427e0ef940d
   Yoga: 2a45d7e59592db061217551fd3bbe2dd993817ae
 
 PODFILE CHECKSUM: 9b81b0f7bfba9e6fb4fa10efe8319f7860794e08
 
-COCOAPODS: 1.14.3
+COCOAPODS: 1.15.2

--- a/ios/MarkdownCommitHook.h
+++ b/ios/MarkdownCommitHook.h
@@ -11,6 +11,7 @@
 
 using namespace facebook::react;
 
+namespace expensify {
 namespace livemarkdown {
 
 struct MarkdownTextInputDecoratorPair {
@@ -38,5 +39,6 @@ private:
 };
 
 } // namespace livemarkdown
+} // namespace expensify
 
 #endif // RCT_NEW_ARCH_ENABLED

--- a/ios/MarkdownCommitHook.mm
+++ b/ios/MarkdownCommitHook.mm
@@ -11,6 +11,7 @@
 
 using namespace facebook::react;
 
+namespace expensify {
 namespace livemarkdown {
 
 MarkdownCommitHook::MarkdownCommitHook(
@@ -192,5 +193,6 @@ RootShadowNode::Unshared MarkdownCommitHook::shadowTreeWillCommit(
 }
 
 } // namespace livemarkdown
+} // namespace expensify
 
 #endif // RCT_NEW_ARCH_ENABLED

--- a/ios/RCTLiveMarkdownModule.mm
+++ b/ios/RCTLiveMarkdownModule.mm
@@ -7,13 +7,15 @@
 #import "MarkdownShadowFamilyRegistry.h"
 #import "RCTLiveMarkdownModule.h"
 
+using namespace expensify::livemarkdown;
+
 // A turbomodule used to register the commit hook
 // I think this is the easiest way to access the UIManager, which we need to
 // actually register the hook
 
 @implementation RCTLiveMarkdownModule {
   BOOL installed_;
-  std::shared_ptr<livemarkdown::MarkdownCommitHook> commitHook_;
+  std::shared_ptr<MarkdownCommitHook> commitHook_;
   __weak RCTSurfacePresenter *surfacePresenter_;
 }
 
@@ -23,8 +25,7 @@ RCT_EXPORT_MODULE(@"LiveMarkdownModule")
   if (!installed_ && surfacePresenter_ != nil) {
     RCTScheduler *scheduler = [surfacePresenter_ scheduler];
 
-    commitHook_ =
-      std::make_shared<livemarkdown::MarkdownCommitHook>(scheduler.uiManager);
+    commitHook_ = std::make_shared<MarkdownCommitHook>(scheduler.uiManager);
     installed_ = YES;
   }
   return @1;

--- a/ios/RCTTextInputComponentView+Markdown.mm
+++ b/ios/RCTTextInputComponentView+Markdown.mm
@@ -8,6 +8,8 @@
 
 #import "MarkdownShadowFamilyRegistry.h"
 
+using namespace expensify::livemarkdown;
+
 @implementation RCTTextInputComponentView (Markdown)
 
 - (void)setMarkdownUtils:(RCTMarkdownUtils *)markdownUtils {


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Details
This PR wraps several classes into namespace `expensify::livemarkdown` as well as moves existing `livemarkdown` namespace into `expensify`.

### Related Issues
<!-- Please replace GH_LINK with the link to the GitHub issue this Pull Request is related to -->
GH_LINK

### Manual Tests
<!---
Most changes should have accompanying tests. Describe the tests you added or if no tests were added an explanation about why one was not needed.
--->

### Linked PRs
<!---
Please include links to any update PRs in repos that must change their package.json version.
--->