### PR TITLE
Fix unsupported type inline image

### DIFF
--- a/android/src/main/java/com/expensify/livemarkdown/MarkdownUtils.java
+++ b/android/src/main/java/com/expensify/livemarkdown/MarkdownUtils.java
@@ -164,8 +164,6 @@ public class MarkdownUtils {
           depth);
         setSpan(ssb, span, start, end);
         break;
-      default:
-        throw new IllegalStateException("Unsupported type: " + type);
     }
   }
 


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Details
This PR fixes the following error on Android:

```
Exception in HostFunction: java.lang.IllegalStateException: Unsupported type: inline-image
```

<img width="441" alt="Screenshot 2024-09-16 at 10 30 57" src="https://github.com/user-attachments/assets/25b5287e-e769-4d01-9965-c0a2624c9dd9">

### Related Issues
<!-- Please replace GH_LINK with the link to the GitHub issue this Pull Request is related to -->
GH_LINK

### Manual Tests
<!---
Most changes should have accompanying tests. Describe the tests you added or if no tests were added an explanation about why one was not needed.
--->

### Linked PRs
<!---
Please include links to any update PRs in repos that must change their package.json version.
--->