### PR TITLE
Move patch-package from postinstall to prepare

### DIFF
--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -1509,7 +1509,7 @@ PODS:
     - React-logger (= 0.76.3)
     - React-perflogger (= 0.76.3)
     - React-utils (= 0.76.3)
-  - RNLiveMarkdown (0.1.216):
+  - RNLiveMarkdown (0.1.218):
     - DoubleConversion
     - glog
     - hermes-engine
@@ -1529,10 +1529,10 @@ PODS:
     - ReactCodegen
     - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
-    - RNLiveMarkdown/newarch (= 0.1.216)
+    - RNLiveMarkdown/newarch (= 0.1.218)
     - RNReanimated/worklets
     - Yoga
-  - RNLiveMarkdown/newarch (0.1.216):
+  - RNLiveMarkdown/newarch (0.1.218):
     - DoubleConversion
     - glog
     - hermes-engine
@@ -1913,7 +1913,7 @@ SPEC CHECKSUMS:
   React-utils: 2bcaf4f4dfe361344bce2fae428603d518488630
   ReactCodegen: 3a85e3cb68c92f16b2ffcf192e30364d78f8ccb9
   ReactCommon: 89c87b343deacc8610b099ac764848f0ce937e3e
-  RNLiveMarkdown: 832e5ce7d3896c8352a859497a2465336105ea32
+  RNLiveMarkdown: cc674559a93c1f503ed6aac341a66346f05ef153
   RNReanimated: 97d6090ccdf33859f28cc6d394fb4fd799e75d29
   SocketRocket: d4aabe649be1e368d1318fdf28a022d714d65748
   Yoga: f6dc1b6029519815d5516a1241821c6a9074af6d

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,7 +7,6 @@
     "": {
       "name": "@expensify/react-native-live-markdown",
       "version": "0.1.218",
-      "hasInstallScript": true,
       "license": "MIT",
       "workspaces": [
         "./example",

--- a/package.json
+++ b/package.json
@@ -36,10 +36,9 @@
     "lint:example": "eslint example --ext .js,.ts,.tsx",
     "lint:WebExample": "eslint WebExample --ext .js,.ts,.tsx",
     "clean": "del-cli android/build example/android/build example/android/app/build example/ios/build lib",
-    "prepare": "bob build",
+    "prepare": "patch-package && bob build",
     "build:watch": "nodemon --watch src --ext .ts,.tsx,.css --exec \"rm -f .build_complete && npm run prepare && npm pack && touch .build_complete\"",
-    "release": "release-it",
-    "postinstall": "patch-package"
+    "release": "release-it"
   },
   "keywords": [
     "react-native",


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Details
<!-- Explanation of the change or anything fishy that is going on -->
This PR moves `patch-package` command from `postinstall` step to `prepare` step in `package.json` so it doesn't run when `react-native-live-markdown` is installed as a dependency but still does run when installing dependencies for development in this repository.

Fixes https://github.com/Expensify/react-native-live-markdown/issues/573.

### Related Issues
<!-- Please replace GH_LINK with the link to the GitHub issue this Pull Request is related to -->
GH_LINK

### Manual Tests
<!---
Most changes should have accompanying tests. Describe the tests you added or if no tests were added an explanation about why one was not needed.
--->

### Linked PRs
<!---
Please include links to any update PRs in repos that must change their package.json version.
--->