### PR TITLE
Fix blockquote line height on iOS

### DIFF
--- a/apple/MarkdownFormatter.mm
+++ b/apple/MarkdownFormatter.mm
@@ -28,7 +28,11 @@
                  defaultTextAttributes:defaultTextAttributes];
   }
 
-  RCTApplyBaselineOffset(attributedString);
+  [attributedString.string enumerateSubstringsInRange:NSMakeRange(0, attributedString.length)
+                                              options:NSStringEnumerationByLines | NSStringEnumerationSubstringNotRequired
+                                           usingBlock:^(NSString * _Nullable substring, NSRange substringRange, NSRange enclosingRange, BOOL * _Nonnull stop) {
+    RCTApplyBaselineOffset(attributedString, enclosingRange);
+  }];
 
   [attributedString endEditing];
 
@@ -116,12 +120,12 @@
   }
 }
 
-static void RCTApplyBaselineOffset(NSMutableAttributedString *attributedText)
+static void RCTApplyBaselineOffset(NSMutableAttributedString *attributedText, NSRange attributedTextRange)
 {
   __block CGFloat maximumLineHeight = 0;
 
   [attributedText enumerateAttribute:NSParagraphStyleAttributeName
-                             inRange:NSMakeRange(0, attributedText.length)
+                             inRange:attributedTextRange
                              options:NSAttributedStringEnumerationLongestEffectiveRangeNotRequired
                           usingBlock:^(NSParagraphStyle *paragraphStyle, __unused NSRange range, __unused BOOL *stop) {
     if (!paragraphStyle) {
@@ -139,7 +143,7 @@ static void RCTApplyBaselineOffset(NSMutableAttributedString *attributedText)
   __block CGFloat maximumFontLineHeight = 0;
 
   [attributedText enumerateAttribute:NSFontAttributeName
-                             inRange:NSMakeRange(0, attributedText.length)
+                             inRange:attributedTextRange
                              options:NSAttributedStringEnumerationLongestEffectiveRangeNotRequired
                           usingBlock:^(UIFont *font, NSRange range, __unused BOOL *stop) {
     if (!font) {
@@ -156,7 +160,7 @@ static void RCTApplyBaselineOffset(NSMutableAttributedString *attributedText)
   CGFloat baseLineOffset = (maximumLineHeight - maximumFontLineHeight) / 2.0;
   [attributedText addAttribute:NSBaselineOffsetAttributeName
                          value:@(baseLineOffset)
-                         range:NSMakeRange(0, attributedText.length)];
+                         range:attributedTextRange];
 }
 
 @end

--- a/apple/MarkdownFormatter.mm
+++ b/apple/MarkdownFormatter.mm
@@ -24,7 +24,8 @@
                                   type:std::string([markdownRange.type UTF8String])
                                  range:markdownRange.range
                                  depth:markdownRange.depth
-                         markdownStyle:markdownStyle];
+                         markdownStyle:markdownStyle
+                 defaultTextAttributes:defaultTextAttributes];
   }
 
   RCTApplyBaselineOffset(attributedString);
@@ -38,7 +39,9 @@
                                 type:(const std::string)type
                                range:(const NSRange)range
                                depth:(const int)depth
-                       markdownStyle:(nonnull RCTMarkdownStyle *)markdownStyle {
+                       markdownStyle:(nonnull RCTMarkdownStyle *)markdownStyle
+               defaultTextAttributes:(nonnull NSDictionary<NSAttributedStringKey, id> *)defaultTextAttributes
+{
   if (type == "bold" || type == "italic" || type == "code" || type == "pre" || type == "h1" || type == "emoji") {
     UIFont *font = [attributedString attribute:NSFontAttributeName atIndex:range.location effectiveRange:NULL];
     if (type == "bold") {
@@ -99,7 +102,8 @@
     [attributedString addAttribute:NSForegroundColorAttributeName value:markdownStyle.linkColor range:range];
   } else if (type == "blockquote") {
     CGFloat indent = (markdownStyle.blockquoteMarginLeft + markdownStyle.blockquoteBorderWidth + markdownStyle.blockquotePaddingLeft) * depth;
-    NSMutableParagraphStyle *paragraphStyle = [NSMutableParagraphStyle new];
+    NSParagraphStyle *defaultParagraphStyle = defaultTextAttributes[NSParagraphStyleAttributeName];
+    NSMutableParagraphStyle *paragraphStyle = defaultParagraphStyle != nil ? [defaultParagraphStyle mutableCopy] : [NSMutableParagraphStyle new];
     paragraphStyle.firstLineHeadIndent = indent;
     paragraphStyle.headIndent = indent;
     [attributedString addAttribute:NSParagraphStyleAttributeName value:paragraphStyle range:range];

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -1497,7 +1497,7 @@ PODS:
     - React-logger (= 0.75.3)
     - React-perflogger (= 0.75.3)
     - React-utils (= 0.75.3)
-  - RNLiveMarkdown (0.1.208):
+  - RNLiveMarkdown (0.1.210):
     - DoubleConversion
     - glog
     - hermes-engine
@@ -1517,10 +1517,10 @@ PODS:
     - ReactCodegen
     - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
-    - RNLiveMarkdown/newarch (= 0.1.208)
+    - RNLiveMarkdown/newarch (= 0.1.210)
     - RNReanimated/worklets
     - Yoga
-  - RNLiveMarkdown/newarch (0.1.208):
+  - RNLiveMarkdown/newarch (0.1.210):
     - DoubleConversion
     - glog
     - hermes-engine
@@ -1897,7 +1897,7 @@ SPEC CHECKSUMS:
   React-utils: f2afa6acd905ca2ce7bb8ffb4a22f7f8a12534e8
   ReactCodegen: e35c23cdd36922f6d2990c6c1f1b022ade7ad74d
   ReactCommon: 289214026502e6a93484f4a46bcc0efa4f3f2864
-  RNLiveMarkdown: 1ee098c3a830c3133c23fc163b0aff29398a293e
+  RNLiveMarkdown: 687bc45ffb3b4af261f414fea169f10eae5ac261
   RNReanimated: 75df06d3a81fc147b83056ae469512f573365b1d
   SocketRocket: abac6f5de4d4d62d24e11868d7a2f427e0ef940d
   Yoga: 1354c027ab07c7736f99a3bef16172d6f1b12b47

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -1497,7 +1497,7 @@ PODS:
     - React-logger (= 0.75.3)
     - React-perflogger (= 0.75.3)
     - React-utils (= 0.75.3)
-  - RNLiveMarkdown (0.1.205):
+  - RNLiveMarkdown (0.1.208):
     - DoubleConversion
     - glog
     - hermes-engine
@@ -1517,10 +1517,10 @@ PODS:
     - ReactCodegen
     - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
-    - RNLiveMarkdown/newarch (= 0.1.205)
+    - RNLiveMarkdown/newarch (= 0.1.208)
     - RNReanimated/worklets
     - Yoga
-  - RNLiveMarkdown/newarch (0.1.205):
+  - RNLiveMarkdown/newarch (0.1.208):
     - DoubleConversion
     - glog
     - hermes-engine
@@ -1897,7 +1897,7 @@ SPEC CHECKSUMS:
   React-utils: f2afa6acd905ca2ce7bb8ffb4a22f7f8a12534e8
   ReactCodegen: e35c23cdd36922f6d2990c6c1f1b022ade7ad74d
   ReactCommon: 289214026502e6a93484f4a46bcc0efa4f3f2864
-  RNLiveMarkdown: bf0f16b1e8c3320d600a5931d270e19afef9fa92
+  RNLiveMarkdown: e8b7f5cf8a0e8027850a781ffc86119e21fb406a
   RNReanimated: 75df06d3a81fc147b83056ae469512f573365b1d
   SocketRocket: abac6f5de4d4d62d24e11868d7a2f427e0ef940d
   Yoga: 1354c027ab07c7736f99a3bef16172d6f1b12b47


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Details
This PR fixes line height inside blockquote on iOS.

When `lineHeight` style is set on `MarkdownTextInput`, React Native adds `NSParagraphStyle` with `minimumLineHeight` and `maximumLineHeight` to the attributed string.

In Live Markdown, blockquote indent is set using another `NSParagraphStyle` with `firstLineHeadIndent` and `headIndent`.

Currently, we create `NSParagraphStyle` using `[NSParagraphStyle new]`, ignoring the `NSParagraphStyle` created by React Native.

This PR uses the `NSParagraphStyle` set by React Native when creating `NSParagraphStyle` for blockquotes.

<table>
<thead>
<tr>
<th>Before</th>
<th>After</th>
</tr>
</thead>
<tbody>
<tr>
<td><video src="https://github.com/user-attachments/assets/e3dc8e3b-91c4-4fda-82dc-c540f346e2f0" /></td>
<td><video src="https://github.com/user-attachments/assets/67724dd0-9fd0-4495-9488-4b7619bbd235" /></td>
</tr>
</tbody>
</table>

### Related Issues
<!-- Please replace GH_LINK with the link to the GitHub issue this Pull Request is related to -->
GH_LINK

### Manual Tests
When testing, please set `lineHeight: 30` inside `styles.input` in `App.tsx`.

### Linked PRs
<!---
Please include links to any update PRs in repos that must change their package.json version.
--->