### PR TITLE
Refactor new arch ifdefs

### DIFF
--- a/RNLiveMarkdown.podspec
+++ b/RNLiveMarkdown.podspec
@@ -37,8 +37,10 @@ Pod::Spec.new do |s|
     ])
   end
 
-  s.subspec "common" do |ss|
-    ss.source_files         = "cpp/**/*.{cpp,h}"
-    ss.header_dir           = "RNLiveMarkdown"
+  if ENV['RCT_NEW_ARCH_ENABLED'] == '1'
+    s.subspec "newarch" do |ss|
+      ss.source_files         = "cpp/**/*.{cpp,h}"
+      ss.header_dir           = "RNLiveMarkdown"
+    end
   end
 end

--- a/cpp/react/renderer/components/RNLiveMarkdownSpec/MarkdownShadowFamilyRegistry.cpp
+++ b/cpp/react/renderer/components/RNLiveMarkdownSpec/MarkdownShadowFamilyRegistry.cpp
@@ -1,5 +1,3 @@
-#ifdef RCT_NEW_ARCH_ENABLED
-
 #include "MarkdownShadowFamilyRegistry.h"
 
 namespace expensify {
@@ -60,5 +58,3 @@ bool MarkdownShadowFamilyRegistry::shouldForceUpdate(facebook::react::Tag tag) {
 
 } // namespace livemarkdown
 } // namespace expensify
-
-#endif // RCT_NEW_ARCH_ENABLED

--- a/cpp/react/renderer/components/RNLiveMarkdownSpec/MarkdownShadowFamilyRegistry.cpp
+++ b/cpp/react/renderer/components/RNLiveMarkdownSpec/MarkdownShadowFamilyRegistry.cpp
@@ -1,4 +1,4 @@
-#if defined(RCT_NEW_ARCH_ENABLED) || defined(ANDROID)
+#ifdef RCT_NEW_ARCH_ENABLED
 
 #include "MarkdownShadowFamilyRegistry.h"
 
@@ -61,4 +61,4 @@ bool MarkdownShadowFamilyRegistry::shouldForceUpdate(facebook::react::Tag tag) {
 } // namespace livemarkdown
 } // namespace expensify
 
-#endif
+#endif // RCT_NEW_ARCH_ENABLED

--- a/cpp/react/renderer/components/RNLiveMarkdownSpec/MarkdownShadowFamilyRegistry.h
+++ b/cpp/react/renderer/components/RNLiveMarkdownSpec/MarkdownShadowFamilyRegistry.h
@@ -1,5 +1,5 @@
 #pragma once
-#if defined(RCT_NEW_ARCH_ENABLED) || defined(ANDROID)
+#ifdef RCT_NEW_ARCH_ENABLED
 
 #include <react/renderer/core/ShadowNodeFamily.h>
 
@@ -38,4 +38,4 @@ private:
 } // namespace livemarkdown
 } // namespace expensify
 
-#endif
+#endif // RCT_NEW_ARCH_ENABLED

--- a/cpp/react/renderer/components/RNLiveMarkdownSpec/MarkdownShadowFamilyRegistry.h
+++ b/cpp/react/renderer/components/RNLiveMarkdownSpec/MarkdownShadowFamilyRegistry.h
@@ -1,5 +1,4 @@
 #pragma once
-#ifdef RCT_NEW_ARCH_ENABLED
 
 #include <react/renderer/core/ShadowNodeFamily.h>
 
@@ -37,5 +36,3 @@ private:
 
 } // namespace livemarkdown
 } // namespace expensify
-
-#endif // RCT_NEW_ARCH_ENABLED

--- a/cpp/react/renderer/components/RNLiveMarkdownSpec/MarkdownTextInputDecoratorShadowNode.cpp
+++ b/cpp/react/renderer/components/RNLiveMarkdownSpec/MarkdownTextInputDecoratorShadowNode.cpp
@@ -1,4 +1,4 @@
-#if defined(RCT_NEW_ARCH_ENABLED) || defined(ANDROID)
+#ifdef RCT_NEW_ARCH_ENABLED
 
 #include "MarkdownTextInputDecoratorShadowNode.h"
 
@@ -34,4 +34,4 @@ MarkdownTextInputDecoratorShadowNode::updateFragmentState(
 } // namespace react
 } // namespace facebook
 
-#endif
+#endif // RCT_NEW_ARCH_ENABLED

--- a/cpp/react/renderer/components/RNLiveMarkdownSpec/MarkdownTextInputDecoratorShadowNode.cpp
+++ b/cpp/react/renderer/components/RNLiveMarkdownSpec/MarkdownTextInputDecoratorShadowNode.cpp
@@ -1,5 +1,3 @@
-#ifdef RCT_NEW_ARCH_ENABLED
-
 #include "MarkdownTextInputDecoratorShadowNode.h"
 
 using namespace expensify::livemarkdown;
@@ -33,5 +31,3 @@ MarkdownTextInputDecoratorShadowNode::updateFragmentState(
 
 } // namespace react
 } // namespace facebook
-
-#endif // RCT_NEW_ARCH_ENABLED

--- a/cpp/react/renderer/components/RNLiveMarkdownSpec/MarkdownTextInputDecoratorShadowNode.h
+++ b/cpp/react/renderer/components/RNLiveMarkdownSpec/MarkdownTextInputDecoratorShadowNode.h
@@ -1,5 +1,5 @@
 #pragma once
-#if defined(RCT_NEW_ARCH_ENABLED) || defined(ANDROID)
+#ifdef RCT_NEW_ARCH_ENABLED
 
 #include "MarkdownShadowFamilyRegistry.h"
 #include "MarkdownTextInputDecoratorState.h"
@@ -46,4 +46,4 @@ private:
 } // namespace react
 } // namespace facebook
 
-#endif
+#endif // RCT_NEW_ARCH_ENABLED

--- a/cpp/react/renderer/components/RNLiveMarkdownSpec/MarkdownTextInputDecoratorShadowNode.h
+++ b/cpp/react/renderer/components/RNLiveMarkdownSpec/MarkdownTextInputDecoratorShadowNode.h
@@ -1,5 +1,4 @@
 #pragma once
-#ifdef RCT_NEW_ARCH_ENABLED
 
 #include "MarkdownShadowFamilyRegistry.h"
 #include "MarkdownTextInputDecoratorState.h"
@@ -45,5 +44,3 @@ private:
 
 } // namespace react
 } // namespace facebook
-
-#endif // RCT_NEW_ARCH_ENABLED

--- a/cpp/react/renderer/components/RNLiveMarkdownSpec/MarkdownTextInputDecoratorState.h
+++ b/cpp/react/renderer/components/RNLiveMarkdownSpec/MarkdownTextInputDecoratorState.h
@@ -1,5 +1,5 @@
 #pragma once
-#if defined(RCT_NEW_ARCH_ENABLED) || defined(ANDROID)
+#ifdef RCT_NEW_ARCH_ENABLED
 
 #include <react/renderer/core/ShadowNodeFamily.h>
 
@@ -34,4 +34,4 @@ public:
 } // namespace react
 } // namespace facebook
 
-#endif
+#endif // RCT_NEW_ARCH_ENABLED

--- a/cpp/react/renderer/components/RNLiveMarkdownSpec/MarkdownTextInputDecoratorState.h
+++ b/cpp/react/renderer/components/RNLiveMarkdownSpec/MarkdownTextInputDecoratorState.h
@@ -1,5 +1,4 @@
 #pragma once
-#ifdef RCT_NEW_ARCH_ENABLED
 
 #include <react/renderer/core/ShadowNodeFamily.h>
 
@@ -33,5 +32,3 @@ public:
 
 } // namespace react
 } // namespace facebook
-
-#endif // RCT_NEW_ARCH_ENABLED

--- a/cpp/react/renderer/components/RNLiveMarkdownSpec/MarkdownTextInputDecoratorViewComponentDescriptor.h
+++ b/cpp/react/renderer/components/RNLiveMarkdownSpec/MarkdownTextInputDecoratorViewComponentDescriptor.h
@@ -1,5 +1,5 @@
 #pragma once
-#if defined(RCT_NEW_ARCH_ENABLED) || defined(ANDROID)
+#ifdef RCT_NEW_ARCH_ENABLED
 
 #include "MarkdownTextInputDecoratorShadowNode.h"
 #include <react/debug/react_native_assert.h>
@@ -17,4 +17,4 @@ public:
 } // namespace react
 } // namespace facebook
 
-#endif
+#endif // RCT_NEW_ARCH_ENABLED

--- a/cpp/react/renderer/components/RNLiveMarkdownSpec/MarkdownTextInputDecoratorViewComponentDescriptor.h
+++ b/cpp/react/renderer/components/RNLiveMarkdownSpec/MarkdownTextInputDecoratorViewComponentDescriptor.h
@@ -1,5 +1,4 @@
 #pragma once
-#ifdef RCT_NEW_ARCH_ENABLED
 
 #include "MarkdownTextInputDecoratorShadowNode.h"
 #include <react/debug/react_native_assert.h>
@@ -16,5 +15,3 @@ public:
 
 } // namespace react
 } // namespace facebook
-
-#endif // RCT_NEW_ARCH_ENABLED

--- a/cpp/react/renderer/components/RNLiveMarkdownSpec/OwningShadowNodeFragment.h
+++ b/cpp/react/renderer/components/RNLiveMarkdownSpec/OwningShadowNodeFragment.h
@@ -1,5 +1,4 @@
 #pragma once
-#ifdef RCT_NEW_ARCH_ENABLED
 
 #include <react/renderer/core/Props.h>
 #include <react/renderer/core/ShadowNode.h>
@@ -27,5 +26,3 @@ struct OwningShadowNodeFragment {
 
 } // namespace livemarkdown
 } // namespace expensify
-
-#endif // RCT_NEW_ARCH_ENABLED

--- a/cpp/react/renderer/components/RNLiveMarkdownSpec/OwningShadowNodeFragment.h
+++ b/cpp/react/renderer/components/RNLiveMarkdownSpec/OwningShadowNodeFragment.h
@@ -1,5 +1,5 @@
 #pragma once
-#if defined(RCT_NEW_ARCH_ENABLED) || defined(ANDROID)
+#ifdef RCT_NEW_ARCH_ENABLED
 
 #include <react/renderer/core/Props.h>
 #include <react/renderer/core/ShadowNode.h>
@@ -28,4 +28,4 @@ struct OwningShadowNodeFragment {
 } // namespace livemarkdown
 } // namespace expensify
 
-#endif
+#endif // RCT_NEW_ARCH_ENABLED

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -1497,7 +1497,7 @@ PODS:
     - React-logger (= 0.75.2)
     - React-perflogger (= 0.75.2)
     - React-utils (= 0.75.2)
-  - RNLiveMarkdown (0.1.143):
+  - RNLiveMarkdown (0.1.160):
     - DoubleConversion
     - glog
     - hermes-engine
@@ -1517,9 +1517,9 @@ PODS:
     - ReactCodegen
     - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
-    - RNLiveMarkdown/common (= 0.1.143)
+    - RNLiveMarkdown/newarch (= 0.1.160)
     - Yoga
-  - RNLiveMarkdown/common (0.1.143):
+  - RNLiveMarkdown/newarch (0.1.160):
     - DoubleConversion
     - glog
     - hermes-engine
@@ -1805,7 +1805,7 @@ SPEC CHECKSUMS:
   React-utils: 81a715d9c0a2a49047e77a86f3a2247408540deb
   ReactCodegen: 60973d382704c793c605b9be0fc7f31cb279442f
   ReactCommon: 6ef348087d250257c44c0204461c03f036650e9b
-  RNLiveMarkdown: e44918843c2638692348f39eafc275698baf0444
+  RNLiveMarkdown: 201e1457f83d07376ae08c918c8ad14e3078d5a0
   SocketRocket: abac6f5de4d4d62d24e11868d7a2f427e0ef940d
   Yoga: 2a45d7e59592db061217551fd3bbe2dd993817ae
 


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Details

This PR removes the following ifdefs in `cpp/react/renderer/components/RNLiveMarkdownSpec/*.{cpp,h}` files:

```diff
-#if defined(RCT_NEW_ARCH_ENABLED) || defined(ANDROID)
```

The workaround with `|| defined(ANDROID)` was necessary because `RCT_NEW_ARCH_ENABLED` was not set when compiling autogenerated `autolinking.cpp` from `appmodules` target and there's no easy way to set additional flags.

Theoretically, we could add `#define RCT_NEW_ARCH_ENABLED 1` at the beginning of `RNLiveMarkdownSpec.h` but this solution seems a bit unstable.

Instead, all files in `cpp/react/renderer/components/` will be compiled conditionally based on whether the New Architecture is enabled or not.

On Android, there's a separate `CMakeLists.txt` in `android/src/main/new_arch`.

On iOS, there's a separate `newarch` subspec (previously named `common`).

### Related Issues
<!-- Please replace GH_LINK with the link to the GitHub issue this Pull Request is related to -->
GH_LINK

### Manual Tests
<!---
Most changes should have accompanying tests. Describe the tests you added or if no tests were added an explanation about why one was not needed.
--->

### Linked PRs
<!---
Please include links to any update PRs in repos that must change their package.json version.
--->