### PR TITLE
Throw error when `html-entities` is not workletized

### DIFF
--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -1497,7 +1497,7 @@ PODS:
     - React-logger (= 0.75.3)
     - React-perflogger (= 0.75.3)
     - React-utils (= 0.75.3)
-  - RNLiveMarkdown (0.1.199):
+  - RNLiveMarkdown (0.1.203):
     - DoubleConversion
     - glog
     - hermes-engine
@@ -1517,10 +1517,10 @@ PODS:
     - ReactCodegen
     - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
-    - RNLiveMarkdown/newarch (= 0.1.199)
+    - RNLiveMarkdown/newarch (= 0.1.203)
     - RNReanimated/worklets
     - Yoga
-  - RNLiveMarkdown/newarch (0.1.199):
+  - RNLiveMarkdown/newarch (0.1.203):
     - DoubleConversion
     - glog
     - hermes-engine
@@ -1897,7 +1897,7 @@ SPEC CHECKSUMS:
   React-utils: f2afa6acd905ca2ce7bb8ffb4a22f7f8a12534e8
   ReactCodegen: e35c23cdd36922f6d2990c6c1f1b022ade7ad74d
   ReactCommon: 289214026502e6a93484f4a46bcc0efa4f3f2864
-  RNLiveMarkdown: 18dd4ceada29d66a6b7c29b1b0df589e2fc82183
+  RNLiveMarkdown: ed779eaf35a346f5254079b825a13f0a032ba64a
   RNReanimated: ab6c33a61e90c4cbe5dbcbe65bd6c7cb3be167e6
   SocketRocket: abac6f5de4d4d62d24e11868d7a2f427e0ef940d
   Yoga: 1354c027ab07c7736f99a3bef16172d6f1b12b47

--- a/src/parseExpensiMark.ts
+++ b/src/parseExpensiMark.ts
@@ -2,7 +2,16 @@
 
 import {ExpensiMark} from 'expensify-common';
 import {unescapeText} from 'expensify-common/dist/utils';
+import {decode} from 'html-entities';
+import type {WorkletFunction} from 'react-native-reanimated/lib/typescript/commonTypes';
 import type {MarkdownType, MarkdownRange} from './commonTypes';
+
+// eslint-disable-next-line no-underscore-dangle
+if (__DEV__ && (decode as WorkletFunction).__workletHash === undefined) {
+  throw new Error(
+    "[react-native-live-markdown] `parseExpensiMark` requires `html-entities` package to be workletized. Please add `'worklet';` directive at the top of `node_modules/html-entities/lib/index.js` using patch-package.",
+  );
+}
 
 const MAX_PARSABLE_LENGTH = 4000;
 


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Details
This PR checks if `decode` function from `html-entities` package is a worklet and throws the following error if that's not the case (only in dev mode).

Suggested by @s77rt in https://github.com/Expensify/App/issues/52475#issuecomment-2529709503.

<img width="448" alt="Screenshot 2024-12-10 at 09 24 30" src="https://github.com/user-attachments/assets/e0b8c310-bf5b-48b9-87e9-6df41c40cd91">

### Related Issues
<!-- Please replace GH_LINK with the link to the GitHub issue this Pull Request is related to -->
GH_LINK

### Manual Tests
<!---
Most changes should have accompanying tests. Describe the tests you added or if no tests were added an explanation about why one was not needed.
--->

### Linked PRs
<!---
Please include links to any update PRs in repos that must change their package.json version.
--->