### PR TITLE
Fix scrolling lines into view

### DIFF
--- a/src/web/utils/cursorUtils.ts
+++ b/src/web/utils/cursorUtils.ts
@@ -58,16 +58,12 @@ function scrollIntoView(target: MarkdownTextInputElement, node: TreeNode) {
   const currentLine = target.tree.childNodes[orderIndex]?.element;
   const scrollTargetElement = currentLine || node.element;
 
-  const selection = window.getSelection();
-  if (selection && selection.rangeCount > 0) {
-    const caretRect = scrollTargetElement.getBoundingClientRect();
-    const targetRect = target.getBoundingClientRect();
-
-    // In case the caret is below the visible input area, scroll to the end of the node
-    if (caretRect.top + caretRect.height > targetRect.top + targetRect.height) {
-      targetElement.scrollTop = caretRect.top - targetRect.top + target.scrollTop - targetRect.height + caretRect.height + 4;
-      return;
-    }
+  const caretRect = scrollTargetElement.getBoundingClientRect();
+  const targetRect = target.getBoundingClientRect();
+  // In case the caret is below the visible input area, scroll to the end of the node
+  if (caretRect.top + caretRect.height > targetRect.top + targetRect.height) {
+    targetElement.scrollTop = caretRect.top - targetRect.top + target.scrollTop - targetRect.height + caretRect.height + 4;
+    return;
   }
 
   scrollTargetElement.scrollIntoView({

--- a/src/web/utils/cursorUtils.ts
+++ b/src/web/utils/cursorUtils.ts
@@ -54,28 +54,25 @@ function setCursorPosition(target: MarkdownTextInputElement, startIndex: number,
 
 function scrollIntoView(target: MarkdownTextInputElement, node: TreeNode) {
   const targetElement = target;
-  if (node.type === 'br' && node.parentNode?.parentNode?.type === 'line') {
-    // If the node is a line break, scroll to the parent paragraph, because Safari doesn't support scrollIntoView on br elements
-    node.parentNode.parentNode.element.scrollIntoView({
-      block: 'nearest',
-    });
-  } else {
-    const selection = window.getSelection();
-    if (selection && selection.rangeCount > 0) {
-      const range = selection.getRangeAt(0);
-      const caretRect = range.getBoundingClientRect();
-      const targetRect = target.getBoundingClientRect();
+  const orderIndex = Number(node.orderIndex.split(',')[0]);
+  const currentLine = target.tree.childNodes[orderIndex]?.element;
+  const scrollTargetElement = currentLine || node.element;
 
-      // In case the caret is below the visible input area, scroll to the end of the node
-      if (caretRect.top + caretRect.height > targetRect.top + targetRect.height) {
-        targetElement.scrollTop = caretRect.top + caretRect.height - targetRect.top - targetRect.height + target.scrollTop;
-      }
+  const selection = window.getSelection();
+  if (selection && selection.rangeCount > 0) {
+    const caretRect = scrollTargetElement.getBoundingClientRect();
+    const targetRect = target.getBoundingClientRect();
+
+    // In case the caret is below the visible input area, scroll to the end of the node
+    if (caretRect.top + caretRect.height > targetRect.top + targetRect.height) {
+      targetElement.scrollTop = caretRect.top - targetRect.top + target.scrollTop - targetRect.height + caretRect.height + 4;
+      return;
     }
-
-    node.element.scrollIntoView({
-      block: 'nearest',
-    });
   }
+
+  scrollTargetElement.scrollIntoView({
+    block: 'nearest',
+  });
 }
 
 function moveCursorToEnd(target: HTMLElement) {


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Details
<!-- Explanation of the change or anything fishy that is going on -->
THis PR fixies the problem with scrolling elements into view.It changes the logic to now scroll the whole line into view instead of just a child element 
### Related Issues
<!-- Please replace GH_LINK with the link to the GitHub issue this Pull Request is related to -->
https://github.com/Expensify/App/issues/50174

### Manual Tests
<!---
Most changes should have accompanying tests. Describe the tests you added or if no tests were added an explanation about why one was not needed.
--->
1. Add a height limit to the input inside the example app to make the component scrollable
2. Clear the input
3. Add newlines so the scroll bar appears on the side of the input
4. Paste emoji 
5. Verify if the emoji is fully visible

### Linked PRs
<!---
Please include links to any updated PRs in repos that must change their package.json version.
--->