### PR TITLE
Prevent italic or strikethrough emojis on Android

### DIFF
--- a/src/__tests__/splitRangesOnEmojis.test.ts
+++ b/src/__tests__/splitRangesOnEmojis.test.ts
@@ -1,0 +1,64 @@
+import type {MarkdownRange} from '../commonTypes';
+import {splitRangesOnEmojis} from '../rangeUtils';
+
+test('No Overlap', () => {
+  const markdownRanges: MarkdownRange[] = [
+    {type: 'strikethrough', start: 0, length: 10, depth: 1},
+    {type: 'emoji', start: 12, length: 2, depth: 1},
+  ];
+
+  const splittedRanges = splitRangesOnEmojis(markdownRanges, 'strikethrough');
+  expect(splittedRanges).toEqual([
+    {type: 'strikethrough', start: 0, length: 10, depth: 1},
+    {type: 'emoji', start: 12, length: 2, depth: 1},
+  ]);
+});
+
+test('Overlap Different Type', () => {
+  const markdownRanges: MarkdownRange[] = [
+    {type: 'strikethrough', start: 0, length: 10, depth: 1},
+    {type: 'emoji', start: 3, length: 4, depth: 1},
+  ];
+
+  const splittedRanges = splitRangesOnEmojis(markdownRanges, 'italic');
+  expect(splittedRanges).toEqual(markdownRanges);
+});
+
+test('Single Overlap', () => {
+  let markdownRanges: MarkdownRange[] = [
+    {type: 'strikethrough', start: 0, length: 10, depth: 1},
+    {type: 'emoji', start: 3, length: 4, depth: 1},
+  ];
+
+  markdownRanges = splitRangesOnEmojis(markdownRanges, 'strikethrough');
+  markdownRanges.sort((a, b) => a.start - b.start);
+
+  expect(markdownRanges).toEqual([
+    {type: 'strikethrough', start: 0, length: 3, depth: 1},
+    {type: 'emoji', start: 3, length: 4, depth: 1},
+    {type: 'strikethrough', start: 7, length: 3, depth: 1},
+  ]);
+});
+
+test('Multiple Overlaps Multiple Types', () => {
+  let markdownRanges: MarkdownRange[] = [
+    {type: 'italic', start: 0, length: 20, depth: 1},
+    {type: 'strikethrough', start: 2, length: 12, depth: 1},
+    {type: 'emoji', start: 3, length: 1, depth: 1},
+    {type: 'emoji', start: 8, length: 2, depth: 1},
+    {type: 'strikethrough', start: 22, length: 5, depth: 1},
+  ];
+
+  markdownRanges = splitRangesOnEmojis(markdownRanges, 'strikethrough');
+  markdownRanges.sort((a, b) => a.start - b.start);
+
+  expect(markdownRanges).toEqual([
+    {type: 'italic', start: 0, length: 20, depth: 1},
+    {type: 'strikethrough', start: 2, length: 1, depth: 1},
+    {type: 'emoji', start: 3, length: 1, depth: 1},
+    {type: 'strikethrough', start: 4, length: 4, depth: 1},
+    {type: 'emoji', start: 8, length: 2, depth: 1},
+    {type: 'strikethrough', start: 10, length: 4, depth: 1},
+    {type: 'strikethrough', start: 22, length: 5, depth: 1},
+  ]);
+});

--- a/src/__tests__/splitRangesOnEmojis.test.ts
+++ b/src/__tests__/splitRangesOnEmojis.test.ts
@@ -1,64 +1,163 @@
 import type {MarkdownRange} from '../commonTypes';
 import {splitRangesOnEmojis} from '../rangeUtils';
 
-test('No Overlap', () => {
+const sortRanges = (ranges: MarkdownRange[]) => {
+  return ranges.sort((a, b) => a.start - b.start);
+};
+
+test('no overlap', () => {
   const markdownRanges: MarkdownRange[] = [
-    {type: 'strikethrough', start: 0, length: 10, depth: 1},
-    {type: 'emoji', start: 12, length: 2, depth: 1},
+    {type: 'strikethrough', start: 0, length: 10},
+    {type: 'emoji', start: 12, length: 2},
   ];
 
   const splittedRanges = splitRangesOnEmojis(markdownRanges, 'strikethrough');
   expect(splittedRanges).toEqual([
-    {type: 'strikethrough', start: 0, length: 10, depth: 1},
-    {type: 'emoji', start: 12, length: 2, depth: 1},
+    {type: 'strikethrough', start: 0, length: 10},
+    {type: 'emoji', start: 12, length: 2},
   ]);
 });
 
-test('Overlap Different Type', () => {
+test('overlap different type', () => {
   const markdownRanges: MarkdownRange[] = [
-    {type: 'strikethrough', start: 0, length: 10, depth: 1},
-    {type: 'emoji', start: 3, length: 4, depth: 1},
+    {type: 'strikethrough', start: 0, length: 10},
+    {type: 'emoji', start: 3, length: 4},
   ];
 
   const splittedRanges = splitRangesOnEmojis(markdownRanges, 'italic');
   expect(splittedRanges).toEqual(markdownRanges);
 });
 
-test('Single Overlap', () => {
-  let markdownRanges: MarkdownRange[] = [
-    {type: 'strikethrough', start: 0, length: 10, depth: 1},
-    {type: 'emoji', start: 3, length: 4, depth: 1},
-  ];
+describe('single overlap', () => {
+  test('emoji at the beginning', () => {
+    let markdownRanges: MarkdownRange[] = [
+      {type: 'strikethrough', start: 0, length: 10},
+      {type: 'emoji', start: 0, length: 2},
+    ];
 
-  markdownRanges = splitRangesOnEmojis(markdownRanges, 'strikethrough');
-  markdownRanges.sort((a, b) => a.start - b.start);
+    markdownRanges = splitRangesOnEmojis(markdownRanges, 'strikethrough');
+    sortRanges(markdownRanges);
 
-  expect(markdownRanges).toEqual([
-    {type: 'strikethrough', start: 0, length: 3, depth: 1},
-    {type: 'emoji', start: 3, length: 4, depth: 1},
-    {type: 'strikethrough', start: 7, length: 3, depth: 1},
-  ]);
+    expect(markdownRanges).toEqual([
+      {type: 'emoji', start: 0, length: 2},
+      {type: 'strikethrough', start: 2, length: 8},
+    ]);
+  });
+
+  test('emoji in the middle', () => {
+    let markdownRanges: MarkdownRange[] = [
+      {type: 'strikethrough', start: 0, length: 10},
+      {type: 'emoji', start: 3, length: 4},
+    ];
+
+    markdownRanges = splitRangesOnEmojis(markdownRanges, 'strikethrough');
+    sortRanges(markdownRanges);
+
+    expect(markdownRanges).toEqual([
+      {type: 'strikethrough', start: 0, length: 3},
+      {type: 'emoji', start: 3, length: 4},
+      {type: 'strikethrough', start: 7, length: 3},
+    ]);
+  });
+
+  test('emoji at the end', () => {
+    let markdownRanges: MarkdownRange[] = [
+      {type: 'strikethrough', start: 0, length: 10},
+      {type: 'emoji', start: 8, length: 2},
+    ];
+
+    markdownRanges = splitRangesOnEmojis(markdownRanges, 'strikethrough');
+    sortRanges(markdownRanges);
+
+    expect(markdownRanges).toEqual([
+      {type: 'strikethrough', start: 0, length: 8},
+      {type: 'emoji', start: 8, length: 2},
+    ]);
+  });
+
+  test('multiple emojis in the middle', () => {
+    let markdownRanges: MarkdownRange[] = [
+      {type: 'strikethrough', start: 0, length: 10},
+      {type: 'emoji', start: 3, length: 2},
+      {type: 'emoji', start: 5, length: 2},
+    ];
+
+    markdownRanges = splitRangesOnEmojis(markdownRanges, 'strikethrough');
+    sortRanges(markdownRanges);
+
+    expect(markdownRanges).toEqual([
+      {type: 'strikethrough', start: 0, length: 3},
+      {type: 'emoji', start: 3, length: 2},
+      {type: 'emoji', start: 5, length: 2},
+      {type: 'strikethrough', start: 7, length: 3},
+    ]);
+  });
+
+  test('just emojis', () => {
+    let markdownRanges: MarkdownRange[] = [
+      {type: 'strikethrough', start: 0, length: 6},
+      {type: 'emoji', start: 0, length: 2},
+      {type: 'emoji', start: 2, length: 2},
+      {type: 'emoji', start: 4, length: 2},
+    ];
+
+    markdownRanges = splitRangesOnEmojis(markdownRanges, 'strikethrough');
+
+    expect(markdownRanges).toEqual([
+      {type: 'emoji', start: 0, length: 2},
+      {type: 'emoji', start: 2, length: 2},
+      {type: 'emoji', start: 4, length: 2},
+    ]);
+  });
 });
 
-test('Multiple Overlaps Multiple Types', () => {
-  let markdownRanges: MarkdownRange[] = [
-    {type: 'italic', start: 0, length: 20, depth: 1},
-    {type: 'strikethrough', start: 2, length: 12, depth: 1},
-    {type: 'emoji', start: 3, length: 1, depth: 1},
-    {type: 'emoji', start: 8, length: 2, depth: 1},
-    {type: 'strikethrough', start: 22, length: 5, depth: 1},
-  ];
+describe('multiple overlaps', () => {
+  test('multiple types splitting on one', () => {
+    let markdownRanges: MarkdownRange[] = [
+      {type: 'italic', start: 0, length: 20},
+      {type: 'strikethrough', start: 2, length: 12},
+      {type: 'emoji', start: 3, length: 1},
+      {type: 'emoji', start: 8, length: 2},
+      {type: 'strikethrough', start: 22, length: 5},
+    ];
 
-  markdownRanges = splitRangesOnEmojis(markdownRanges, 'strikethrough');
-  markdownRanges.sort((a, b) => a.start - b.start);
+    markdownRanges = splitRangesOnEmojis(markdownRanges, 'strikethrough');
+    sortRanges(markdownRanges);
 
-  expect(markdownRanges).toEqual([
-    {type: 'italic', start: 0, length: 20, depth: 1},
-    {type: 'strikethrough', start: 2, length: 1, depth: 1},
-    {type: 'emoji', start: 3, length: 1, depth: 1},
-    {type: 'strikethrough', start: 4, length: 4, depth: 1},
-    {type: 'emoji', start: 8, length: 2, depth: 1},
-    {type: 'strikethrough', start: 10, length: 4, depth: 1},
-    {type: 'strikethrough', start: 22, length: 5, depth: 1},
-  ]);
+    expect(markdownRanges).toEqual([
+      {type: 'italic', start: 0, length: 20},
+      {type: 'strikethrough', start: 2, length: 1},
+      {type: 'emoji', start: 3, length: 1},
+      {type: 'strikethrough', start: 4, length: 4},
+      {type: 'emoji', start: 8, length: 2},
+      {type: 'strikethrough', start: 10, length: 4},
+      {type: 'strikethrough', start: 22, length: 5},
+    ]);
+  });
+
+  test('multiple types splitting on all', () => {
+    let markdownRanges: MarkdownRange[] = [
+      {type: 'italic', start: 0, length: 20},
+      {type: 'strikethrough', start: 2, length: 12},
+      {type: 'emoji', start: 3, length: 1},
+      {type: 'emoji', start: 8, length: 2},
+      {type: 'strikethrough', start: 22, length: 5},
+    ];
+
+    markdownRanges = splitRangesOnEmojis(markdownRanges, 'strikethrough');
+    markdownRanges = splitRangesOnEmojis(markdownRanges, 'italic');
+    sortRanges(markdownRanges);
+
+    expect(markdownRanges).toEqual([
+      {type: 'italic', start: 0, length: 3},
+      {type: 'strikethrough', start: 2, length: 1},
+      {type: 'emoji', start: 3, length: 1},
+      {type: 'italic', start: 4, length: 4},
+      {type: 'strikethrough', start: 4, length: 4},
+      {type: 'emoji', start: 8, length: 2},
+      {type: 'italic', start: 10, length: 10},
+      {type: 'strikethrough', start: 10, length: 4},
+      {type: 'strikethrough', start: 22, length: 5},
+    ]);
+  });
 });

--- a/src/__tests__/splitRangesOnEmojis.test.ts
+++ b/src/__tests__/splitRangesOnEmojis.test.ts
@@ -112,7 +112,7 @@ describe('single overlap', () => {
 });
 
 describe('multiple overlaps', () => {
-  test('multiple types splitting on one', () => {
+  test('splitting on one type', () => {
     let markdownRanges: MarkdownRange[] = [
       {type: 'italic', start: 0, length: 20},
       {type: 'strikethrough', start: 2, length: 12},
@@ -135,7 +135,7 @@ describe('multiple overlaps', () => {
     ]);
   });
 
-  test('multiple types splitting on all', () => {
+  test('splitting on two types', () => {
     let markdownRanges: MarkdownRange[] = [
       {type: 'italic', start: 0, length: 20},
       {type: 'strikethrough', start: 2, length: 12},

--- a/src/parseExpensiMark.ts
+++ b/src/parseExpensiMark.ts
@@ -6,6 +6,7 @@ import {unescapeText} from 'expensify-common/dist/utils';
 import {decode} from 'html-entities';
 import type {WorkletFunction} from 'react-native-reanimated/lib/typescript/commonTypes';
 import type {MarkdownType, MarkdownRange} from './commonTypes';
+import {splitRangesOnEmojis} from './rangeUtils';
 
 function isWeb() {
   return Platform.OS === 'web';
@@ -236,6 +237,8 @@ function parseTreeToTextAndRanges(tree: StackItem): [string, MarkdownRange[]] {
 // getTagPriority returns a priority for a tag, higher priority means the tag should be processed first
 function getTagPriority(tag: string) {
   switch (tag) {
+    case 'syntax': // syntax has the lowest priority so other styles can be applied to it
+      return -1;
     case 'blockquote':
       return 2;
     case 'h1':
@@ -287,8 +290,13 @@ function parseExpensiMark(markdown: string): MarkdownRange[] {
       )}'\nOriginal input: '${JSON.stringify(markdown)}'`,
     );
   }
-  const sortedRanges = sortRanges(ranges);
+
+  let splittedRanges = splitRangesOnEmojis(ranges, 'italic');
+  splittedRanges = splitRangesOnEmojis(splittedRanges, 'strikethrough');
+
+  const sortedRanges = sortRanges(splittedRanges);
   const groupedRanges = groupRanges(sortedRanges);
+
   return groupedRanges;
 }
 

--- a/src/rangeUtils.ts
+++ b/src/rangeUtils.ts
@@ -31,9 +31,9 @@ function splitRangesOnEmojis(ranges: MarkdownRange[], type: MarkdownType): Markd
         if (emojiStart >= currentStart && emojiEnd <= currentEnd) {
           // Intersection
           const newRange: MarkdownRange = {
+            type: currentRange.type,
             start: currentStart,
             length: emojiStart - currentStart,
-            type: currentRange.type,
             ...(currentRange?.depth && {depth: currentRange?.depth}),
           };
 
@@ -53,7 +53,6 @@ function splitRangesOnEmojis(ranges: MarkdownRange[], type: MarkdownType): Markd
       i++;
     }
   }
-
   return newRanges;
 }
 

--- a/src/rangeUtils.ts
+++ b/src/rangeUtils.ts
@@ -1,0 +1,60 @@
+import type {MarkdownRange, MarkdownType} from './commonTypes';
+
+function splitRangesOnEmojis(ranges: MarkdownRange[], type: MarkdownType): MarkdownRange[] {
+  const emojiRanges: MarkdownRange[] = ranges.filter((range) => range.type === 'emoji');
+  const newRanges: MarkdownRange[] = [];
+
+  let i = 0;
+  let j = 0;
+  while (i < ranges.length) {
+    const currentRange = ranges[i];
+    if (!currentRange) {
+      break;
+    }
+
+    if (currentRange.type !== type || currentRange.type === 'emoji') {
+      newRanges.push(currentRange);
+      i++;
+    } else {
+      // Iterate through all emoji ranges before the end of the current range, splitting the current range at each intersection.
+      while (j < emojiRanges.length) {
+        const emojiRange = emojiRanges[j];
+        if (!emojiRange || emojiRange.start > currentRange.start + currentRange.length) {
+          break;
+        }
+
+        const currentStart: number = currentRange.start;
+        const currentEnd: number = currentRange.start + currentRange.length;
+        const emojiStart: number = emojiRange.start;
+        const emojiEnd: number = emojiRange.start + emojiRange.length;
+
+        if (emojiStart >= currentStart && emojiEnd <= currentEnd) {
+          // Intersection
+          const newRange: MarkdownRange = {
+            start: currentStart,
+            length: emojiStart - currentStart,
+            type: currentRange.type,
+            depth: currentRange.depth,
+          };
+
+          currentRange.start = emojiEnd;
+          currentRange.length = currentEnd - emojiEnd;
+
+          if (newRange.length > 0) {
+            newRanges.push(newRange);
+          }
+        }
+        j++;
+      }
+
+      if (currentRange.length > 0) {
+        newRanges.push(currentRange);
+      }
+      i++;
+    }
+  }
+  return newRanges;
+}
+
+// eslint-disable-next-line import/prefer-default-export
+export {splitRangesOnEmojis};

--- a/src/rangeUtils.ts
+++ b/src/rangeUtils.ts
@@ -12,7 +12,7 @@ function splitRangesOnEmojis(ranges: MarkdownRange[], type: MarkdownType): Markd
       break;
     }
 
-    if (currentRange.type !== type || currentRange.type === 'emoji') {
+    if (currentRange.type !== type) {
       newRanges.push(currentRange);
       i++;
     } else {
@@ -34,7 +34,7 @@ function splitRangesOnEmojis(ranges: MarkdownRange[], type: MarkdownType): Markd
             start: currentStart,
             length: emojiStart - currentStart,
             type: currentRange.type,
-            depth: currentRange.depth,
+            ...(currentRange?.depth && {depth: currentRange?.depth}),
           };
 
           currentRange.start = emojiEnd;
@@ -53,6 +53,7 @@ function splitRangesOnEmojis(ranges: MarkdownRange[], type: MarkdownType): Markd
       i++;
     }
   }
+
   return newRanges;
 }
 

--- a/src/rangeUtils.ts
+++ b/src/rangeUtils.ts
@@ -1,3 +1,5 @@
+'worklet';
+
 import type {MarkdownRange, MarkdownType} from './commonTypes';
 
 function splitRangesOnEmojis(ranges: MarkdownRange[], type: MarkdownType): MarkdownRange[] {


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Details
<!-- Explanation of the change or anything fishy that is going on -->
This PR fixes adding italics and strikethrough style to the emojis on Android and web platforms. It adds range splitting algorithm in TypeScript to `parseExpensiMark` function so we won't interfere with the results of the custom parsers. This solution replaces https://github.com/Expensify/react-native-live-markdown/pull/534 PR, as discussed internally cc @tomekzaw 
### Related Issues
<!-- Please replace GH_LINK with the link to the GitHub issue this Pull Request is related to -->
https://github.com/Expensify/App/issues/14676

### Manual Tests
<!---
Most changes should have accompanying tests. Describe the tests you added or, if no tests were added an explanation about why one was not needed.
--->
1. To the text that contains emojis, add italics styling, e.g. `_🥰 test 😇 test 🥹_`
2. Verify if the text has italics style and emojis don't
3. Verify if it still works when adding other styles around it, e.g. `# *~_🥰 test 😇 test 🥹_~*`
4. Verify if emojis aren't strikethrough
5. Test it with different style combinations

### Linked PRs
<!---
Please include links to any update PRs in repos that must change their package.json version.
--->