### PR TITLE
Add `getEnd()` method in `MarkdownRange`

### DIFF
--- a/android/src/main/java/com/expensify/livemarkdown/MarkdownFormatter.java
+++ b/android/src/main/java/com/expensify/livemarkdown/MarkdownFormatter.java
@@ -58,7 +58,7 @@ public class MarkdownFormatter {
   private void applyRange(SpannableStringBuilder ssb, MarkdownRange markdownRange, MarkdownStyle markdownStyle) {
     String type = markdownRange.getType();
     int start = markdownRange.getStart();
-    int end = start + markdownRange.getLength();
+    int end = markdownRange.getEnd();
     switch (type) {
       case "bold":
         setSpan(ssb, new MarkdownBoldSpan(), start, end);

--- a/android/src/main/java/com/expensify/livemarkdown/MarkdownRange.java
+++ b/android/src/main/java/com/expensify/livemarkdown/MarkdownRange.java
@@ -3,12 +3,14 @@ package com.expensify.livemarkdown;
 public class MarkdownRange {
   private final String mType;
   private final int mStart;
+  private final int mEnd;
   private final int mLength;
   private final int mDepth;
 
   public MarkdownRange(String type, int start, int length, int depth) {
     mType = type;
     mStart = start;
+    mEnd = start + length;
     mLength = length;
     mDepth = depth;
   }
@@ -19,6 +21,10 @@ public class MarkdownRange {
 
   public int getStart() {
     return mStart;
+  }
+
+  public int getEnd() {
+    return mEnd;
   }
 
   public int getLength() {


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Details
This PR adds `getEnd()` method in `MarkdownRange` class on Android. This change was first introduced by @Skalakid in https://github.com/Expensify/react-native-live-markdown/pull/534 and has been partially extracted from that PR.

### Related Issues
<!-- Please replace GH_LINK with the link to the GitHub issue this Pull Request is related to -->
GH_LINK

### Manual Tests
<!---
Most changes should have accompanying tests. Describe the tests you added or if no tests were added an explanation about why one was not needed.
--->

### Linked PRs
<!---
Please include links to any update PRs in repos that must change their package.json version.
--->