### PR TITLE
bump expensify-common to 2.0.108

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ npm install @expensify/react-native-live-markdown react-native-reanimated expens
 npx expo install @expensify/react-native-live-markdown react-native-reanimated expensify-common
 ```
 
-React Native Live Markdown requires [react-native-reanimated](https://github.com/software-mansion/react-native-reanimated) 3.16.3 or newer and [expensify-common](https://github.com/Expensify/expensify-common) 2.0.106 or newer.
+React Native Live Markdown requires [react-native-reanimated](https://github.com/software-mansion/react-native-reanimated) 3.16.3 or newer and [expensify-common](https://github.com/Expensify/expensify-common) 2.0.108 or newer.
 
 Then, install the iOS dependencies with CocoaPods:
 

--- a/example/package.json
+++ b/example/package.json
@@ -9,7 +9,7 @@
     "start": "react-native start"
   },
   "dependencies": {
-    "expensify-common": "2.0.106",
+    "expensify-common": "2.0.108",
     "react": "18.3.1",
     "react-native": "0.75.3",
     "react-native-reanimated": "3.16.3"

--- a/package-lock.json
+++ b/package-lock.json
@@ -39,7 +39,7 @@
         "eslint-plugin-prettier": "^4.0.0",
         "eslint-plugin-promise": "^6.1.1",
         "eslint-plugin-tsdoc": "^0.2.17",
-        "expensify-common": "2.0.106",
+        "expensify-common": "2.0.108",
         "jest": "^29.6.3",
         "jest-environment-jsdom": "^29.7.0",
         "nodemon": "^3.1.3",
@@ -58,7 +58,7 @@
         "node": ">= 18.0.0"
       },
       "peerDependencies": {
-        "expensify-common": ">=2.0.106",
+        "expensify-common": ">=2.0.108",
         "react": "*",
         "react-native": "*",
         "react-native-reanimated": ">=3.16.3"
@@ -68,7 +68,7 @@
       "name": "@expensify/react-native-live-markdown-example",
       "version": "0.0.1",
       "dependencies": {
-        "expensify-common": "2.0.106",
+        "expensify-common": "2.0.108",
         "react": "18.3.1",
         "react-native": "0.75.3",
         "react-native-reanimated": "3.16.3"
@@ -14461,9 +14461,10 @@
       }
     },
     "node_modules/expensify-common": {
-      "version": "2.0.106",
-      "resolved": "https://registry.npmjs.org/expensify-common/-/expensify-common-2.0.106.tgz",
-      "integrity": "sha512-KmxKvglbIUJb0sAcmNxb/AXYAqa3GIZfu3MbmtlYDNJx24mjDjtbGkKhm+16TICDoPj2PDRNogIqgUGWmSSZFQ==",
+      "version": "2.0.108",
+      "resolved": "https://registry.npmjs.org/expensify-common/-/expensify-common-2.0.108.tgz",
+      "integrity": "sha512-q4chHq1dxHJP/5CRTmTiIRrQKZik0Ms2yM6kjCMlCuJT/3aTlFOHCChb24TB/7TgjbSw0utj1cnFhRDfL87RWg==",
+      "license": "MIT",
       "dependencies": {
         "awesome-phonenumber": "^5.4.0",
         "classnames": "2.5.0",

--- a/package.json
+++ b/package.json
@@ -84,7 +84,7 @@
     "eslint-plugin-prettier": "^4.0.0",
     "eslint-plugin-promise": "^6.1.1",
     "eslint-plugin-tsdoc": "^0.2.17",
-    "expensify-common": "2.0.106",
+    "expensify-common": "2.0.108",
     "jest": "^29.6.3",
     "jest-environment-jsdom": "^29.7.0",
     "nodemon": "^3.1.3",
@@ -100,7 +100,7 @@
     "typescript": "~5.3.3"
   },
   "peerDependencies": {
-    "expensify-common": ">=2.0.106",
+    "expensify-common": ">=2.0.108",
     "react": "*",
     "react-native": "*",
     "react-native-reanimated": ">=3.16.3"


### PR DESCRIPTION
cc @dangrous @ntdiary 

### Details
bump expensify-common to 2.0.108 to include a more performant regex https://github.com/Expensify/expensify-common/pull/822

### Related Issues
<!-- Please replace GH_LINK with the link to the GitHub issue this Pull Request is related to -->
https://github.com/Expensify/App/issues/52475

### Manual Tests
1. Type `![test](https://camo.githubusercontent.com/4848d0f965f332077b77a1a0488c3e66b4769032104f4de6890bae218b4add8d/68747470733a2f2f70696373756d2e70686f746f732f69642f313036372f3230302f333030 )_test`
3. Verify the app doesn't crash

### Linked PRs
<!---
Please include links to any update PRs in repos that must change their package.json version.
--->