### PR TITLE
Fix build with `USE_FRAMEWORKS=static`

### DIFF
--- a/RNLiveMarkdown.podspec
+++ b/RNLiveMarkdown.podspec
@@ -4,6 +4,10 @@ react_native_node_modules_dir = ENV['REACT_NATIVE_NODE_MODULES_DIR'] || File.joi
 react_native_json = JSON.parse(File.read(File.join(react_native_node_modules_dir, 'react-native/package.json')))
 react_native_minor_version = react_native_json['version'].split('.')[1].to_i
 
+pods_root = Pod::Config.instance.project_pods_root
+react_native_reanimated_node_modules_dir = ENV['REACT_NATIVE_REANIMATED_NODE_MODULES_DIR'] || File.dirname(`cd "#{Pod::Config.instance.installation_root.to_s}" && node --print "require.resolve('react-native-reanimated/package.json')"`)
+react_native_reanimated_node_modules_dir_from_pods_root = Pathname.new(react_native_reanimated_node_modules_dir).relative_path_from(pods_root).to_s
+
 package = JSON.parse(File.read(File.join(__dir__, "package.json")))
 folly_compiler_flags = '-DFOLLY_NO_CONFIG -DFOLLY_MOBILE=1 -DFOLLY_USE_LIBCPP=1 -Wno-comma -Wno-shorten-64-to-32'
 
@@ -23,7 +27,11 @@ Pod::Spec.new do |s|
   s.dependency "RNReanimated/worklets"
 
   s.xcconfig = {
-    "OTHER_CFLAGS" => "$(inherited) -DREACT_NATIVE_MINOR_VERSION=#{react_native_minor_version}"
+    "OTHER_CFLAGS" => "$(inherited) -DREACT_NATIVE_MINOR_VERSION=#{react_native_minor_version}",
+    "HEADER_SEARCH_PATHS" => [
+      "\"$(PODS_ROOT)/#{react_native_reanimated_node_modules_dir_from_pods_root}/apple\"",
+      "\"$(PODS_ROOT)/#{react_native_reanimated_node_modules_dir_from_pods_root}/Common/cpp\"",
+    ].join(' '),
   }
 
   install_modules_dependencies(s)
@@ -33,6 +41,7 @@ Pod::Spec.new do |s|
       "react/renderer/textlayoutmanager/platform/ios",
       "react/renderer/components/textinput/platform/ios",
     ])
+    add_dependency(s, "React-rendererconsistency")
   end
 
   if ENV['RCT_NEW_ARCH_ENABLED'] == '1'

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -1497,7 +1497,7 @@ PODS:
     - React-logger (= 0.75.3)
     - React-perflogger (= 0.75.3)
     - React-utils (= 0.75.3)
-  - RNLiveMarkdown (0.1.205):
+  - RNLiveMarkdown (0.1.208):
     - DoubleConversion
     - glog
     - hermes-engine
@@ -1517,10 +1517,10 @@ PODS:
     - ReactCodegen
     - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
-    - RNLiveMarkdown/newarch (= 0.1.205)
+    - RNLiveMarkdown/newarch (= 0.1.208)
     - RNReanimated/worklets
     - Yoga
-  - RNLiveMarkdown/newarch (0.1.205):
+  - RNLiveMarkdown/newarch (0.1.208):
     - DoubleConversion
     - glog
     - hermes-engine
@@ -1897,7 +1897,7 @@ SPEC CHECKSUMS:
   React-utils: f2afa6acd905ca2ce7bb8ffb4a22f7f8a12534e8
   ReactCodegen: e35c23cdd36922f6d2990c6c1f1b022ade7ad74d
   ReactCommon: 289214026502e6a93484f4a46bcc0efa4f3f2864
-  RNLiveMarkdown: bf0f16b1e8c3320d600a5931d270e19afef9fa92
+  RNLiveMarkdown: 1ee098c3a830c3133c23fc163b0aff29398a293e
   RNReanimated: 75df06d3a81fc147b83056ae469512f573365b1d
   SocketRocket: abac6f5de4d4d62d24e11868d7a2f427e0ef940d
   Yoga: 1354c027ab07c7736f99a3bef16172d6f1b12b47


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Details
Fixes https://github.com/Expensify/react-native-live-markdown/issues/588.
Fixes https://github.com/Expensify/App/issues/54256.

This PR fixes failing iOS build with `USE_FRAMEWORKS=static` caused by two problems.

<img width="1329" alt="Screenshot 2024-12-17 at 19 02 53" src="https://github.com/user-attachments/assets/63a0abf6-48c3-475c-a7dc-a5cf97584746" />

1. `'worklets/WorkletRuntime/WorkletRuntime.h' file not found` – this is caused by incorrect header structure in react-native-reanimated when `USE_FRAMEWORKS=static` is enabled. This is related to https://github.com/software-mansion/react-native-reanimated/pull/6614. The workaround here is to find path to `node_modules/react-native-reanimated`, append it with `apple/` or `Common/cpp/` and add them to header search paths. This needs to be fixed in react-native-reanimated; once fixed there we can remove the workaround here.

2. `react/renderer/consistency/ShadowTreeRevisionConsistencyManager.h` file not found` – this is resolved by declaring a dependency on `React-rendererconsistency` podspec when `USE_FRAMEWORKS=static` is enabled. We already do the same thing for `React-FabricComponents`.

### Related Issues
<!-- Please replace GH_LINK with the link to the GitHub issue this Pull Request is related to -->
GH_LINK

### Manual Tests
<!---
Most changes should have accompanying tests. Describe the tests you added or if no tests were added an explanation about why one was not needed.
--->

### Linked PRs
<!---
Please include links to any update PRs in repos that must change their package.json version.
--->