### PR TITLE
Fix caret position in web when deleting forward with no characters selected

### DIFF
--- a/src/MarkdownTextInput.web.tsx
+++ b/src/MarkdownTextInput.web.tsx
@@ -296,7 +296,10 @@ const MarkdownTextInput = React.forwardRef<TextInput, MarkdownTextInputProps>(
         }
 
         const prevSelection = contentSelection.current ?? {start: 0, end: 0};
-        const newCursorPosition = Math.max(Math.max(contentSelection.current.end, 0) + (parsedText.length - previousText.length), 0);
+        const newCursorPosition =
+          inputType === 'deleteContentForward' && contentSelection.current.start === contentSelection.current.end
+            ? Math.max(contentSelection.current.start, 0) // Don't move the caret when deleting forward with no characters selected
+            : Math.max(Math.max(contentSelection.current.end, 0) + (parsedText.length - previousText.length), 0);
 
         if (compositionRef.current) {
           updateTextColor(divRef.current, parsedText);


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Details
<!-- Explanation of the change or anything fishy that is going on -->
The caret is in the wrong position after deleting forward with no characters selected.

### Related Issues
<!-- Please replace GH_LINK with the link to the GitHub issue this Pull Request is related to -->
https://github.com/Expensify/App/issues/48797

**Proposal:** https://github.com/Expensify/App/issues/48797#issuecomment-2348124289

### Manual Tests
<!---
Most changes should have accompanying tests. Describe the tests you added or if no tests were added an explanation about why one was not needed.
--->

1. Open the web examples.
2. Click in the middle of a word.
3. Press the `Delete` key.

**Expected result:** The caret position does not change.

#### Videos

##### Before this fix

https://github.com/user-attachments/assets/ae634a3f-2d63-454d-ac13-3024883b1556

##### After this fix

https://github.com/user-attachments/assets/43f6df3e-42b8-4b12-b959-c0d1ad8efca0

### Linked PRs
<!---
Please include links to any update PRs in repos that must change their package.json version.
--->