### PR TITLE
Introduce `MarkdownRange` class on Android

### DIFF
--- a/android/src/main/java/com/expensify/livemarkdown/MarkdownRange.java
+++ b/android/src/main/java/com/expensify/livemarkdown/MarkdownRange.java
@@ -1,0 +1,31 @@
+package com.expensify.livemarkdown;
+
+public class MarkdownRange {
+  private final String mType;
+  private final int mStart;
+  private final int mLength;
+  private final int mDepth;
+
+  public MarkdownRange(String type, int start, int length, int depth) {
+    mType = type;
+    mStart = start;
+    mLength = length;
+    mDepth = depth;
+  }
+
+  public String getType() {
+    return mType;
+  }
+
+  public int getStart() {
+    return mStart;
+  }
+
+  public int getLength() {
+    return mLength;
+  }
+
+  public int getDepth() {
+    return mDepth;
+  }
+}

--- a/android/src/main/java/com/expensify/livemarkdown/MarkdownUtils.java
+++ b/android/src/main/java/com/expensify/livemarkdown/MarkdownUtils.java
@@ -16,6 +16,8 @@ import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
 
+import java.util.LinkedList;
+import java.util.List;
 import java.util.Objects;
 
 public class MarkdownUtils {
@@ -68,6 +70,7 @@ public class MarkdownUtils {
       mPrevParserId = mParserId;
     }
 
+    List<MarkdownRange> markdownRanges = new LinkedList<>();
     try {
       JSONArray ranges = new JSONArray(output);
       for (int i = 0; i < ranges.length(); i++) {
@@ -80,14 +83,21 @@ public class MarkdownUtils {
         if (length == 0 || end > input.length()) {
           continue;
         }
-        applyRange(ssb, type, start, end, depth);
+        markdownRanges.add(new MarkdownRange(type, start, length, depth));
       }
     } catch (JSONException e) {
       RNLog.w(mReactContext, "[react-native-live-markdown] Incorrect schema of worklet parser output: " + e.getMessage());
     }
+
+    for (MarkdownRange markdownRange : markdownRanges) {
+      applyRange(ssb, markdownRange);
+    }
   }
 
-  private void applyRange(SpannableStringBuilder ssb, String type, int start, int end, int depth) {
+  private void applyRange(SpannableStringBuilder ssb, MarkdownRange markdownRange) {
+    String type = markdownRange.getType();
+    int start = markdownRange.getStart();
+    int end = start + markdownRange.getLength();
     switch (type) {
       case "bold":
         setSpan(ssb, new MarkdownBoldSpan(), start, end);
@@ -149,7 +159,7 @@ public class MarkdownUtils {
           mMarkdownStyle.getBlockquoteBorderWidth(),
           mMarkdownStyle.getBlockquoteMarginLeft(),
           mMarkdownStyle.getBlockquotePaddingLeft(),
-          depth);
+          markdownRange.getDepth());
         setSpan(ssb, span, start, end);
         break;
     }


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Details
This PR adds an intermediate step in formatting `applyMarkdownFormatting` method on Android. Instead of using `JSONObject` obtained from parser directly, first we populate `markdownRanges` list consisting of `MarkdownRange` objects. Then, we call `applyRange` while iterating over the array.

This change will make it simpler to split the implementation into smaller parts and memoize the parser output as Java objects instead of memoizing JSON string.

### Related Issues
<!-- Please replace GH_LINK with the link to the GitHub issue this Pull Request is related to -->
GH_LINK

### Manual Tests
<!---
Most changes should have accompanying tests. Describe the tests you added or if no tests were added an explanation about why one was not needed.
--->

### Linked PRs
<!---
Please include links to any update PRs in repos that must change their package.json version.
--->