### PR TITLE
fix: return empty array instead of throwing error if text !== markdown

### DIFF
--- a/src/__tests__/parseExpensiMark.test.ts
+++ b/src/__tests__/parseExpensiMark.test.ts
@@ -31,6 +31,10 @@ test('no formatting', () => {
   expect('Hello, world!').toBeParsedAs([]);
 });
 
+describe('parsing error', () => {
+  expect(`> [exa\nmple.com](https://example.com)`).toBeParsedAs([]);
+});
+
 test('bold', () => {
   expect('Hello, *world*!').toBeParsedAs([
     {type: 'syntax', start: 7, length: 1},

--- a/src/parseExpensiMark.ts
+++ b/src/parseExpensiMark.ts
@@ -281,11 +281,12 @@ function parseExpensiMark(markdown: string): MarkdownRange[] {
   const tree = parseTokensToTree(tokens);
   const [text, ranges] = parseTreeToTextAndRanges(tree);
   if (text !== markdown) {
-    throw new Error(
+    console.error(
       `[react-native-live-markdown] Parsing error: the processed text does not match the original Markdown input. This may be caused by incorrect parsing functions or invalid input Markdown.\nProcessed input: '${JSON.stringify(
         text,
       )}'\nOriginal input: '${JSON.stringify(markdown)}'`,
     );
+    return [];
   }
   const sortedRanges = sortRanges(ranges);
   const groupedRanges = groupRanges(sortedRanges);


### PR DESCRIPTION
### Details

This PR fixes a bug where pressing enter/new line key doesn't cause the url text to be moved to a new line.

### Related Issues

https://github.com/Expensify/App/issues/54522

### Manual Tests

### Linked PRs