### PR TITLE
Fix inline image preview styling

### DIFF
--- a/src/MarkdownTextInputDecoratorViewNativeComponent.ts
+++ b/src/MarkdownTextInputDecoratorViewNativeComponent.ts
@@ -47,6 +47,8 @@ interface MarkdownStyle {
     backgroundColor: ColorValue;
   };
   inlineImage: {
+    minWidth: Float;
+    minHeight: Float;
     maxWidth: Float;
     maxHeight: Float;
     marginTop: Float;

--- a/src/MarkdownTextInputDecoratorViewNativeComponent.ts
+++ b/src/MarkdownTextInputDecoratorViewNativeComponent.ts
@@ -53,6 +53,7 @@ interface MarkdownStyle {
     maxHeight: Float;
     marginTop: Float;
     marginBottom: Float;
+    borderRadius: Float;
   };
   loadingIndicatorContainer?: {
     backgroundColor?: ColorValue;

--- a/src/styleUtils.ts
+++ b/src/styleUtils.ts
@@ -55,6 +55,8 @@ function makeDefaultMarkdownStyle(): MarkdownStyle {
       backgroundColor: 'pink',
     },
     inlineImage: {
+      minWidth: 50,
+      minHeight: 50,
       maxWidth: 150,
       maxHeight: 150,
       marginTop: 5,

--- a/src/styleUtils.ts
+++ b/src/styleUtils.ts
@@ -61,6 +61,7 @@ function makeDefaultMarkdownStyle(): MarkdownStyle {
       maxHeight: 150,
       marginTop: 5,
       marginBottom: 0,
+      borderRadius: 5,
     },
     loadingIndicator: {
       primaryColor: 'gray',

--- a/src/web/inputElements/inlineImage.ts
+++ b/src/web/inputElements/inlineImage.ts
@@ -26,8 +26,8 @@ function createImageElement(url: string, callback: (img: HTMLElement) => void) {
 }
 
 /** Adds already loaded image element from current input content to the tree node */
-function updateImageTreeNode(targetNode: TreeNode, newElement: HTMLMarkdownElement) {
-  const paddingBottom = `${newElement.style.height}`;
+function updateImageTreeNode(targetNode: TreeNode, newElement: HTMLMarkdownElement, imageMarginTop = 0) {
+  const paddingBottom = `${parseStringWithUnitToNumber(newElement.style.height) + imageMarginTop}px`;
   targetNode.element.appendChild(newElement);
 
   let currentParent = targetNode.element;
@@ -49,12 +49,17 @@ function addInlineImagePreview(currentInput: MarkdownTextInputElement, targetNod
     imageHref = text.substring(linkRange.start, linkRange.start + linkRange.length);
   }
 
+  const maxWidth = markdownStyle.inlineImage?.maxWidth;
+  const maxHeight = markdownStyle.inlineImage?.maxHeight;
+  const imageMarginTop = parseStringWithUnitToNumber(`${markdownStyle.inlineImage?.marginTop}`);
+  const imageMarginBottom = parseStringWithUnitToNumber(`${markdownStyle.inlineImage?.marginBottom}`);
+
   // If the inline image markdown with the same href exists in the current input, use it instead of creating new one.
   // Prevents from image flickering and layout jumps
   const alreadyLoadedPreview = currentInput.querySelector(`img[src="${imageHref}"]`);
   const loadedImageContainer = alreadyLoadedPreview?.parentElement;
   if (loadedImageContainer && loadedImageContainer.getAttribute('data-type') === 'inline-container') {
-    return updateImageTreeNode(targetNode, loadedImageContainer as HTMLMarkdownElement);
+    return updateImageTreeNode(targetNode, loadedImageContainer as HTMLMarkdownElement, imageMarginTop);
   }
 
   // Add a loading spinner
@@ -62,11 +67,6 @@ function addInlineImagePreview(currentInput: MarkdownTextInputElement, targetNod
   if (spinner) {
     targetNode.element.appendChild(spinner);
   }
-
-  const maxWidth = markdownStyle.inlineImage?.maxWidth;
-  const maxHeight = markdownStyle.inlineImage?.maxHeight;
-  const imageMarginTop = parseStringWithUnitToNumber(`${markdownStyle.inlineImage?.marginTop}`);
-  const imageMarginBottom = parseStringWithUnitToNumber(`${markdownStyle.inlineImage?.marginBottom}`);
 
   Object.assign(targetNode.element.style, {
     display: 'block',
@@ -97,13 +97,12 @@ function addInlineImagePreview(currentInput: MarkdownTextInputElement, targetNod
 
     targetNode.element.appendChild(imageContainer);
 
-    const imageHeight = `${imageContainer.clientHeight + imageMarginTop}px`;
     Object.assign(imageContainer.style, {
-      height: imageHeight,
+      height: `${imageContainer.clientHeight}px`,
     });
     // Set paddingBottom to the height of the image so it's displayed under the block
     Object.assign(targetNode.element.style, {
-      paddingBottom: imageHeight,
+      paddingBottom: `${imageContainer.clientHeight + imageMarginTop}px`,
     });
   });
 

--- a/src/web/inputElements/inlineImage.ts
+++ b/src/web/inputElements/inlineImage.ts
@@ -49,8 +49,6 @@ function addInlineImagePreview(currentInput: MarkdownTextInputElement, targetNod
     imageHref = text.substring(linkRange.start, linkRange.start + linkRange.length);
   }
 
-  const maxWidth = markdownStyle.inlineImage?.maxWidth;
-  const maxHeight = markdownStyle.inlineImage?.maxHeight;
   const imageMarginTop = parseStringWithUnitToNumber(`${markdownStyle.inlineImage?.marginTop}`);
   const imageMarginBottom = parseStringWithUnitToNumber(`${markdownStyle.inlineImage?.marginBottom}`);
 
@@ -82,15 +80,17 @@ function addInlineImagePreview(currentInput: MarkdownTextInputElement, targetNod
       currentSpinner.remove();
     }
 
+    const img = imageContainer.firstChild as HTMLImageElement;
+
     // Set the image styles
     Object.assign(imageContainer.style, {
       ...inlineImageDefaultStyles,
-      maxHeight,
-      maxWidth,
     });
 
-    const img = imageContainer.firstChild as HTMLImageElement;
+    const {minHeight, minWidth, maxHeight, maxWidth} = markdownStyle.inlineImage || {};
     Object.assign(img.style, {
+      minHeight,
+      minWidth,
       maxHeight,
       maxWidth,
     });

--- a/src/web/inputElements/inlineImage.ts
+++ b/src/web/inputElements/inlineImage.ts
@@ -87,12 +87,13 @@ function addInlineImagePreview(currentInput: MarkdownTextInputElement, targetNod
       ...inlineImageDefaultStyles,
     });
 
-    const {minHeight, minWidth, maxHeight, maxWidth} = markdownStyle.inlineImage || {};
+    const {minHeight, minWidth, maxHeight, maxWidth, borderRadius} = markdownStyle.inlineImage || {};
     Object.assign(img.style, {
       minHeight,
       minWidth,
       maxHeight,
       maxWidth,
+      borderRadius,
     });
 
     targetNode.element.appendChild(imageContainer);


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Details
<!-- Explanation of the change or anything fishy that is going on -->
This PR fixes inline image preview styling. It fixies `marginTop` property and adds `minWidth`, `minHeight` and `borderRadius` props
### Related Issues
<!-- Please replace GH_LINK with the link to the GitHub issue this Pull Request is related to -->
GH_LINK

### Manual Tests
<!---
Most changes should have accompanying tests. Describe the tests you added or if no tests were added an explanation about why one was not needed.
--->
1. Open the app and play with the styling values for `inlineImage` in `styleUtils.ts`
### Linked PRs
<!---
Please include links to any update PRs in repos that must change their package.json version.
--->