### PR TITLE
Move loading shared library to `MarkdownParser`

### DIFF
--- a/android/src/main/java/com/expensify/livemarkdown/MarkdownParser.java
+++ b/android/src/main/java/com/expensify/livemarkdown/MarkdownParser.java
@@ -4,6 +4,7 @@ import androidx.annotation.NonNull;
 
 import com.facebook.react.bridge.ReactContext;
 import com.facebook.react.util.RNLog;
+import com.facebook.soloader.SoLoader;
 
 import org.json.JSONArray;
 import org.json.JSONException;
@@ -14,6 +15,10 @@ import java.util.LinkedList;
 import java.util.List;
 
 public class MarkdownParser {
+  static {
+    SoLoader.loadLibrary("livemarkdown");
+  }
+
   private final @NonNull ReactContext mReactContext;
   private String mPrevText;
   private int mPrevParserId;

--- a/android/src/main/java/com/expensify/livemarkdown/MarkdownUtils.java
+++ b/android/src/main/java/com/expensify/livemarkdown/MarkdownUtils.java
@@ -9,16 +9,11 @@ import androidx.annotation.NonNull;
 import com.expensify.livemarkdown.spans.*;
 import com.facebook.react.bridge.ReactContext;
 import com.facebook.react.views.text.internal.span.CustomLineHeightSpan;
-import com.facebook.soloader.SoLoader;
 
 import java.util.List;
 import java.util.Objects;
 
 public class MarkdownUtils {
-  static {
-    SoLoader.loadLibrary("livemarkdown");
-  }
-
   public MarkdownUtils(@NonNull ReactContext reactContext) {
     mAssetManager = reactContext.getAssets();
     mMarkdownParser = new MarkdownParser(reactContext);


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Details
This PR moves `SoLoader.loadLibrary` call from `MarkdownUtils` to `MarkdownParser` which I forgot to do in https://github.com/Expensify/react-native-live-markdown/pull/560.

### Related Issues
<!-- Please replace GH_LINK with the link to the GitHub issue this Pull Request is related to -->
GH_LINK

### Manual Tests
<!---
Most changes should have accompanying tests. Describe the tests you added or if no tests were added an explanation about why one was not needed.
--->

### Linked PRs
<!---
Please include links to any update PRs in repos that must change their package.json version.
--->