### PR TITLE
Fix single line input

### DIFF
--- a/src/MarkdownTextInput.web.tsx
+++ b/src/MarkdownTextInput.web.tsx
@@ -176,10 +176,11 @@ const MarkdownTextInput = React.forwardRef<TextInput, MarkdownTextInputProps>(
           flattenedStyle && {
             caretColor: (flattenedStyle as TextStyle).color || 'black',
           },
+          multiline && {whitespace: 'pre-wrap'},
           disabled && styles.disabledInputStyles,
           parseToReactDOMStyle(flattenedStyle),
         ]) as CSSProperties,
-      [flattenedStyle, disabled],
+      [flattenedStyle, multiline, disabled],
     );
 
     const undo = useCallback(

--- a/src/MarkdownTextInput.web.tsx
+++ b/src/MarkdownTextInput.web.tsx
@@ -176,7 +176,7 @@ const MarkdownTextInput = React.forwardRef<TextInput, MarkdownTextInputProps>(
           flattenedStyle && {
             caretColor: (flattenedStyle as TextStyle).color || 'black',
           },
-          multiline && {whitespace: 'pre-wrap'},
+          {whiteSpace: multiline ? 'pre-wrap' : 'nowrap'},
           disabled && styles.disabledInputStyles,
           parseToReactDOMStyle(flattenedStyle),
         ]) as CSSProperties,

--- a/src/MarkdownTextInput.web.tsx
+++ b/src/MarkdownTextInput.web.tsx
@@ -149,7 +149,7 @@ const MarkdownTextInput = React.forwardRef<TextInput, MarkdownTextInputProps>(
         if (text === null) {
           return {text: divRef.current.value, cursorPosition: null};
         }
-        const parsedText = updateInputStructure(target, text, cursorPosition, customMarkdownStyles, !multiline, shouldForceDOMUpdate);
+        const parsedText = updateInputStructure(target, text, cursorPosition, customMarkdownStyles, false, shouldForceDOMUpdate);
         divRef.current.value = parsedText.text;
 
         if (history.current && shouldAddToHistory) {
@@ -158,7 +158,7 @@ const MarkdownTextInput = React.forwardRef<TextInput, MarkdownTextInputProps>(
 
         return parsedText;
       },
-      [multiline],
+      [],
     );
 
     const processedMarkdownStyle = useMemo(() => {
@@ -683,7 +683,6 @@ const styles = StyleSheet.create({
     fontFamily: 'sans-serif',
     // @ts-expect-error it works on web
     boxSizing: 'border-box',
-    whiteSpace: 'pre-wrap',
     overflowY: 'auto',
     overflowX: 'auto',
     overflowWrap: 'break-word',

--- a/src/web/MarkdownTextInput.css
+++ b/src/web/MarkdownTextInput.css
@@ -3,6 +3,10 @@
   overflow: auto;
 }
 
+.react-native-live-markdown-input-multiline {
+  white-space: pre-wrap;
+}
+
 .react-native-live-markdown-input-singleline p {
   display: inline-block;
 }

--- a/src/web/MarkdownTextInput.css
+++ b/src/web/MarkdownTextInput.css
@@ -1,8 +1,3 @@
-.react-native-live-markdown-input-singleline {
-  white-space: nowrap;
-  overflow: auto;
-}
-
 .react-native-live-markdown-input-multiline {
   white-space: pre-wrap;
 }
@@ -21,11 +16,6 @@
 
 .react-native-live-markdown-input-singleline br {
   display: none;
-}
-
-.react-native-live-markdown-input-singleline * {
-  display: inline;
-  white-space: nowrap;
 }
 
 .react-native-live-markdown-input-singleline:empty::before,

--- a/src/web/MarkdownTextInput.css
+++ b/src/web/MarkdownTextInput.css
@@ -3,6 +3,14 @@
   overflow: auto;
 }
 
+.react-native-live-markdown-input-singleline p {
+  display: inline-block;
+}
+
+.react-native-live-markdown-input-multiline p {
+  display: block;
+}
+
 .react-native-live-markdown-input-singleline::-webkit-scrollbar {
   display: none;
 }

--- a/src/web/utils/blockUtils.ts
+++ b/src/web/utils/blockUtils.ts
@@ -6,7 +6,6 @@ function addStyleToBlock(targetElement: HTMLElement, type: NodeType, markdownSty
   switch (type) {
     case 'line':
       Object.assign(node.style, {
-        display: 'block',
         margin: '0',
         padding: '0',
       });


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Details
<!-- Explanation of the change or anything fishy that is going on -->
This PR fixes single line Live Markdown Input on web, so the text content is always displayed in a single line.
### Related Issues
<!-- Please replace GH_LINK with the link to the GitHub issue this Pull Request is related to -->
https://github.com/Expensify/react-native-live-markdown/issues/481

### Manual Tests
<!---
Most changes should have accompanying tests. Describe the tests you added or if no tests were added an explanation about why one was not needed.
--->
1. Remove `multiline` prop from the `<MarkdownTextInput>` component or set it to `false`
2. Open the example app
3. Verify if the input behaves normally

### Linked PRs
<!---
Please include links to any update PRs in repos that must change their package.json version.
--->