### PR TITLE
Cleanup CMakeLists.txt

### DIFF
--- a/android/src/main/cpp/CMakeLists.txt
+++ b/android/src/main/cpp/CMakeLists.txt
@@ -18,20 +18,17 @@ find_package(fbjni REQUIRED CONFIG)
 find_package(ReactAndroid REQUIRED CONFIG)
 find_package(hermes-engine REQUIRED CONFIG)
 
+target_link_libraries(
+        ${CMAKE_PROJECT_NAME}
+        fbjni::fbjni
+        hermes-engine::libhermes
+        ReactAndroid::jsi
+)
+
 if (ReactAndroid_VERSION_MINOR GREATER_EQUAL 76)
-  target_link_libraries(${CMAKE_PROJECT_NAME}
-          fbjni::fbjni
-          ReactAndroid::jsi
-          ReactAndroid::reactnative
-          hermes-engine::libhermes
-  )
+  target_link_libraries(${CMAKE_PROJECT_NAME} ReactAndroid::reactnative)
 elseif (ReactAndroid_VERSION_MINOR GREATER_EQUAL 75)
-  target_link_libraries(${CMAKE_PROJECT_NAME}
-          fbjni::fbjni
-          ReactAndroid::jsi
-          ReactAndroid::reactnativejni
-          hermes-engine::libhermes
-  )
+  target_link_libraries(${CMAKE_PROJECT_NAME} ReactAndroid::reactnativejni)
 else ()
   message(FATAL_ERROR "react-native-live-markdown requires react-native 0.75 or newer.")
 endif ()

--- a/android/src/main/new_arch/CMakeLists.txt
+++ b/android/src/main/new_arch/CMakeLists.txt
@@ -34,51 +34,43 @@ target_include_directories(
         ${LIB_CPP_DIR}
 )
 
+find_package(fbjni REQUIRED CONFIG)
 find_package(ReactAndroid REQUIRED CONFIG)
+
+target_link_libraries(
+        ${LIB_TARGET_NAME}
+        fbjni::fbjni
+        ReactAndroid::jsi
+)
 
 if (ReactAndroid_VERSION_MINOR GREATER_EQUAL 76)
   target_link_libraries(
           ${LIB_TARGET_NAME}
           ReactAndroid::reactnative
-          ReactAndroid::jsi
-          fbjni::fbjni
   )
 elseif (ReactAndroid_VERSION_MINOR GREATER_EQUAL 75)
   target_link_libraries(
           ${LIB_TARGET_NAME}
+          ReactAndroid::fabricjni
+          ReactAndroid::folly_runtime
+          ReactAndroid::glog
+          ReactAndroid::react_debug
+          ReactAndroid::react_nativemodule_core
+          ReactAndroid::react_performance_timeline
+          ReactAndroid::react_render_consistency
+          ReactAndroid::react_render_core
+          ReactAndroid::react_render_debug
+          ReactAndroid::react_render_graphics
+          ReactAndroid::react_render_imagemanager
+          ReactAndroid::react_render_mapbuffer
+          ReactAndroid::react_render_observers_events
+          ReactAndroid::react_render_textlayoutmanager
+          ReactAndroid::reactnativejni
           ReactAndroid::rrc_text
           ReactAndroid::rrc_textinput
-          ReactAndroid::react_render_textlayoutmanager
-          ReactAndroid::react_render_imagemanager
-          ReactAndroid::reactnativejni
-          ReactAndroid::mapbufferjni
-          fabricjni
-          fbjni
-          folly_runtime
-          glog
-          jsi
-          react_codegen_rncore
-          react_debug
-          react_nativemodule_core
-          react_render_core
-          react_render_debug
-          react_render_graphics
-          react_render_mapbuffer
-          ReactAndroid::react_render_uimanager
-          ReactAndroid::react_render_scheduler
-          react_utils
-          runtimeexecutor
-          rrc_view
-          turbomodulejsijni
-          yoga
-          android
-          log
-          mapbufferjni
-          reactnativejni
-          react_render_consistency
-          react_performance_timeline
-          react_render_observers_events
-          react_featureflags
+          ReactAndroid::rrc_view
+          ReactAndroid::runtimeexecutor
+          ReactAndroid::yoga
   )
 else ()
   message(FATAL_ERROR "react-native-live-markdown requires react-native 0.75 or newer.")


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Details
* Moved common prefabs outside of conditionals
* Removed unused prefabs and shared libraries (e.g. `android`, `log`, `ReactAndroid::mapbufferjni`)
* Added missing `find_package` for `fbjni` prefab
* Added missing `ReactAndroid::` prefix in prefabs

### Related Issues
<!-- Please replace GH_LINK with the link to the GitHub issue this Pull Request is related to -->
GH_LINK

### Manual Tests
<!---
Most changes should have accompanying tests. Describe the tests you added or if no tests were added an explanation about why one was not needed.
--->

### Linked PRs
<!---
Please include links to any update PRs in repos that must change their package.json version.
--->