### PR TITLE
Fix custom parsing on the web

### DIFF
--- a/src/__tests__/parseExpensiMark.test.ts
+++ b/src/__tests__/parseExpensiMark.test.ts
@@ -1,6 +1,6 @@
 import {expect} from '@jest/globals';
 import type {MarkdownRange} from '../commonTypes';
-import parseExpensiMark from '../parseExpensiMark';
+import {parseExpensiMark} from '../parseExpensiMark';
 
 declare module 'expect' {
   interface Matchers<R> {

--- a/src/__tests__/webParser.test.tsx
+++ b/src/__tests__/webParser.test.tsx
@@ -1,7 +1,7 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import {expect} from '@jest/globals';
 import {parseRangesToHTMLNodes} from '../web/utils/parserUtils';
-import parseExpensiMark from '../parseExpensiMark';
+import {parseExpensiMark} from '../parseExpensiMark';
 
 declare module 'expect' {
   interface Matchers<R> {

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,4 +1,4 @@
 export {default as MarkdownTextInput} from './MarkdownTextInput';
 export type {MarkdownTextInputProps, MarkdownStyle} from './MarkdownTextInput';
 export type {MarkdownType, MarkdownRange} from './commonTypes';
-export {default as parseExpensiMark} from './parseExpensiMark';
+export {parseExpensiMark} from './parseExpensiMark';

--- a/src/parseExpensiMark.ts
+++ b/src/parseExpensiMark.ts
@@ -292,4 +292,4 @@ function parseExpensiMark(markdown: string): MarkdownRange[] {
   return groupedRanges;
 }
 
-export default parseExpensiMark;
+export {parseExpensiMark, sortRanges};

--- a/src/web/utils/parserUtils.ts
+++ b/src/web/utils/parserUtils.ts
@@ -6,6 +6,7 @@ import {getCurrentCursorPosition, moveCursorToEnd, setCursorPosition} from './cu
 import {addStyleToBlock, extendBlockStructure, getFirstBlockMarkdownRange, isBlockMarkdownType} from './blockUtils';
 import type {InlineImagesInputProps, MarkdownRange} from '../../commonTypes';
 import {getAnimationCurrentTimes, updateAnimationsTime} from './animationUtils';
+import {sortRanges} from '../../parseExpensiMark';
 
 type Paragraph = {
   text: string;
@@ -167,7 +168,8 @@ function parseRangesToHTMLNodes(
     return {dom: rootElement, tree: rootNode};
   }
 
-  const markdownRanges = ungroupRanges(ranges);
+  const sortedRanges = sortRanges(ranges);
+  const markdownRanges = ungroupRanges(sortedRanges);
   lines = mergeLinesWithMultilineTags(lines, markdownRanges);
 
   let lastRangeEndIndex = 0;


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Details
<!-- Explanation of the change or anything fishy that is going on -->

This PR adds range sorting in web range to HTML parser in `parserUtils.ts`. Web parsers requires sorted ranges to work properly, so we with fix we enforce the correct order of items


https://github.com/user-attachments/assets/ae384c30-a387-4cc4-a9b2-1b0eaafdcfed



### Related Issues
<!-- Please replace GH_LINK with the link to the GitHub issue this Pull Request is related to -->
https://github.com/Expensify/react-native-live-markdown/issues/584

### Manual Tests
<!---
Most changes should have accompanying tests. Describe the tests you added or if no tests were added an explanation about why one was not needed.
--->
1. Open the example app
2. Write following text: `@a #1`

### Linked PRs
<!---
Please include links to any update PRs in repos that must change their package.json version.
--->