### PR TITLE
Fix deprecated API usage in `MarkdownFontFamilySpan`

### DIFF
--- a/android/src/main/java/com/expensify/livemarkdown/MarkdownFontFamilySpan.java
+++ b/android/src/main/java/com/expensify/livemarkdown/MarkdownFontFamilySpan.java
@@ -8,8 +8,7 @@ import android.text.style.MetricAffectingSpan;
 
 import androidx.annotation.NonNull;
 
-import com.facebook.react.common.assets.ReactFontManager.TypefaceStyle;
-import com.facebook.react.views.text.ReactFontManager;
+import com.facebook.react.common.assets.ReactFontManager;
 
 public class MarkdownFontFamilySpan extends MetricAffectingSpan implements MarkdownSpan {
 
@@ -32,12 +31,7 @@ public class MarkdownFontFamilySpan extends MetricAffectingSpan implements Markd
   }
 
   private void apply(@NonNull TextPaint textPaint) {
-    int style = TypefaceStyle.NORMAL;
-    if (textPaint.getTypeface() != null) {
-      style = textPaint.getTypeface().getStyle();
-    } else {
-      style = TypefaceStyle.NORMAL;
-    }
+    int style = textPaint.getTypeface() != null ? textPaint.getTypeface().getStyle() : ReactFontManager.TypefaceStyle.NORMAL;
     Typeface typeface = ReactFontManager.getInstance().getTypeface(mFontFamily, style, mAssetManager);
     textPaint.setTypeface(typeface);
     textPaint.setFlags(textPaint.getFlags() | Paint.SUBPIXEL_TEXT_FLAG);


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Details
This PR removes depreecated API usage in MarkdownFontFamilySpan.java caused by using deprecated class `ReactFontManager` from `com.facebook.react.views.text` package instead of `com.facebook.react.common.assets`.

See https://github.com/facebook/react-native/pull/38506 for more details.

```diff
-import com.facebook.react.views.text.ReactFontManager;
+import com.facebook.react.common.assets.ReactFontManager;
```

### Related Issues
<!-- Please replace GH_LINK with the link to the GitHub issue this Pull Request is related to -->
GH_LINK

### Manual Tests
<!---
Most changes should have accompanying tests. Describe the tests you added or if no tests were added an explanation about why one was not needed.
--->

### Linked PRs
<!---
Please include links to any update PRs in repos that must change their package.json version.
--->