### PR TITLE
Add systraces on Android

### DIFF
--- a/android/src/main/java/com/expensify/livemarkdown/MarkdownFormatter.java
+++ b/android/src/main/java/com/expensify/livemarkdown/MarkdownFormatter.java
@@ -8,6 +8,7 @@ import androidx.annotation.NonNull;
 
 import com.expensify.livemarkdown.spans.*;
 import com.facebook.react.views.text.internal.span.CustomLineHeightSpan;
+import com.facebook.systrace.Systrace;
 
 import java.util.List;
 import java.util.Objects;
@@ -20,22 +21,37 @@ public class MarkdownFormatter {
   }
 
   public void format(SpannableStringBuilder ssb, List<MarkdownRange> markdownRanges, @NonNull MarkdownStyle markdownStyle) {
-    Objects.requireNonNull(markdownStyle, "mMarkdownStyle is null");
-    removeSpans(ssb);
-    applyRanges(ssb, markdownRanges, markdownStyle);
+    try {
+      Systrace.beginSection(0, "format");
+      Objects.requireNonNull(markdownStyle, "mMarkdownStyle is null");
+      removeSpans(ssb);
+      applyRanges(ssb, markdownRanges, markdownStyle);
+    } finally {
+      Systrace.endSection(0);
+    }
   }
 
   private void removeSpans(SpannableStringBuilder ssb) {
-    // We shouldn't use `removeSpans()` because it also removes SpellcheckSpan, SuggestionSpan etc.
-    MarkdownSpan[] spans = ssb.getSpans(0, ssb.length(), MarkdownSpan.class);
-    for (MarkdownSpan span : spans) {
-      ssb.removeSpan(span);
+    try {
+      Systrace.beginSection(0, "removeSpans");
+      // We shouldn't use `removeSpans()` because it also removes SpellcheckSpan, SuggestionSpan etc.
+      MarkdownSpan[] spans = ssb.getSpans(0, ssb.length(), MarkdownSpan.class);
+      for (MarkdownSpan span : spans) {
+        ssb.removeSpan(span);
+      }
+    } finally {
+      Systrace.endSection(0);
     }
   }
 
   private void applyRanges(SpannableStringBuilder ssb, List<MarkdownRange> markdownRanges, @NonNull MarkdownStyle markdownStyle) {
-    for (MarkdownRange markdownRange : markdownRanges) {
-      applyRange(ssb, markdownRange, markdownStyle);
+    try {
+      Systrace.beginSection(0, "applyRanges");
+      for (MarkdownRange markdownRange : markdownRanges) {
+        applyRange(ssb, markdownRange, markdownStyle);
+      }
+    } finally {
+      Systrace.endSection(0);
     }
   }
 

--- a/android/src/main/java/com/expensify/livemarkdown/MarkdownParser.java
+++ b/android/src/main/java/com/expensify/livemarkdown/MarkdownParser.java
@@ -55,6 +55,7 @@ public class MarkdownParser {
 
       List<MarkdownRange> markdownRanges = new LinkedList<>();
       try {
+        Systrace.beginSection(0, "markdownRanges");
         JSONArray ranges = new JSONArray(json);
         for (int i = 0; i < ranges.length(); i++) {
           JSONObject range = ranges.getJSONObject(i);
@@ -73,6 +74,8 @@ public class MarkdownParser {
         mPrevParserId = parserId;
         mPrevMarkdownRanges = Collections.emptyList();
         return mPrevMarkdownRanges;
+      } finally {
+        Systrace.endSection(0);
       }
 
       mPrevText = text;

--- a/android/src/main/java/com/expensify/livemarkdown/MarkdownParser.java
+++ b/android/src/main/java/com/expensify/livemarkdown/MarkdownParser.java
@@ -5,6 +5,7 @@ import androidx.annotation.NonNull;
 import com.facebook.react.bridge.ReactContext;
 import com.facebook.react.util.RNLog;
 import com.facebook.soloader.SoLoader;
+import com.facebook.systrace.Systrace;
 
 import org.json.JSONArray;
 import org.json.JSONException;
@@ -31,46 +32,55 @@ public class MarkdownParser {
   private native String nativeParse(String text, int parserId);
 
   public synchronized List<MarkdownRange> parse(String text, int parserId) {
-    if (text.equals(mPrevText) && parserId == mPrevParserId) {
-      return mPrevMarkdownRanges;
-    }
-
-    String json;
     try {
-      json = nativeParse(text, parserId);
-    } catch (Exception e) {
-      // Skip formatting, runGuarded will show the error in LogBox
-      mPrevText = text;
-      mPrevParserId = parserId;
-      mPrevMarkdownRanges = Collections.emptyList();
-      return mPrevMarkdownRanges;
-    }
+      Systrace.beginSection(0, "parse");
 
-    List<MarkdownRange> markdownRanges = new LinkedList<>();
-    try {
-      JSONArray ranges = new JSONArray(json);
-      for (int i = 0; i < ranges.length(); i++) {
-        JSONObject range = ranges.getJSONObject(i);
-        String type = range.getString("type");
-        int start = range.getInt("start");
-        int length = range.getInt("length");
-        int depth = range.optInt("depth", 1);
-        if (length == 0 || start + length > text.length()) {
-          continue;
-        }
-        markdownRanges.add(new MarkdownRange(type, start, length, depth));
+      if (text.equals(mPrevText) && parserId == mPrevParserId) {
+        return mPrevMarkdownRanges;
       }
-    } catch (JSONException e) {
-      RNLog.w(mReactContext, "[react-native-live-markdown] Incorrect schema of worklet parser output: " + e.getMessage());
+
+      String json;
+      try {
+        Systrace.beginSection(0, "nativeParse");
+        json = nativeParse(text, parserId);
+      } catch (Exception e) {
+        // Skip formatting, runGuarded will show the error in LogBox
+        mPrevText = text;
+        mPrevParserId = parserId;
+        mPrevMarkdownRanges = Collections.emptyList();
+        return mPrevMarkdownRanges;
+      } finally {
+        Systrace.endSection(0);
+      }
+
+      List<MarkdownRange> markdownRanges = new LinkedList<>();
+      try {
+        JSONArray ranges = new JSONArray(json);
+        for (int i = 0; i < ranges.length(); i++) {
+          JSONObject range = ranges.getJSONObject(i);
+          String type = range.getString("type");
+          int start = range.getInt("start");
+          int length = range.getInt("length");
+          int depth = range.optInt("depth", 1);
+          if (length == 0 || start + length > text.length()) {
+            continue;
+          }
+          markdownRanges.add(new MarkdownRange(type, start, length, depth));
+        }
+      } catch (JSONException e) {
+        RNLog.w(mReactContext, "[react-native-live-markdown] Incorrect schema of worklet parser output: " + e.getMessage());
+        mPrevText = text;
+        mPrevParserId = parserId;
+        mPrevMarkdownRanges = Collections.emptyList();
+        return mPrevMarkdownRanges;
+      }
+
       mPrevText = text;
       mPrevParserId = parserId;
-      mPrevMarkdownRanges = Collections.emptyList();
+      mPrevMarkdownRanges = markdownRanges;
       return mPrevMarkdownRanges;
+    } finally {
+      Systrace.endSection(0);
     }
-
-    mPrevText = text;
-    mPrevParserId = parserId;
-    mPrevMarkdownRanges = markdownRanges;
-    return mPrevMarkdownRanges;
   }
 }

--- a/android/src/main/java/com/expensify/livemarkdown/MarkdownUtils.java
+++ b/android/src/main/java/com/expensify/livemarkdown/MarkdownUtils.java
@@ -5,6 +5,7 @@ import android.text.SpannableStringBuilder;
 import androidx.annotation.NonNull;
 
 import com.facebook.react.bridge.ReactContext;
+import com.facebook.systrace.Systrace;
 
 import java.util.List;
 
@@ -29,8 +30,13 @@ public class MarkdownUtils {
   }
 
   public void applyMarkdownFormatting(SpannableStringBuilder ssb) {
-    String text = ssb.toString();
-    List<MarkdownRange> markdownRanges = mMarkdownParser.parse(text, mParserId);
-    mMarkdownFormatter.format(ssb, markdownRanges, mMarkdownStyle);
+    try {
+      Systrace.beginSection(0, "applyMarkdownFormatting");
+      String text = ssb.toString();
+      List<MarkdownRange> markdownRanges = mMarkdownParser.parse(text, mParserId);
+      mMarkdownFormatter.format(ssb, markdownRanges, mMarkdownStyle);
+    } finally {
+      Systrace.endSection(0);
+    }
   }
 }


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Details
This PR adds systraces on Android for easier profiling.

Thanks to that I've noticed that `applyMarkdownFormatting` is executed twice per each keypress (at least `parseNative` is correctly memoized).

<img width="614" alt="Screenshot 2024-12-05 at 23 07 46" src="https://github.com/user-attachments/assets/4212f1ac-9c48-4862-b27c-0bf0fde99b9a">

I will try to find a fix for that in a separate PR.

### Related Issues
<!-- Please replace GH_LINK with the link to the GitHub issue this Pull Request is related to -->
GH_LINK

### Manual Tests
<!---
Most changes should have accompanying tests. Describe the tests you added or if no tests were added an explanation about why one was not needed.
--->

### Linked PRs
<!---
Please include links to any update PRs in repos that must change their package.json version.
--->