### PR TITLE
Fix inline images flickering

### DIFF
--- a/src/MarkdownTextInput.web.tsx
+++ b/src/MarkdownTextInput.web.tsx
@@ -61,6 +61,7 @@ type MarkdownTextInputElement = HTMLDivElement &
   HTMLInputElement & {
     tree: TreeNode;
     selection: Selection;
+    imageElements: HTMLImageElement[];
   };
 
 type HTMLMarkdownElement = HTMLElement & {

--- a/src/web/inputElements/inlineImage.ts
+++ b/src/web/inputElements/inlineImage.ts
@@ -75,10 +75,16 @@ function handleOnLoad(
       justifyContent: 'center',
     }),
   });
-
   Object.assign(img.style, !err && imgStyle);
 
   targetElement.appendChild(imageContainer);
+
+  const currentInputElement = currentInput;
+  if (currentInput.imageElements) {
+    currentInputElement.imageElements.push(img);
+  } else {
+    currentInputElement.imageElements = [img];
+  }
 
   const imageClientHeight = Math.max(img.clientHeight, imageContainer.clientHeight);
   Object.assign(imageContainer.style, {
@@ -164,7 +170,7 @@ function addInlineImagePreview(
 
   // If the inline image markdown with the same href exists in the current input, use it instead of creating new one.
   // Prevents from image flickering and layout jumps
-  const alreadyLoadedPreview = currentInput.querySelector(`img[src="${imageHref}"]`);
+  const alreadyLoadedPreview = currentInput.imageElements?.find((el) => el?.src === imageHref);
   const loadedImageContainer = alreadyLoadedPreview?.parentElement;
 
   if (loadedImageContainer && loadedImageContainer.getAttribute('data-type') === 'inline-container') {


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Details
<!-- Explanation of the change or anything fishy that is going on -->
This PR fixes the inline image flickering bug, when removing the line after it


https://github.com/user-attachments/assets/4e5828b8-e501-496c-aa15-a19fcaae9c6b



### Related Issues
<!-- Please replace GH_LINK with the link to the GitHub issue this Pull Request is related to -->
https://github.com/Expensify/App/pull/50047

### Manual Tests
<!---
Most changes should have accompanying tests. Describe the tests you added or if no tests were added an explanation about why one was not needed.
--->
1. Open an example app
2. Add a new line after the image
3. Hit backspace
4. Verify if the image didn't flicker

### Linked PRs
<!---
Please include links to any update PRs in repos that must change their package.json version.
--->
