### PR TITLE
Add support for short mentions from ExpensiMark

### DIFF
--- a/src/commonTypes.ts
+++ b/src/commonTypes.ts
@@ -5,6 +5,7 @@ type MarkdownType =
   | 'emoji'
   | 'mention-here'
   | 'mention-user'
+  | 'mention-short'
   | 'mention-report'
   | 'link'
   | 'code'

--- a/src/parseExpensiMark.ts
+++ b/src/parseExpensiMark.ts
@@ -154,6 +154,8 @@ function parseTreeToTextAndRanges(tree: StackItem): [string, MarkdownRange[]] {
         addChildrenWithStyle(node, 'mention-here');
       } else if (node.tag === '<mention-user>') {
         addChildrenWithStyle(node, 'mention-user');
+      } else if (node.tag === '<mention-short>') {
+        addChildrenWithStyle(node, 'mention-short');
       } else if (node.tag === '<mention-report>') {
         addChildrenWithStyle(node, 'mention-report');
       } else if (node.tag === '<blockquote>') {


### PR DESCRIPTION
### Details
This simple PR adds new markdown type called `mention-short`
 - the new `<mention-short>` tag will be returned from ExpensiMark once this PR is merged: https://github.com/Expensify/expensify-common/pull/824
 - mention short currently does not have it's own special styling

More details about short mentions can be found here: https://github.com/Expensify/App/issues/38025#issuecomment-2558138517

### Related Issues
https://github.com/Expensify/App/issues/38025

### Manual Tests
<!---
Most changes should have accompanying tests. Describe the tests you added or if no tests were added an explanation about why one was not needed.
--->

### Linked PRs
<!---
Please include links to any update PRs in repos that must change their package.json version.
--->