### PR TITLE
Introduce `MarkdownRange` class on iOS

### DIFF
--- a/apple/MarkdownRange.h
+++ b/apple/MarkdownRange.h
@@ -1,0 +1,15 @@
+#import <Foundation/Foundation.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface MarkdownRange : NSObject
+
+@property (nonatomic, strong) NSString *type;
+@property (nonatomic) NSRange range;
+@property (nonatomic) NSUInteger depth;
+
+- (instancetype)initWithType:(NSString *)type range:(NSRange)range depth:(NSUInteger)depth;
+
+NS_ASSUME_NONNULL_END
+
+@end

--- a/apple/MarkdownRange.mm
+++ b/apple/MarkdownRange.mm
@@ -1,0 +1,15 @@
+#import "MarkdownRange.h"
+
+@implementation MarkdownRange
+
+- (instancetype)initWithType:(NSString *)type range:(NSRange)range depth:(NSUInteger)depth {
+    self = [super init];
+    if (self) {
+        _type = type;
+        _range = range;
+        _depth = depth;
+    }
+    return self;
+}
+
+@end

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -1497,7 +1497,7 @@ PODS:
     - React-logger (= 0.75.3)
     - React-perflogger (= 0.75.3)
     - React-utils (= 0.75.3)
-  - RNLiveMarkdown (0.1.187):
+  - RNLiveMarkdown (0.1.188):
     - DoubleConversion
     - glog
     - hermes-engine
@@ -1517,10 +1517,10 @@ PODS:
     - ReactCodegen
     - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
-    - RNLiveMarkdown/newarch (= 0.1.187)
+    - RNLiveMarkdown/newarch (= 0.1.188)
     - RNReanimated/worklets
     - Yoga
-  - RNLiveMarkdown/newarch (0.1.187):
+  - RNLiveMarkdown/newarch (0.1.188):
     - DoubleConversion
     - glog
     - hermes-engine
@@ -1897,7 +1897,7 @@ SPEC CHECKSUMS:
   React-utils: f2afa6acd905ca2ce7bb8ffb4a22f7f8a12534e8
   ReactCodegen: e35c23cdd36922f6d2990c6c1f1b022ade7ad74d
   ReactCommon: 289214026502e6a93484f4a46bcc0efa4f3f2864
-  RNLiveMarkdown: ab4c8425068c97fa7cca6bbf376ed1d83e0df166
+  RNLiveMarkdown: c0d3ebfa32b4a6a33f1dbfc76ab9a06e516bfb1a
   RNReanimated: ab6c33a61e90c4cbe5dbcbe65bd6c7cb3be167e6
   SocketRocket: abac6f5de4d4d62d24e11868d7a2f427e0ef940d
   Yoga: 1354c027ab07c7736f99a3bef16172d6f1b12b47


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Details
This PR adds an intermediate step in formatting `NSAttributedString` on iOS. Instead of using `jsi::Value` from parser directly, first we populate `markdownRanges` array consisting of `MarkdownRange` objects. Then, we call `applyRangeToAttributedString` while iterating over the array.

The main benefit is that now we can memoize the parser output on the native side since holding `jsi::Value` is not recommended. It will also make it simpler to split the implementation into smaller parts.

### Related Issues
<!-- Please replace GH_LINK with the link to the GitHub issue this Pull Request is related to -->
GH_LINK

### Manual Tests
<!---
Most changes should have accompanying tests. Describe the tests you added or if no tests were added an explanation about why one was not needed.
--->

### Linked PRs
<!---
Please include links to any update PRs in repos that must change their package.json version.
--->