### PR TITLE
@jpiasecki/memoize utils commit hook

### DIFF
--- a/apple/MarkdownCommitHook.h
+++ b/apple/MarkdownCommitHook.h
@@ -36,8 +36,10 @@ public:
       RootShadowNode::Unshared const &newRootShadowNode) noexcept override;
 
 private:
-  static RCTMarkdownUtils* getMarkdownUtils(const MarkdownTextInputDecoratorShadowNode& decorator);
-  static RCTMarkdownUtils* getOrCreateMarkdownUtils(const MarkdownTextInputDecoratorShadowNode& decorator);
+  static RCTMarkdownUtils *
+  getMarkdownUtils(const MarkdownTextInputDecoratorShadowNode &decorator);
+  static RCTMarkdownUtils *getOrCreateMarkdownUtils(
+      const MarkdownTextInputDecoratorShadowNode &decorator);
   const std::shared_ptr<UIManager> uiManager_;
 };
 

--- a/apple/MarkdownCommitHook.h
+++ b/apple/MarkdownCommitHook.h
@@ -8,6 +8,7 @@
 #include <memory>
 
 #include "MarkdownTextInputDecoratorShadowNode.h"
+#include "RCTMarkdownUtils.h"
 
 using namespace facebook::react;
 
@@ -35,6 +36,8 @@ public:
       RootShadowNode::Unshared const &newRootShadowNode) noexcept override;
 
 private:
+  static RCTMarkdownUtils* getMarkdownUtils(const MarkdownTextInputDecoratorShadowNode& decorator);
+  static RCTMarkdownUtils* getOrCreateMarkdownUtils(const MarkdownTextInputDecoratorShadowNode& decorator);
   const std::shared_ptr<UIManager> uiManager_;
 };
 

--- a/apple/MarkdownCommitHook.mm
+++ b/apple/MarkdownCommitHook.mm
@@ -24,20 +24,25 @@ MarkdownCommitHook::~MarkdownCommitHook() noexcept {
   uiManager_->unregisterCommitHook(*this);
 }
 
-RCTMarkdownUtils* MarkdownCommitHook::getMarkdownUtils(const MarkdownTextInputDecoratorShadowNode &decorator) {
-    const auto decoratorState = std::static_pointer_cast<const ConcreteState<MarkdownTextInputDecoratorState>>(decorator.getState());
-    const auto memoizedUtils = (RCTMarkdownUtils*)unwrapManagedObject(decoratorState->getData().markdownUtils);
-    return memoizedUtils;
+RCTMarkdownUtils *MarkdownCommitHook::getMarkdownUtils(
+    const MarkdownTextInputDecoratorShadowNode &decorator) {
+  const auto decoratorState = std::static_pointer_cast<
+      const ConcreteState<MarkdownTextInputDecoratorState>>(
+      decorator.getState());
+  const auto memoizedUtils = (RCTMarkdownUtils *)unwrapManagedObject(
+      decoratorState->getData().markdownUtils);
+  return memoizedUtils;
 }
 
-RCTMarkdownUtils* MarkdownCommitHook::getOrCreateMarkdownUtils(const MarkdownTextInputDecoratorShadowNode &decorator) {
-    const auto memoizedUtils = MarkdownCommitHook::getMarkdownUtils(decorator);
-    
-    if (memoizedUtils != nullptr) {
-        return memoizedUtils;
-    } else {
-        return [[RCTMarkdownUtils alloc] init];
-    }
+RCTMarkdownUtils *MarkdownCommitHook::getOrCreateMarkdownUtils(
+    const MarkdownTextInputDecoratorShadowNode &decorator) {
+  const auto memoizedUtils = MarkdownCommitHook::getMarkdownUtils(decorator);
+
+  if (memoizedUtils != nullptr) {
+    return memoizedUtils;
+  } else {
+    return [[RCTMarkdownUtils alloc] init];
+  }
 }
 
 RootShadowNode::Unshared MarkdownCommitHook::shadowTreeWillCommit(
@@ -110,8 +115,8 @@ RootShadowNode::Unshared MarkdownCommitHook::shadowTreeWillCommit(
     const auto fontSizeMultiplier =
         newRootShadowNode->getConcreteProps().layoutContext.fontSizeMultiplier;
 
-    RCTMarkdownUtils* usedUtils = nil;
-      
+    RCTMarkdownUtils *usedUtils = nil;
+
     // We only want to update the shadow node when the attributed string is
     // stored by value If it's stored by pointer, the markdown formatting should
     // already by applied to it, since the only source of that pointer (besides
@@ -150,7 +155,8 @@ RootShadowNode::Unshared MarkdownCommitHook::shadowTreeWillCommit(
             // this can possibly be optimized
             RCTMarkdownStyle *markdownStyle = [[RCTMarkdownStyle alloc]
                 initWithStruct:markdownProps.markdownStyle];
-            usedUtils = MarkdownCommitHook::getOrCreateMarkdownUtils(*nodes.decorator);
+            usedUtils =
+                MarkdownCommitHook::getOrCreateMarkdownUtils(*nodes.decorator);
             [usedUtils setMarkdownStyle:markdownStyle];
 
             // convert the attibuted string stored in state to
@@ -160,14 +166,15 @@ RootShadowNode::Unshared MarkdownCommitHook::shadowTreeWillCommit(
                     stateData.attributedStringBox);
 
             // Handles the first render, where the text stored in props is
-            // different than the one stored in state. The one in state is empty,
-            // while the one in props is passed from JS. If we don't update the
-            // state here, we'll end up with a one-default-line-sized text input
+            // different than the one stored in state. The one in state is
+            // empty, while the one in props is passed from JS. If we don't
+            // update the state here, we'll end up with a one-default-line-sized
+            // text input
             if (textInputState.getRevision() == State::initialRevisionValue) {
-                auto plainStringFromState =
-                    std::string([[nsAttributedString string] UTF8String]);
+              auto plainStringFromState =
+                  std::string([[nsAttributedString string] UTF8String]);
 
-                if (plainStringFromState != textInputProps.text) {
+              if (plainStringFromState != textInputProps.text) {
                 // creates new AttributedString from props, adapted from
                 // TextInputShadowNode (ios one, text inputs are
                 // platform-specific)
@@ -182,14 +189,15 @@ RootShadowNode::Unshared MarkdownCommitHook::shadowTreeWillCommit(
 
                 // convert the newly created attributed string to
                 // NSAttributedString
-                nsAttributedString = RCTNSAttributedStringFromAttributedStringBox(
-                    AttributedStringBox{attributedString});
-                }
+                nsAttributedString =
+                    RCTNSAttributedStringFromAttributedStringBox(
+                        AttributedStringBox{attributedString});
+              }
             }
 
             // apply markdown
             auto newString = [usedUtils parseMarkdown:nsAttributedString
-                                   withAttributes:defaultNSTextAttributes];
+                                       withAttributes:defaultNSTextAttributes];
 
             // create a clone of the old TextInputState and update the
             // attributed string box to point to the string with markdown
@@ -205,7 +213,7 @@ RootShadowNode::Unshared MarkdownCommitHook::shadowTreeWillCommit(
             });
           });
     } else if (stateData.attributedStringBox.getMode() ==
-            AttributedStringBox::Mode::OpaquePointer) {
+               AttributedStringBox::Mode::OpaquePointer) {
       rootNode = rootNode->cloneTree(
           nodes.textInput->getFamily(),
           [&nodes, &textInputState, &stateData, &usedUtils,
@@ -225,7 +233,8 @@ RootShadowNode::Unshared MarkdownCommitHook::shadowTreeWillCommit(
             // this can possibly be optimized
             RCTMarkdownStyle *markdownStyle = [[RCTMarkdownStyle alloc]
                 initWithStruct:markdownProps.markdownStyle];
-            usedUtils = MarkdownCommitHook::getOrCreateMarkdownUtils(*nodes.decorator);
+            usedUtils =
+                MarkdownCommitHook::getOrCreateMarkdownUtils(*nodes.decorator);
             [usedUtils setMarkdownStyle:markdownStyle];
 
             // convert the attibuted string stored in state to
@@ -236,7 +245,7 @@ RootShadowNode::Unshared MarkdownCommitHook::shadowTreeWillCommit(
 
             // apply markdown
             auto newString = [usedUtils parseMarkdown:nsAttributedString
-                                   withAttributes:defaultNSTextAttributes];
+                                       withAttributes:defaultNSTextAttributes];
 
             // create a clone of the old TextInputState and update the
             // attributed string box to point to the string with markdown
@@ -252,24 +261,39 @@ RootShadowNode::Unshared MarkdownCommitHook::shadowTreeWillCommit(
             });
           });
     }
-      
-      // if usedUtils is not nil, then we did some work on the TextInput ShadowNode, we may need to update the decorator as well
-      if (usedUtils != nil) {
-          const auto ancestors = nodes.decorator->getFamily().getAncestors(*rootNode);
-          const auto parentInfo = ancestors.back();
-          const auto decoratorNode = std::static_pointer_cast<const MarkdownTextInputDecoratorShadowNode>(parentInfo.first.get().getChildren().at(parentInfo.second));
 
-          // if usedUtils is defferent from the one kept in the decorator state, it needs to be updated to ensure memoization works correctly
-          if (usedUtils != MarkdownCommitHook::getMarkdownUtils(*decoratorNode)) {
-              const auto olddecoratorState = *std::static_pointer_cast<const ConcreteState<MarkdownTextInputDecoratorState>>(decoratorNode->getState());
-              const auto newDecoratorState = std::make_shared<const MarkdownTextInputDecoratorState>(olddecoratorState.getData().decoratorFamily, wrapManagedObject(usedUtils));
-              const auto newDecoratorNode = decoratorNode->clone({.state = std::make_shared<const ConcreteState<MarkdownTextInputDecoratorState>>(newDecoratorState, olddecoratorState)});
-              
-              // since we did clone the path to the text input, parent node is mutable at this point - no need to clone the entire path
-              const auto mutableParent = const_cast<ShadowNode*>(&parentInfo.first.get());
-              mutableParent->replaceChild(*decoratorNode, newDecoratorNode);
-          }
+    // if usedUtils is not nil, then we did some work on the TextInput
+    // ShadowNode, we may need to update the decorator as well
+    if (usedUtils != nil) {
+      const auto ancestors =
+          nodes.decorator->getFamily().getAncestors(*rootNode);
+      const auto parentInfo = ancestors.back();
+      const auto decoratorNode =
+          std::static_pointer_cast<const MarkdownTextInputDecoratorShadowNode>(
+              parentInfo.first.get().getChildren().at(parentInfo.second));
+
+      // if usedUtils is defferent from the one kept in the decorator state, it
+      // needs to be updated to ensure memoization works correctly
+      if (usedUtils != MarkdownCommitHook::getMarkdownUtils(*decoratorNode)) {
+        const auto olddecoratorState = *std::static_pointer_cast<
+            const ConcreteState<MarkdownTextInputDecoratorState>>(
+            decoratorNode->getState());
+        const auto newDecoratorState =
+            std::make_shared<const MarkdownTextInputDecoratorState>(
+                olddecoratorState.getData().decoratorFamily,
+                wrapManagedObject(usedUtils));
+        const auto newDecoratorNode = decoratorNode->clone(
+            {.state = std::make_shared<
+                 const ConcreteState<MarkdownTextInputDecoratorState>>(
+                 newDecoratorState, olddecoratorState)});
+
+        // since we did clone the path to the text input, parent node is mutable
+        // at this point - no need to clone the entire path
+        const auto mutableParent =
+            const_cast<ShadowNode *>(&parentInfo.first.get());
+        mutableParent->replaceChild(*decoratorNode, newDecoratorNode);
       }
+    }
   }
 
   return std::static_pointer_cast<RootShadowNode>(rootNode);

--- a/cpp/react/renderer/components/RNLiveMarkdownSpec/MarkdownTextInputDecoratorState.h
+++ b/cpp/react/renderer/components/RNLiveMarkdownSpec/MarkdownTextInputDecoratorState.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <memory>
 #include <react/renderer/core/ShadowNodeFamily.h>
 
 namespace facebook {
@@ -9,18 +10,25 @@ class JSI_EXPORT MarkdownTextInputDecoratorState final {
 public:
   using Shared = std::shared_ptr<const MarkdownTextInputDecoratorState>;
 
-  MarkdownTextInputDecoratorState() : decoratorFamily(nullptr){};
+  MarkdownTextInputDecoratorState() : decoratorFamily(nullptr), markdownUtils(nullptr){};
   MarkdownTextInputDecoratorState(
       const ShadowNodeFamily::Shared textInputFamily_)
-      : decoratorFamily(textInputFamily_){};
+      : decoratorFamily(textInputFamily_),
+        markdownUtils(nullptr){};
+  MarkdownTextInputDecoratorState(
+      const ShadowNodeFamily::Shared textInputFamily_,
+      const std::shared_ptr<void> markdownUtils_)
+      : decoratorFamily(textInputFamily_),
+        markdownUtils(markdownUtils_){};
 
 #ifdef ANDROID
   MarkdownTextInputDecoratorState(
       MarkdownTextInputDecoratorState const &previousState, folly::dynamic data)
-      : decoratorFamily(previousState.decoratorFamily){};
+      : decoratorFamily(previousState.decoratorFamily), markdownUtils(nullptr){};
 #endif
 
   const ShadowNodeFamily::Shared decoratorFamily;
+  const std::shared_ptr<void> markdownUtils;
 
 #ifdef ANDROID
   folly::dynamic getDynamic() const {

--- a/cpp/react/renderer/components/RNLiveMarkdownSpec/MarkdownTextInputDecoratorState.h
+++ b/cpp/react/renderer/components/RNLiveMarkdownSpec/MarkdownTextInputDecoratorState.h
@@ -10,21 +10,21 @@ class JSI_EXPORT MarkdownTextInputDecoratorState final {
 public:
   using Shared = std::shared_ptr<const MarkdownTextInputDecoratorState>;
 
-  MarkdownTextInputDecoratorState() : decoratorFamily(nullptr), markdownUtils(nullptr){};
+  MarkdownTextInputDecoratorState()
+      : decoratorFamily(nullptr), markdownUtils(nullptr){};
   MarkdownTextInputDecoratorState(
       const ShadowNodeFamily::Shared textInputFamily_)
-      : decoratorFamily(textInputFamily_),
-        markdownUtils(nullptr){};
+      : decoratorFamily(textInputFamily_), markdownUtils(nullptr){};
   MarkdownTextInputDecoratorState(
       const ShadowNodeFamily::Shared textInputFamily_,
       const std::shared_ptr<void> markdownUtils_)
-      : decoratorFamily(textInputFamily_),
-        markdownUtils(markdownUtils_){};
+      : decoratorFamily(textInputFamily_), markdownUtils(markdownUtils_){};
 
 #ifdef ANDROID
   MarkdownTextInputDecoratorState(
       MarkdownTextInputDecoratorState const &previousState, folly::dynamic data)
-      : decoratorFamily(previousState.decoratorFamily), markdownUtils(nullptr){};
+      : decoratorFamily(previousState.decoratorFamily),
+        markdownUtils(nullptr){};
 #endif
 
   const ShadowNodeFamily::Shared decoratorFamily;


### PR DESCRIPTION
### Details
Instead of creating `RCTMarkdownUtils` every time the commit hook is run, memoize it in the state of the decorator shadow node. We can accomplish that by cloning the decorator node after the text input node is cloned. This way, we can clone the decorator in-place since the parent would be mutable at that point in time.

### Manual Tests
Verify that the library still works and isn't flickering on the new architecture