### PR TITLE
FIX: Android - Live markdown style not applied consistently

### DIFF
--- a/android/src/main/java/com/expensify/livemarkdown/MarkdownTextInputDecoratorView.java
+++ b/android/src/main/java/com/expensify/livemarkdown/MarkdownTextInputDecoratorView.java
@@ -61,6 +61,7 @@ public class MarkdownTextInputDecoratorView extends View {
       mReactEditText = (ReactEditText) previousSibling;
       mTextWatcher = new MarkdownTextWatcher(mMarkdownUtils);
       mReactEditText.addTextChangedListener(mTextWatcher);
+      applyNewStyles();
     }
   }
 


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Details
<!-- Explanation of the change or anything fishy that is going on -->

Coming from this **E/App** issue:
- https://github.com/Expensify/App/issues/53645

only on **Android: Native**, the input live markdown styling was not being applied on subsequent component mount. More details can be found in the issue on why and how we went about fixing the issue.

cc @tomekzaw as you already have context on the discussions and approved the solution

### Related Issues
<!-- Please replace GH_LINK with the link to the GitHub issue this Pull Request is related to -->
- https://github.com/Expensify/App/issues/53645

### Manual Tests
<!---
Most changes should have accompanying tests. Describe the tests you added or if no tests were added an explanation about why one was not needed.
--->

**Note**: Not reproducible with the example app because it doesn't have a navigation stack and the component structure which led to the issue in **E/App**.

**E/App Tests**

1. Go to FAB > Submit expense > Manual.
2. Enter amount > Next.
3. Select a recipient.
4. Tap Description.
5. Enter text with markdown and save.
6. Tap Description again and verify that the markdown styling is applied when the input is mounted.

| Before | After |
| ------------- | ------------- |
| <video src="https://github.com/user-attachments/assets/25eadc98-f823-4005-95ed-8957559f7d77"> | <video src="https://github.com/user-attachments/assets/2dad7284-62cf-4aa2-93cb-5d01e3916683"> |

### Linked PRs
<!---
Please include links to any update PRs in repos that must change their package.json version.
--->