### PR TITLE
Improve removing spans on Android

### DIFF
--- a/android/src/main/java/com/expensify/livemarkdown/MarkdownUtils.java
+++ b/android/src/main/java/com/expensify/livemarkdown/MarkdownUtils.java
@@ -16,6 +16,7 @@ import org.json.JSONObject;
 
 import java.io.IOException;
 import java.io.InputStream;
+import java.util.ArrayList;
 import java.util.Objects;
 
 public class MarkdownUtils {
@@ -61,6 +62,8 @@ public class MarkdownUtils {
   private String mPrevOutput;
 
   private MarkdownStyle mMarkdownStyle;
+
+  private final ArrayList<MarkdownSpan> mMarkdownSpans = new ArrayList<>();
 
   public void setMarkdownStyle(@NonNull MarkdownStyle markdownStyle) {
     mMarkdownStyle = markdownStyle;
@@ -170,13 +173,14 @@ public class MarkdownUtils {
 
   private void setSpan(SpannableStringBuilder ssb, MarkdownSpan span, int start, int end) {
     ssb.setSpan(span, start, end, Spanned.SPAN_EXCLUSIVE_EXCLUSIVE);
+    mMarkdownSpans.add(span);
   }
 
   private void removeSpans(SpannableStringBuilder ssb) {
-    // We shouldn't use `removeSpans()` because it also removes SpellcheckSpan, SuggestionSpan etc.
-    MarkdownSpan[] spans = ssb.getSpans(0, ssb.length(), MarkdownSpan.class);
-    for (MarkdownSpan span : spans) {
+    // We shouldn't use `ssb.removeSpans()` because it also removes SpellcheckSpan, SuggestionSpan etc.
+    for (MarkdownSpan span : mMarkdownSpans) {
       ssb.removeSpan(span);
     }
+    mMarkdownSpans.clear();
   }
 }


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Details
<!-- Explanation of the change or anything fishy that is going on -->
This PR changes the way how spans are removed before applying new formatting.

Previously, we would call `ssb.getSpans(0, ssb.length(), MarkdownSpan.class);` to find all span added in the previous run. All added spans implement `MarkdownSpan` interface.

After this change, each time we add a span, we add it to `mMarkdownSpans` list (`ArrayList`). Then, we iterate over that list to remove all previously added spans and clear the list afterwards.

TODO: test performance

### Related Issues
<!-- Please replace GH_LINK with the link to the GitHub issue this Pull Request is related to -->
GH_LINK

### Manual Tests
<!---
Most changes should have accompanying tests. Describe the tests you added or if no tests were added an explanation about why one was not needed.
--->

### Linked PRs
<!---
Please include links to any update PRs in repos that must change their package.json version.
--->