### PR TITLE
Fix codeblock text parsing

### DIFF
--- a/src/parseExpensiMark.ts
+++ b/src/parseExpensiMark.ts
@@ -172,7 +172,7 @@ function parseTreeToTextAndRanges(tree: StackItem): [string, MarkdownRange[]] {
         text += '\n';
       } else if (node.tag.startsWith('<pre')) {
         appendSyntax('```');
-        const content = node.children.join('').replaceAll('&#32;', ' ');
+        const content = node.children.join('');
         addChildrenWithStyle(content, 'pre');
         appendSyntax('```');
       } else if (node.tag.startsWith('<a href="')) {


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Details
<!-- Explanation of the change or anything fishy that is going on -->
This PR fixes parsing '&#.32;' (space HTML entity) in the codeblocks

### Related Issues
<!-- Please replace GH_LINK with the link to the GitHub issue this Pull Request is related to -->
https://github.com/Expensify/react-native-live-markdown/issues/580

### Manual Tests
<!---
Most changes should have accompanying tests. Describe the tests you added or if no tests were added an explanation about why one was not needed.
--->

### Linked PRs
<!---
Please include links to any update PRs in repos that must change their package.json version.
--->