### PR TITLE
Skip formatting if data unchanged on Android

### DIFF
--- a/android/src/main/java/com/expensify/livemarkdown/MarkdownFormatter.java
+++ b/android/src/main/java/com/expensify/livemarkdown/MarkdownFormatter.java
@@ -15,6 +15,9 @@ import java.util.Objects;
 
 public class MarkdownFormatter {
   private final @NonNull AssetManager mAssetManager;
+  private String mPrevText;
+  private List<MarkdownRange> mPrevMarkdownRanges;
+  private MarkdownStyle mPrevMarkdownStyle;
 
   public MarkdownFormatter(@NonNull AssetManager assetManager) {
     mAssetManager = assetManager;
@@ -24,8 +27,19 @@ public class MarkdownFormatter {
     try {
       Systrace.beginSection(0, "format");
       Objects.requireNonNull(markdownStyle, "mMarkdownStyle is null");
+
+      String text = ssb.toString();
+      if (text.equals(mPrevText) && markdownRanges == mPrevMarkdownRanges && markdownStyle == mPrevMarkdownStyle) {
+        // Use shallow comparison of markdown ranges and markdown style
+        // to optimistically skip removing and applying the same spans
+        return;
+      }
+
       removeSpans(ssb);
       applyRanges(ssb, markdownRanges, markdownStyle);
+      mPrevText = text;
+      mPrevMarkdownRanges = markdownRanges;
+      mPrevMarkdownStyle = markdownStyle;
     } finally {
       Systrace.endSection(0);
     }


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Details
This PR skips removing and applying spans on Android if the text, ranges and styles are unchanged to previous run of `MarkdownFormatter` as span operations are relatively time-consuming on Android.

In particular, this lets us save some time during mounting phase as per systraces below:

#### Before
<img width="900" alt="Screenshot 2024-12-07 at 12 04 14" src="https://github.com/user-attachments/assets/20790b6d-e46d-45c8-b427-b8345d607b7f">

#### After
<img width="650" alt="Screenshot 2024-12-07 at 12 03 13" src="https://github.com/user-attachments/assets/1422f460-c850-43bc-b934-b4f60503bace">

### Related Issues
<!-- Please replace GH_LINK with the link to the GitHub issue this Pull Request is related to -->
GH_LINK

### Manual Tests
<!---
Most changes should have accompanying tests. Describe the tests you added or if no tests were added an explanation about why one was not needed.
--->

### Linked PRs
<!---
Please include links to any update PRs in repos that must change their package.json version.
--->