### PR TITLE
Move formatting logic to separate class on iOS

### DIFF
--- a/apple/MarkdownFormatter.h
+++ b/apple/MarkdownFormatter.h
@@ -1,0 +1,18 @@
+#import <Foundation/Foundation.h>
+#import <RNLiveMarkdown/MarkdownRange.h>
+#import <RNLiveMarkdown/RCTMarkdownStyle.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+const NSAttributedStringKey RCTLiveMarkdownBlockquoteDepthAttributeName = @"RCTLiveMarkdownBlockquoteDepth";
+
+@interface MarkdownFormatter : NSObject
+
+- (nonnull NSAttributedString *)format:(nonnull NSString *)text
+                        withAttributes:(nullable NSDictionary<NSAttributedStringKey, id>*)attributes
+                    withMarkdownRanges:(nonnull NSArray<MarkdownRange *> *)markdownRanges
+                     withMarkdownStyle:(nonnull RCTMarkdownStyle *)markdownStyle;
+
+NS_ASSUME_NONNULL_END
+
+@end

--- a/apple/MarkdownFormatter.mm
+++ b/apple/MarkdownFormatter.mm
@@ -1,0 +1,158 @@
+#import "MarkdownFormatter.h"
+#import <React/RCTFont.h>
+
+@implementation MarkdownFormatter
+
+- (nonnull NSAttributedString *)format:(nonnull NSString *)text
+                        withAttributes:(nullable NSDictionary<NSAttributedStringKey, id> *)attributes
+                    withMarkdownRanges:(nonnull NSArray<MarkdownRange *> *)markdownRanges
+                     withMarkdownStyle:(nonnull RCTMarkdownStyle *)markdownStyle
+{
+  NSMutableAttributedString *attributedString = [[NSMutableAttributedString alloc] initWithString:text attributes:attributes];
+
+  [attributedString beginEditing];
+
+  // If the attributed string ends with underlined text, blurring the single-line input imprints the underline style across the whole string.
+  // It looks like a bug in iOS, as there is no underline style to be found in the attributed string, especially after formatting.
+  // This is a workaround that applies the NSUnderlineStyleNone to the string before iterating over ranges which resolves this problem.
+  [attributedString addAttribute:NSUnderlineStyleAttributeName
+                           value:[NSNumber numberWithInteger:NSUnderlineStyleNone]
+                           range:NSMakeRange(0, attributedString.length)];
+
+  for (MarkdownRange *markdownRange in markdownRanges) {
+    [self applyRangeToAttributedString:attributedString
+                                  type:std::string([markdownRange.type UTF8String])
+                                 range:markdownRange.range
+                                 depth:markdownRange.depth
+                         markdownStyle:markdownStyle];
+  }
+
+  RCTApplyBaselineOffset(attributedString);
+
+  [attributedString endEditing];
+
+  return attributedString;
+}
+
+- (void)applyRangeToAttributedString:(NSMutableAttributedString *)attributedString
+                                type:(const std::string)type
+                               range:(const NSRange)range
+                               depth:(const int)depth
+                       markdownStyle:(nonnull RCTMarkdownStyle *)markdownStyle {
+  if (type == "bold" || type == "italic" || type == "code" || type == "pre" || type == "h1" || type == "emoji") {
+    UIFont *font = [attributedString attribute:NSFontAttributeName atIndex:range.location effectiveRange:NULL];
+    if (type == "bold") {
+      font = [RCTFont updateFont:font withWeight:@"bold"];
+    } else if (type == "italic") {
+      font = [RCTFont updateFont:font withStyle:@"italic"];
+    } else if (type == "code") {
+      font = [RCTFont updateFont:font withFamily:markdownStyle.codeFontFamily
+                                            size:[NSNumber numberWithFloat:markdownStyle.codeFontSize]
+                                          weight:nil
+                                            style:nil
+                                          variant:nil
+                                  scaleMultiplier:0];
+    } else if (type == "pre") {
+      font = [RCTFont updateFont:font withFamily:markdownStyle.preFontFamily
+                                            size:[NSNumber numberWithFloat:markdownStyle.preFontSize]
+                                          weight:nil
+                                          style:nil
+                                        variant:nil
+                                scaleMultiplier:0];
+    } else if (type == "h1") {
+      font = [RCTFont updateFont:font withFamily:nil
+                                            size:[NSNumber numberWithFloat:markdownStyle.h1FontSize]
+                                          weight:@"bold"
+                                            style:nil
+                                          variant:nil
+                                  scaleMultiplier:0];
+    } else if (type == "emoji") {
+      font = [RCTFont updateFont:font withFamily:nil
+                                            size:[NSNumber numberWithFloat:markdownStyle.emojiFontSize]
+                                          weight:nil
+                                            style:nil
+                                          variant:nil
+                                  scaleMultiplier:0];
+    }
+    [attributedString addAttribute:NSFontAttributeName value:font range:range];
+  }
+
+  if (type == "syntax") {
+    [attributedString addAttribute:NSForegroundColorAttributeName value:markdownStyle.syntaxColor range:range];
+  } else if (type == "strikethrough") {
+    [attributedString addAttribute:NSStrikethroughStyleAttributeName value:[NSNumber numberWithInteger:NSUnderlineStyleSingle] range:range];
+  } else if (type == "code") {
+    [attributedString addAttribute:NSForegroundColorAttributeName value:markdownStyle.codeColor range:range];
+    [attributedString addAttribute:NSBackgroundColorAttributeName value:markdownStyle.codeBackgroundColor range:range];
+  } else if (type == "mention-here") {
+    [attributedString addAttribute:NSForegroundColorAttributeName value:markdownStyle.mentionHereColor range:range];
+    [attributedString addAttribute:NSBackgroundColorAttributeName value:markdownStyle.mentionHereBackgroundColor range:range];
+  } else if (type == "mention-user") {
+    // TODO: change mention color when it mentions current user
+    [attributedString addAttribute:NSForegroundColorAttributeName value:markdownStyle.mentionUserColor range:range];
+    [attributedString addAttribute:NSBackgroundColorAttributeName value:markdownStyle.mentionUserBackgroundColor range:range];
+  } else if (type == "mention-report") {
+    [attributedString addAttribute:NSForegroundColorAttributeName value:markdownStyle.mentionReportColor range:range];
+    [attributedString addAttribute:NSBackgroundColorAttributeName value:markdownStyle.mentionReportBackgroundColor range:range];
+  } else if (type == "link") {
+    [attributedString addAttribute:NSUnderlineStyleAttributeName value:[NSNumber numberWithInteger:NSUnderlineStyleSingle] range:range];
+    [attributedString addAttribute:NSForegroundColorAttributeName value:markdownStyle.linkColor range:range];
+  } else if (type == "blockquote") {
+    CGFloat indent = (markdownStyle.blockquoteMarginLeft + markdownStyle.blockquoteBorderWidth + markdownStyle.blockquotePaddingLeft) * depth;
+    NSMutableParagraphStyle *paragraphStyle = [NSMutableParagraphStyle new];
+    paragraphStyle.firstLineHeadIndent = indent;
+    paragraphStyle.headIndent = indent;
+    [attributedString addAttribute:NSParagraphStyleAttributeName value:paragraphStyle range:range];
+    [attributedString addAttribute:RCTLiveMarkdownBlockquoteDepthAttributeName value:@(depth) range:range];
+  } else if (type == "pre") {
+    [attributedString addAttribute:NSForegroundColorAttributeName value:markdownStyle.preColor range:range];
+    NSRange rangeForBackground = [[attributedString string] characterAtIndex:range.location] == '\n' ? NSMakeRange(range.location + 1, range.length - 1) : range;
+    [attributedString addAttribute:NSBackgroundColorAttributeName value:markdownStyle.preBackgroundColor range:rangeForBackground];
+    // TODO: pass background color and ranges to layout manager
+  }
+}
+
+static void RCTApplyBaselineOffset(NSMutableAttributedString *attributedText)
+{
+  __block CGFloat maximumLineHeight = 0;
+
+  [attributedText enumerateAttribute:NSParagraphStyleAttributeName
+                             inRange:NSMakeRange(0, attributedText.length)
+                             options:NSAttributedStringEnumerationLongestEffectiveRangeNotRequired
+                          usingBlock:^(NSParagraphStyle *paragraphStyle, __unused NSRange range, __unused BOOL *stop) {
+    if (!paragraphStyle) {
+      return;
+    }
+
+    maximumLineHeight = MAX(paragraphStyle.maximumLineHeight, maximumLineHeight);
+  }];
+
+  if (maximumLineHeight == 0) {
+    // `lineHeight` was not specified, nothing to do.
+    return;
+  }
+
+  __block CGFloat maximumFontLineHeight = 0;
+
+  [attributedText enumerateAttribute:NSFontAttributeName
+                             inRange:NSMakeRange(0, attributedText.length)
+                             options:NSAttributedStringEnumerationLongestEffectiveRangeNotRequired
+                          usingBlock:^(UIFont *font, NSRange range, __unused BOOL *stop) {
+    if (!font) {
+      return;
+    }
+
+    maximumFontLineHeight = MAX(font.lineHeight, maximumFontLineHeight);
+  }];
+
+  if (maximumLineHeight < maximumFontLineHeight) {
+    return;
+  }
+
+  CGFloat baseLineOffset = (maximumLineHeight - maximumFontLineHeight) / 2.0;
+  [attributedText addAttribute:NSBaselineOffsetAttributeName
+                         value:@(baseLineOffset)
+                         range:NSMakeRange(0, attributedText.length)];
+}
+
+@end

--- a/apple/MarkdownLayoutManager.h
+++ b/apple/MarkdownLayoutManager.h
@@ -1,5 +1,6 @@
 #import <UIKit/UIKit.h>
 #import <RNLiveMarkdown/RCTMarkdownUtils.h>
+#import <RNLiveMarkdown/MarkdownFormatter.h>
 
 NS_ASSUME_NONNULL_BEGIN
 

--- a/apple/RCTMarkdownUtils.h
+++ b/apple/RCTMarkdownUtils.h
@@ -3,8 +3,6 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
-const NSAttributedStringKey RCTLiveMarkdownBlockquoteDepthAttributeName = @"RCTLiveMarkdownBlockquoteDepth";
-
 @interface RCTMarkdownUtils : NSObject
 
 @property (nonatomic) RCTMarkdownStyle *markdownStyle;

--- a/apple/RCTMarkdownUtils.mm
+++ b/apple/RCTMarkdownUtils.mm
@@ -1,13 +1,10 @@
 #import <RNLiveMarkdown/RCTMarkdownUtils.h>
-#import <RNLiveMarkdown/MarkdownGlobal.h>
 #import <RNLiveMarkdown/MarkdownParser.h>
-#import "react_native_assert.h"
-#import <React/RCTAssert.h>
-#import <React/RCTFont.h>
-#include <jsi/jsi.h>
+#import <RNLiveMarkdown/MarkdownFormatter.h>
 
 @implementation RCTMarkdownUtils {
   MarkdownParser *_markdownParser;
+  MarkdownFormatter *_markdownFormatter;
   NSString *_prevInputString;
   NSAttributedString *_prevAttributedString;
   NSDictionary<NSAttributedStringKey, id> *_prevTextAttributes;
@@ -19,6 +16,7 @@
 {
   if (self = [super init]) {
     _markdownParser = [MarkdownParser new];
+    _markdownFormatter = [MarkdownFormatter new];
   }
 
   return self;
@@ -26,162 +24,30 @@
 
 - (NSAttributedString *)parseMarkdown:(nullable NSAttributedString *)input withAttributes:(nullable NSDictionary<NSAttributedStringKey,id> *)attributes
 {
-    @synchronized (self) {
-        if (input == nil) {
-            return nil;
-        }
-
-        NSString *inputString = [input string];
-        if ([inputString isEqualToString:_prevInputString] && [attributes isEqualToDictionary:_prevTextAttributes] && [_markdownStyle isEqual:_prevMarkdownStyle] && [_parserId isEqualToNumber:_prevParserId]) {
-            return _prevAttributedString;
-        }
-
-        NSArray<MarkdownRange *> *markdownRanges = [_markdownParser parse:inputString withParserId:_parserId];
-
-        NSMutableAttributedString *attributedString = [[NSMutableAttributedString alloc] initWithString:inputString attributes:attributes];
-        [attributedString beginEditing];
-
-        // If the attributed string ends with underlined text, blurring the single-line input imprints the underline style across the whole string.
-        // It looks like a bug in iOS, as there is no underline style to be found in the attributed string, especially after formatting.
-        // This is a workaround that applies the NSUnderlineStyleNone to the string before iterating over ranges which resolves this problem.
-        [attributedString addAttribute:NSUnderlineStyleAttributeName value:[NSNumber numberWithInteger:NSUnderlineStyleNone] range:NSMakeRange(0, attributedString.length)];
-
-        for (MarkdownRange *markdownRange in markdownRanges) {
-            [self applyRangeToAttributedString:attributedString
-                                          type:std::string([markdownRange.type UTF8String])
-                                         range:markdownRange.range
-                                         depth:markdownRange.depth];
-        }
-
-        RCTApplyBaselineOffset(attributedString);
-
-        [attributedString endEditing];
-
-        _prevInputString = inputString;
-        _prevAttributedString = attributedString;
-        _prevTextAttributes = attributes;
-        _prevMarkdownStyle = _markdownStyle;
-        _prevParserId = _parserId;
-
-        return attributedString;
-    }
-}
-
-- (void)applyRangeToAttributedString:(NSMutableAttributedString *)attributedString type:(const std::string)type range:(NSRange)range depth:(const int)depth {
-    if (type == "bold" || type == "italic" || type == "code" || type == "pre" || type == "h1" || type == "emoji") {
-        UIFont *font = [attributedString attribute:NSFontAttributeName atIndex:range.location effectiveRange:NULL];
-        if (type == "bold") {
-            font = [RCTFont updateFont:font withWeight:@"bold"];
-        } else if (type == "italic") {
-            font = [RCTFont updateFont:font withStyle:@"italic"];
-        } else if (type == "code") {
-            font = [RCTFont updateFont:font withFamily:_markdownStyle.codeFontFamily
-                                                  size:[NSNumber numberWithFloat:_markdownStyle.codeFontSize]
-                                                weight:nil
-                                                 style:nil
-                                               variant:nil
-                                       scaleMultiplier:0];
-        } else if (type == "pre") {
-            font = [RCTFont updateFont:font withFamily:_markdownStyle.preFontFamily
-                                                  size:[NSNumber numberWithFloat:_markdownStyle.preFontSize]
-                                                weight:nil
-                                                style:nil
-                                              variant:nil
-                                      scaleMultiplier:0];
-        } else if (type == "h1") {
-            font = [RCTFont updateFont:font withFamily:nil
-                                                  size:[NSNumber numberWithFloat:_markdownStyle.h1FontSize]
-                                                weight:@"bold"
-                                                 style:nil
-                                               variant:nil
-                                       scaleMultiplier:0];
-        } else if (type == "emoji") {
-            font = [RCTFont updateFont:font withFamily:nil
-                                                  size:[NSNumber numberWithFloat:_markdownStyle.emojiFontSize]
-                                                weight:nil
-                                                 style:nil
-                                               variant:nil
-                                       scaleMultiplier:0];
-        }
-        [attributedString addAttribute:NSFontAttributeName value:font range:range];
+  @synchronized (self) {
+    if (input == nil) {
+      return nil;
     }
 
-    if (type == "syntax") {
-        [attributedString addAttribute:NSForegroundColorAttributeName value:_markdownStyle.syntaxColor range:range];
-    } else if (type == "strikethrough") {
-        [attributedString addAttribute:NSStrikethroughStyleAttributeName value:[NSNumber numberWithInteger:NSUnderlineStyleSingle] range:range];
-    } else if (type == "code") {
-        [attributedString addAttribute:NSForegroundColorAttributeName value:_markdownStyle.codeColor range:range];
-        [attributedString addAttribute:NSBackgroundColorAttributeName value:_markdownStyle.codeBackgroundColor range:range];
-    } else if (type == "mention-here") {
-        [attributedString addAttribute:NSForegroundColorAttributeName value:_markdownStyle.mentionHereColor range:range];
-        [attributedString addAttribute:NSBackgroundColorAttributeName value:_markdownStyle.mentionHereBackgroundColor range:range];
-    } else if (type == "mention-user") {
-        // TODO: change mention color when it mentions current user
-        [attributedString addAttribute:NSForegroundColorAttributeName value:_markdownStyle.mentionUserColor range:range];
-        [attributedString addAttribute:NSBackgroundColorAttributeName value:_markdownStyle.mentionUserBackgroundColor range:range];
-    } else if (type == "mention-report") {
-        [attributedString addAttribute:NSForegroundColorAttributeName value:_markdownStyle.mentionReportColor range:range];
-        [attributedString addAttribute:NSBackgroundColorAttributeName value:_markdownStyle.mentionReportBackgroundColor range:range];
-    } else if (type == "link") {
-        [attributedString addAttribute:NSUnderlineStyleAttributeName value:[NSNumber numberWithInteger:NSUnderlineStyleSingle] range:range];
-        [attributedString addAttribute:NSForegroundColorAttributeName value:_markdownStyle.linkColor range:range];
-    } else if (type == "blockquote") {
-        CGFloat indent = (_markdownStyle.blockquoteMarginLeft + _markdownStyle.blockquoteBorderWidth + _markdownStyle.blockquotePaddingLeft) * depth;
-        NSMutableParagraphStyle *paragraphStyle = [NSMutableParagraphStyle new];
-        paragraphStyle.firstLineHeadIndent = indent;
-        paragraphStyle.headIndent = indent;
-        [attributedString addAttribute:NSParagraphStyleAttributeName value:paragraphStyle range:range];
-        [attributedString addAttribute:RCTLiveMarkdownBlockquoteDepthAttributeName value:@(depth) range:range];
-    } else if (type == "pre") {
-        [attributedString addAttribute:NSForegroundColorAttributeName value:_markdownStyle.preColor range:range];
-        NSRange rangeForBackground = [[attributedString string] characterAtIndex:range.location] == '\n' ? NSMakeRange(range.location + 1, range.length - 1) : range;
-        [attributedString addAttribute:NSBackgroundColorAttributeName value:_markdownStyle.preBackgroundColor range:rangeForBackground];
-        // TODO: pass background color and ranges to layout manager
-    }
-}
-
-static void RCTApplyBaselineOffset(NSMutableAttributedString *attributedText)
-{
-  __block CGFloat maximumLineHeight = 0;
-
-  [attributedText enumerateAttribute:NSParagraphStyleAttributeName
-                             inRange:NSMakeRange(0, attributedText.length)
-                             options:NSAttributedStringEnumerationLongestEffectiveRangeNotRequired
-                          usingBlock:^(NSParagraphStyle *paragraphStyle, __unused NSRange range, __unused BOOL *stop) {
-    if (!paragraphStyle) {
-      return;
+    NSString *inputString = [input string];
+    if ([inputString isEqualToString:_prevInputString] && [attributes isEqualToDictionary:_prevTextAttributes] && [_markdownStyle isEqual:_prevMarkdownStyle] && [_parserId isEqualToNumber:_prevParserId]) {
+      return _prevAttributedString;
     }
 
-    maximumLineHeight = MAX(paragraphStyle.maximumLineHeight, maximumLineHeight);
-  }];
+    NSArray<MarkdownRange *> *markdownRanges = [_markdownParser parse:inputString withParserId:_parserId];
 
-  if (maximumLineHeight == 0) {
-    // `lineHeight` was not specified, nothing to do.
-    return;
+    NSAttributedString *attributedString = [_markdownFormatter format:inputString
+                                                       withAttributes:attributes
+                                                   withMarkdownRanges:markdownRanges
+                                                    withMarkdownStyle:_markdownStyle];
+    _prevInputString = inputString;
+    _prevAttributedString = attributedString;
+    _prevTextAttributes = attributes;
+    _prevMarkdownStyle = _markdownStyle;
+    _prevParserId = _parserId;
+
+    return attributedString;
   }
-
-  __block CGFloat maximumFontLineHeight = 0;
-
-  [attributedText enumerateAttribute:NSFontAttributeName
-                             inRange:NSMakeRange(0, attributedText.length)
-                             options:NSAttributedStringEnumerationLongestEffectiveRangeNotRequired
-                          usingBlock:^(UIFont *font, NSRange range, __unused BOOL *stop) {
-    if (!font) {
-      return;
-    }
-
-    maximumFontLineHeight = MAX(font.lineHeight, maximumFontLineHeight);
-  }];
-
-  if (maximumLineHeight < maximumFontLineHeight) {
-    return;
-  }
-
-  CGFloat baseLineOffset = (maximumLineHeight - maximumFontLineHeight) / 2.0;
-  [attributedText addAttribute:NSBaselineOffsetAttributeName
-                         value:@(baseLineOffset)
-                         range:NSMakeRange(0, attributedText.length)];
 }
 
 @end

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -1497,7 +1497,7 @@ PODS:
     - React-logger (= 0.75.3)
     - React-perflogger (= 0.75.3)
     - React-utils (= 0.75.3)
-  - RNLiveMarkdown (0.1.195):
+  - RNLiveMarkdown (0.1.199):
     - DoubleConversion
     - glog
     - hermes-engine
@@ -1517,10 +1517,10 @@ PODS:
     - ReactCodegen
     - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
-    - RNLiveMarkdown/newarch (= 0.1.195)
+    - RNLiveMarkdown/newarch (= 0.1.199)
     - RNReanimated/worklets
     - Yoga
-  - RNLiveMarkdown/newarch (0.1.195):
+  - RNLiveMarkdown/newarch (0.1.199):
     - DoubleConversion
     - glog
     - hermes-engine
@@ -1897,7 +1897,7 @@ SPEC CHECKSUMS:
   React-utils: f2afa6acd905ca2ce7bb8ffb4a22f7f8a12534e8
   ReactCodegen: e35c23cdd36922f6d2990c6c1f1b022ade7ad74d
   ReactCommon: 289214026502e6a93484f4a46bcc0efa4f3f2864
-  RNLiveMarkdown: 18b4dec85110bc61b02f53501cd9e7aa08066b7f
+  RNLiveMarkdown: 18dd4ceada29d66a6b7c29b1b0df589e2fc82183
   RNReanimated: ab6c33a61e90c4cbe5dbcbe65bd6c7cb3be167e6
   SocketRocket: abac6f5de4d4d62d24e11868d7a2f427e0ef940d
   Yoga: 1354c027ab07c7736f99a3bef16172d6f1b12b47


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Details
This PR moves formatting logic to `MarkdownFormatter` class on iOS.

Apart from this, I also changed indentation from 4 to 2 spaces in the remaining code on @maksg's request.

This change is analogous to https://github.com/Expensify/react-native-live-markdown/pull/563 for Android.

### Related Issues
<!-- Please replace GH_LINK with the link to the GitHub issue this Pull Request is related to -->
GH_LINK

### Manual Tests
<!---
Most changes should have accompanying tests. Describe the tests you added or if no tests were added an explanation about why one was not needed.
--->

### Linked PRs
<!---
Please include links to any update PRs in repos that must change their package.json version.
--->