### PR TITLE
Fix emoji font size measurement on Android

### DIFF
--- a/android/src/main/java/com/expensify/livemarkdown/spans/MarkdownEmojiSpan.java
+++ b/android/src/main/java/com/expensify/livemarkdown/spans/MarkdownEmojiSpan.java
@@ -2,8 +2,10 @@ package com.expensify.livemarkdown.spans;
 
 import android.text.style.AbsoluteSizeSpan;
 
+import com.facebook.react.uimanager.PixelUtil;
+
 public class MarkdownEmojiSpan extends AbsoluteSizeSpan implements MarkdownSpan {
   public MarkdownEmojiSpan(float fontSize) {
-    super((int) fontSize, true);
+    super((int) PixelUtil.toPixelFromDIP(fontSize), false);
   }
 }


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Details
<!-- Explanation of the change or anything fishy that is going on -->
This fixes the issue on Android that the measured emoji height doesn't match the actual height. It updates `MarkdownEmojiSpan` to apply the same unit conversion as used in `MarkdownFontSizeSpan`.

https://github.com/Expensify/react-native-live-markdown/blob/c282f64b11e8c8ea331add7a7d35d3cb57e450e0/android/src/main/java/com/expensify/livemarkdown/spans/MarkdownFontSizeSpan.java#L9

### Related Issues
<!-- Please replace GH_LINK with the link to the GitHub issue this Pull Request is related to -->
https://github.com/Expensify/App/issues/51287
Proposal: https://github.com/Expensify/App/issues/51287#issuecomment-2452955435

### Manual Tests
<!---
Most changes should have accompanying tests. Describe the tests you added or if no tests were added an explanation about why one was not needed.
--->

1. Build and run the Android example app.
2. Clear the text and insert three emojis 😀🍕🍔.
3. Verify that the emojis display completely.
4. Click Toggle emoji font size.
5. Verify that the emojis still display completely.

#### Screenshots

Before | After
-- | --
<img alt="Before" src="https://github.com/user-attachments/assets/ad335a52-d08f-4480-ba1d-95b8aaefaf5b" /> | <img alt="After" src="https://github.com/user-attachments/assets/27d4f0f8-1827-42a5-b7dd-c0a9a24b950f" />