### PR TITLE
Use custom attribute to store blockquote depth on iOS

### DIFF
--- a/apple/MarkdownLayoutManager.mm
+++ b/apple/MarkdownLayoutManager.mm
@@ -5,34 +5,27 @@
 - (void)drawBackgroundForGlyphRange:(NSRange)glyphsToShow atPoint:(CGPoint)origin {
   [super drawBackgroundForGlyphRange:glyphsToShow atPoint:origin];
 
+  NSTextStorage *textStorage = self.textStorage;
+
   [self enumerateLineFragmentsForGlyphRange:glyphsToShow usingBlock:^(CGRect rect, CGRect usedRect, NSTextContainer * _Nonnull textContainer, NSRange glyphRange, BOOL * _Nonnull stop) {
-    __block BOOL isBlockquote = NO;
-    __block int currentDepth = 0;
+    NSNumber *depth = [textStorage attribute:RCTLiveMarkdownBlockquoteDepthAttributeName atIndex:glyphRange.location effectiveRange:nil];
+    if (depth == nil) {
+      return; // not a blockquote
+    }
+
     RCTMarkdownUtils *markdownUtils = [self valueForKey:@"markdownUtils"];
-    [markdownUtils.blockquoteRangesAndLevels enumerateObjectsUsingBlock:^(NSDictionary *item, NSUInteger idx, BOOL * _Nonnull stop) {
-      NSRange range = [[item valueForKey:@"range"] rangeValue];
-      currentDepth = [[item valueForKey:@"depth"] unsignedIntegerValue];
-      NSUInteger start = range.location;
-      NSUInteger end = start + range.length;
-      NSUInteger location = glyphRange.location;
-      if (location >= start && location < end) {
-        isBlockquote = YES;
-        *stop = YES;
-      }
-    }];
-    if (isBlockquote) {
-      CGFloat paddingLeft = origin.x;
-      CGFloat paddingTop = origin.y;
-      CGFloat y = paddingTop + rect.origin.y;
-      CGFloat width = markdownUtils.markdownStyle.blockquoteBorderWidth;
-      CGFloat height = rect.size.height;
-      CGFloat shift = markdownUtils.markdownStyle.blockquoteMarginLeft + markdownUtils.markdownStyle.blockquoteBorderWidth + markdownUtils.markdownStyle.blockquotePaddingLeft;
-      for (int level = 0; level < currentDepth; level++) {
-        CGFloat x =  paddingLeft + (level * shift) + markdownUtils.markdownStyle.blockquoteMarginLeft;
-        CGRect lineRect = CGRectMake(x, y, width, height);
-        [markdownUtils.markdownStyle.blockquoteBorderColor setFill];
-        UIRectFill(lineRect);
-      }
+    CGFloat paddingLeft = origin.x;
+    CGFloat paddingTop = origin.y;
+    CGFloat y = paddingTop + rect.origin.y;
+    CGFloat width = markdownUtils.markdownStyle.blockquoteBorderWidth;
+    CGFloat height = rect.size.height;
+    CGFloat shift = markdownUtils.markdownStyle.blockquoteMarginLeft + markdownUtils.markdownStyle.blockquoteBorderWidth + markdownUtils.markdownStyle.blockquotePaddingLeft;
+  
+    for (NSUInteger level = 0; level < [depth unsignedIntValue]; level++) {
+      CGFloat x = paddingLeft + (level * shift) + markdownUtils.markdownStyle.blockquoteMarginLeft;
+      CGRect lineRect = CGRectMake(x, y, width, height);
+      [markdownUtils.markdownStyle.blockquoteBorderColor setFill];
+      UIRectFill(lineRect);
     }
   }];
 }

--- a/apple/RCTMarkdownUtils.h
+++ b/apple/RCTMarkdownUtils.h
@@ -3,11 +3,12 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
+const NSAttributedStringKey RCTLiveMarkdownBlockquoteDepthAttributeName = @"RCTLiveMarkdownBlockquoteDepth";
+
 @interface RCTMarkdownUtils : NSObject
 
 @property (nonatomic) RCTMarkdownStyle *markdownStyle;
 @property (nonatomic) NSNumber *parserId;
-@property (nonatomic) NSMutableArray<NSDictionary *> *blockquoteRangesAndLevels;
 
 - (NSAttributedString *)parseMarkdown:(nullable NSAttributedString *)input withAttributes:(nullable NSDictionary<NSAttributedStringKey, id>*)attributes;
 

--- a/apple/RCTMarkdownUtils.mm
+++ b/apple/RCTMarkdownUtils.mm
@@ -38,17 +38,6 @@
 
         NSArray<MarkdownRange *> *markdownRanges = [_markdownParser parse:inputString withParserId:_parserId];
 
-        // TODO: use custom attribute to store blockquote depth instead
-        _blockquoteRangesAndLevels = [NSMutableArray new];
-        for (MarkdownRange *markdownRange in markdownRanges) {
-            if ([markdownRange.type isEqualToString:@"blockquote"]) {
-                [_blockquoteRangesAndLevels addObject:@{
-                    @"range": [NSValue valueWithRange:markdownRange.range],
-                    @"depth": @(markdownRange.depth)
-                }];
-            }
-        }
-
         NSMutableAttributedString *attributedString = [[NSMutableAttributedString alloc] initWithString:inputString attributes:attributes];
         [attributedString beginEditing];
 
@@ -143,6 +132,7 @@
         paragraphStyle.firstLineHeadIndent = indent;
         paragraphStyle.headIndent = indent;
         [attributedString addAttribute:NSParagraphStyleAttributeName value:paragraphStyle range:range];
+        [attributedString addAttribute:RCTLiveMarkdownBlockquoteDepthAttributeName value:@(depth) range:range];
     } else if (type == "pre") {
         [attributedString addAttribute:NSForegroundColorAttributeName value:_markdownStyle.preColor range:range];
         NSRange rangeForBackground = [[attributedString string] characterAtIndex:range.location] == '\n' ? NSMakeRange(range.location + 1, range.length - 1) : range;

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -1497,7 +1497,7 @@ PODS:
     - React-logger (= 0.75.3)
     - React-perflogger (= 0.75.3)
     - React-utils (= 0.75.3)
-  - RNLiveMarkdown (0.1.190):
+  - RNLiveMarkdown (0.1.195):
     - DoubleConversion
     - glog
     - hermes-engine
@@ -1517,10 +1517,10 @@ PODS:
     - ReactCodegen
     - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
-    - RNLiveMarkdown/newarch (= 0.1.190)
+    - RNLiveMarkdown/newarch (= 0.1.195)
     - RNReanimated/worklets
     - Yoga
-  - RNLiveMarkdown/newarch (0.1.190):
+  - RNLiveMarkdown/newarch (0.1.195):
     - DoubleConversion
     - glog
     - hermes-engine
@@ -1897,7 +1897,7 @@ SPEC CHECKSUMS:
   React-utils: f2afa6acd905ca2ce7bb8ffb4a22f7f8a12534e8
   ReactCodegen: e35c23cdd36922f6d2990c6c1f1b022ade7ad74d
   ReactCommon: 289214026502e6a93484f4a46bcc0efa4f3f2864
-  RNLiveMarkdown: a210cbb45b6cb9db0b28ef09aafdc9c77424dd38
+  RNLiveMarkdown: 18b4dec85110bc61b02f53501cd9e7aa08066b7f
   RNReanimated: ab6c33a61e90c4cbe5dbcbe65bd6c7cb3be167e6
   SocketRocket: abac6f5de4d4d62d24e11868d7a2f427e0ef940d
   Yoga: 1354c027ab07c7736f99a3bef16172d6f1b12b47


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Details
This PR removes `_blockquoteRangesAndLevels` in `RCTMarkdownUtils` in favor of storing the blockquote depth as `NSNumber` under custom attribute named `RCTLiveMarkdownBlockquoteDepth`.

This removes cohesion between `_blockquoteRangesAndLevels` and `applyRangeToAttributedString:` which I plan to move to a separate class called `MarkdownFormatter` in an upcoming PR.

It also simplifies the implementation of `MarkdownLayoutManager` where now we can use `[textStorage attribute:atIndex:effectiveRange:];` to check if given range is a blockquote and determine its depth without custom algorithms.

Partially applies https://github.com/Expensify/react-native-live-markdown/pull/520.

### Related Issues
<!-- Please replace GH_LINK with the link to the GitHub issue this Pull Request is related to -->
GH_LINK

### Manual Tests
<!---
Most changes should have accompanying tests. Describe the tests you added or if no tests were added an explanation about why one was not needed.
--->

### Linked PRs
<!---
Please include links to any update PRs in repos that must change their package.json version.
--->