### PR TITLE
Move skipping invalid ranges to parser on iOS

### DIFF
--- a/apple/MarkdownParser.mm
+++ b/apple/MarkdownParser.mm
@@ -46,6 +46,10 @@
         const auto &length = static_cast<int>(item.getProperty(rt, "length").asNumber());
         const auto &depth = item.hasProperty(rt, "depth") ? static_cast<int>(item.getProperty(rt, "depth").asNumber()) : 1;
 
+        if (length == 0 || start + length > text.length) {
+          continue;
+        }
+
         NSRange range = NSMakeRange(start, length);
         MarkdownRange *markdownRange = [[MarkdownRange alloc] initWithType:@(type.c_str()) range:range depth:depth];
         [markdownRanges addObject:markdownRange];

--- a/apple/RCTMarkdownUtils.mm
+++ b/apple/RCTMarkdownUtils.mm
@@ -70,10 +70,6 @@
 }
 
 - (void)applyRangeToAttributedString:(NSMutableAttributedString *)attributedString type:(const std::string)type range:(NSRange)range depth:(const int)depth {
-    if (range.length == 0 || range.location + range.length > attributedString.length) {
-        return;
-    }
-
     if (type == "bold" || type == "italic" || type == "code" || type == "pre" || type == "h1" || type == "emoji") {
         UIFont *font = [attributedString attribute:NSFontAttributeName atIndex:range.location effectiveRange:NULL];
         if (type == "bold") {


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Details
This PR moves logic related to skipping ranges with zero length or exceeding the length or the text from formatting step to parsing step to make logic analogous to Android implementation.

https://github.com/Expensify/react-native-live-markdown/blob/cc1188c26abf8078cdc665788971ce3c6cba0a86/android/src/main/java/com/expensify/livemarkdown/MarkdownParser.java#L53-L55

### Related Issues
<!-- Please replace GH_LINK with the link to the GitHub issue this Pull Request is related to -->
GH_LINK

### Manual Tests
<!---
Most changes should have accompanying tests. Describe the tests you added or if no tests were added an explanation about why one was not needed.
--->

### Linked PRs
<!---
Please include links to any update PRs in repos that must change their package.json version.
--->