### PR TITLE
Live Markdown for web refactor follow ups

### DIFF
--- a/src/MarkdownTextInput.web.tsx
+++ b/src/MarkdownTextInput.web.tsx
@@ -326,6 +326,9 @@ const MarkdownTextInput = React.forwardRef<TextInput, MarkdownTextInputProps>(
             end: newCursorPosition,
           });
           divRef.current.value = parsedText;
+          if (onChangeText) {
+            onChangeText(parsedText);
+          }
           return;
         }
 

--- a/src/web/inputElements/inlineImage.ts
+++ b/src/web/inputElements/inlineImage.ts
@@ -95,7 +95,7 @@ function createImageElement(currentInput: MarkdownTextInputElement, targetNode: 
   if (timeoutMap.has(targetNode.orderIndex)) {
     const mapItem = timeoutMap.get(targetNode.orderIndex);
     // Check if the image URL has been changed, if not, early return so the image can be loaded asynchronously
-    const currentElement = document.querySelector(`[data-type="block"][data-id="${targetNode.orderIndex}"]`) as HTMLMarkdownElement;
+    const currentElement = currentInput.querySelector(`[data-type="block"][data-id="${targetNode.orderIndex}"]`) as HTMLMarkdownElement;
     if (mapItem?.url === url && currentElement && getImagePreviewElement(currentElement)) {
       return;
     }

--- a/src/web/utils/parserUtils.ts
+++ b/src/web/utils/parserUtils.ts
@@ -1,5 +1,5 @@
 import type {HTMLMarkdownElement, MarkdownTextInputElement} from '../../MarkdownTextInput.web';
-import {addNodeToTree, updateTreeElementRefs} from './treeUtils';
+import {addNodeToTree, createRootTreeNode, updateTreeElementRefs} from './treeUtils';
 import type {NodeType, TreeNode} from './treeUtils';
 import type {PartialMarkdownStyle} from '../../styleUtils';
 import {getCurrentCursorPosition, moveCursorToEnd, setCursorPosition} from './cursorUtils';
@@ -154,16 +154,8 @@ function parseRangesToHTMLNodes(
 ) {
   const rootElement: HTMLMarkdownElement = document.createElement('span') as HTMLMarkdownElement;
   const textLength = text.length;
-  const rootNode: TreeNode = {
-    element: rootElement,
-    start: 0,
-    length: textLength,
-    parentNode: null,
-    childNodes: [],
-    type: 'root',
-    orderIndex: '',
-    isGeneratingNewline: false,
-  };
+  const rootNode: TreeNode = createRootTreeNode(rootElement, textLength);
+
   let currentParentNode: TreeNode = rootNode;
   let lines = splitTextIntoLines(text);
 
@@ -319,6 +311,8 @@ function updateInputStructure(
     targetElement.tree = tree;
 
     moveCursor(isFocused, alwaysMoveCursorToTheEnd, cursorPosition, targetElement, shouldScrollIntoView);
+  } else {
+    targetElement.tree = createRootTreeNode(targetElement);
   }
 
   return {text, cursorPosition: cursorPosition || 0};

--- a/src/web/utils/treeUtils.ts
+++ b/src/web/utils/treeUtils.ts
@@ -12,6 +12,19 @@ type TreeNode = Omit<MarkdownRange, 'type'> & {
   isGeneratingNewline: boolean;
 };
 
+function createRootTreeNode(target: HTMLMarkdownElement, length = 0): TreeNode {
+  return {
+    element: target,
+    start: 0,
+    length,
+    parentNode: null,
+    childNodes: [],
+    type: 'root',
+    orderIndex: '',
+    isGeneratingNewline: false,
+  };
+}
+
 function addNodeToTree(element: HTMLMarkdownElement, parentTreeNode: TreeNode, type: NodeType, length: number | null = null) {
   const contentLength = length || (element.nodeName === 'BR' || type === 'br' ? 1 : element.value?.length) || 0;
   const isGeneratingNewline = type === 'line' && !(element.childNodes.length === 1 && (element.childNodes[0] as HTMLElement)?.getAttribute?.('data-type') === 'br');
@@ -115,6 +128,6 @@ function getTreeNodeByIndex(treeRoot: TreeNode, index: number): TreeNode | null 
   return null;
 }
 
-export {addNodeToTree, findHTMLElementInTree, getTreeNodeByIndex, updateTreeElementRefs};
+export {addNodeToTree, findHTMLElementInTree, getTreeNodeByIndex, updateTreeElementRefs, createRootTreeNode};
 
 export type {TreeNode, NodeType};


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Details
<!-- Explanation of the change or anything fishy that is going on -->
This PR fixes:
- creating a tree structure when the input value is empty
- handling composition events
- target element for inline image previews 

### Related Issues
<!-- Please replace GH_LINK with the link to the GitHub issue this Pull Request is related to -->
https://github.com/Expensify/App/pull/49250

### Manual Tests
<!---
Most changes should have accompanying tests. Describe the tests you added or if no tests were added an explanation about why one was not needed.
--->
1. Open an example app
2. Set the default text of the input to `""`
3. Verify if `target.tree` isn't empty

1. On a device with a Samsung keyboard, start typing
2. Verify if the `onChangeText` event is being sent

1. Verify if inline image preview is being added to the correct input in the case where there are many Live Markdown Inputs on the page

### Linked PRs
<!---
Please include links to any updated PRs in repos that must change their package.json version.
--->