### PR TITLE
fix: add `maxParsableTextLength` to prevent freeze while parsing long text

### DIFF
--- a/src/MarkdownTextInput.web.tsx
+++ b/src/MarkdownTextInput.web.tsx
@@ -28,6 +28,7 @@ const useClientEffect = typeof window === 'undefined' ? useEffect : useLayoutEff
 
 interface MarkdownTextInputProps extends TextInputProps {
   markdownStyle?: MarkdownStyle;
+  maxParsableTextLength?: number;
   onClick?: (e: MouseEvent<HTMLDivElement>) => void;
   dir?: string;
   disabled?: boolean;
@@ -79,6 +80,7 @@ const MarkdownTextInput = React.forwardRef<TextInput, MarkdownTextInputProps>(
       numberOfLines,
       multiline = false,
       markdownStyle,
+      maxParsableTextLength = null,
       onBlur,
       onChange,
       onChangeText,
@@ -149,7 +151,7 @@ const MarkdownTextInput = React.forwardRef<TextInput, MarkdownTextInputProps>(
         if (text === null) {
           return {text: divRef.current.value, cursorPosition: null};
         }
-        const parsedText = updateInputStructure(target, text, cursorPosition, multiline, customMarkdownStyles, false, shouldForceDOMUpdate);
+        const parsedText = updateInputStructure(target, text, cursorPosition, maxParsableTextLength, multiline, customMarkdownStyles, false, shouldForceDOMUpdate);
         divRef.current.value = parsedText.text;
 
         if (history.current && shouldAddToHistory) {
@@ -158,7 +160,7 @@ const MarkdownTextInput = React.forwardRef<TextInput, MarkdownTextInputProps>(
 
         return parsedText;
       },
-      [multiline],
+      [maxParsableTextLength, multiline],
     );
 
     const processedMarkdownStyle = useMemo(() => {

--- a/src/web/utils/parserUtils.ts
+++ b/src/web/utils/parserUtils.ts
@@ -282,6 +282,7 @@ function updateInputStructure(
   target: MarkdownTextInputElement,
   text: string,
   cursorPositionIndex: number | null,
+  maxParsableTextLength: number | null,
   isMultiline = true,
   markdownStyle: PartialMarkdownStyle = {},
   alwaysMoveCursorToTheEnd = false,
@@ -296,7 +297,7 @@ function updateInputStructure(
     const selection = getCurrentCursorPosition(target);
     cursorPosition = selection ? selection.start : null;
   }
-  const markdownRanges = global.parseExpensiMarkToRanges(text);
+  const markdownRanges = maxParsableTextLength !== null && text.length <= maxParsableTextLength ? global.parseExpensiMarkToRanges(text) : [];
   if (!text || targetElement.innerHTML === '<br>' || (targetElement && targetElement.innerHTML === '\n')) {
     targetElement.innerHTML = '';
     targetElement.innerText = '';


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Details
<!-- Explanation of the change or anything fishy that is going on -->

### Related Issues
<!-- Please replace GH_LINK with the link to the GitHub issue this Pull Request is related to -->
$ https://github.com/Expensify/App/issues/46766
PROPOSAL: https://github.com/Expensify/App/issues/46766#issuecomment-2318594335

### Manual Tests
<!---
Most changes should have accompanying tests. Describe the tests you added or if no tests were added an explanation about why one was not needed.
--->

### Linked PRs
<!---
Please include links to any update PRs in repos that must change their package.json version.
--->

https://github.com/Expensify/App/pull/49228