### PR TITLE
Remove splitting ranges on emojis on the web

### DIFF
--- a/example/src/testConstants.ts
+++ b/example/src/testConstants.ts
@@ -1,18 +1,6 @@
 const LOCAL_URL = 'http://localhost:19006/';
 
-const EXAMPLE_CONTENT = [
-  'Hello, *world*!',
-  '😀🍕🍔',
-  'https://expensify.com',
-  '# header1',
-  '> blockquote',
-  '`inline code`',
-  '```\ncodeblock\n```',
-  '@here',
-  '@someone@swmansion.com',
-  '#mention-report',
-  '![demo image](https://picsum.photos/id/1067/200/300)',
-].join('\n');
+const EXAMPLE_CONTENT = ['~_😀🍕🍔_~'].join('\n');
 
 const INPUT_ID = 'MarkdownInput_Example';
 const INPUT_HISTORY_DEBOUNCE_TIME_MS = 150;

--- a/example/src/testConstants.ts
+++ b/example/src/testConstants.ts
@@ -1,6 +1,18 @@
 const LOCAL_URL = 'http://localhost:19006/';
 
-const EXAMPLE_CONTENT = ['~_😀🍕🍔_~'].join('\n');
+const EXAMPLE_CONTENT = [
+  'Hello, *world*!',
+  '😀🍕🍔',
+  'https://expensify.com',
+  '# header1',
+  '> blockquote',
+  '`inline code`',
+  '```\ncodeblock\n```',
+  '@here',
+  '@someone@swmansion.com',
+  '#mention-report',
+  '![demo image](https://picsum.photos/id/1067/200/300)',
+].join('\n');
 
 const INPUT_ID = 'MarkdownInput_Example';
 const INPUT_HISTORY_DEBOUNCE_TIME_MS = 150;

--- a/src/parseExpensiMark.ts
+++ b/src/parseExpensiMark.ts
@@ -252,16 +252,16 @@ function parseExpensiMark(markdown: string): MarkdownRange[] {
     );
     return [];
   }
-  let markdownRanges = ranges;
+  const sortedRanges = sortRanges(ranges);
+  let markdownRanges = sortedRanges;
   // Blocks applying italic and strikethrough styles to emojis on Android
   // TODO: Remove this condition when splitting emojis inside the inline code block will be fixed on the web
   if (Platform.OS === 'android') {
     markdownRanges = splitRangesOnEmojis(markdownRanges, 'italic');
     markdownRanges = splitRangesOnEmojis(markdownRanges, 'strikethrough');
   }
-  const sortedRanges = sortRanges(markdownRanges);
-  const groupedRanges = groupRanges(sortedRanges);
 
+  const groupedRanges = groupRanges(markdownRanges);
   return groupedRanges;
 }
 

--- a/src/parseExpensiMark.ts
+++ b/src/parseExpensiMark.ts
@@ -236,6 +236,8 @@ function parseTreeToTextAndRanges(tree: StackItem): [string, MarkdownRange[]] {
   return [text, ranges];
 }
 
+const isAndroid = Platform.OS === 'android';
+
 function parseExpensiMark(markdown: string): MarkdownRange[] {
   if (markdown.length > MAX_PARSABLE_LENGTH) {
     return [];
@@ -252,9 +254,8 @@ function parseExpensiMark(markdown: string): MarkdownRange[] {
     );
     return [];
   }
-  const sortedRanges = sortRanges(ranges);
-  let markdownRanges = sortedRanges;
-  if (Platform.OS === 'android') {
+  let markdownRanges = sortRanges(ranges);
+  if (isAndroid) {
     // Blocks applying italic and strikethrough styles to emojis on Android
     // TODO: Remove this condition when splitting emojis inside the inline code block will be fixed on the web
     markdownRanges = splitRangesOnEmojis(markdownRanges, 'italic');

--- a/src/parseExpensiMark.ts
+++ b/src/parseExpensiMark.ts
@@ -252,11 +252,14 @@ function parseExpensiMark(markdown: string): MarkdownRange[] {
     );
     return [];
   }
-
-  let splittedRanges = splitRangesOnEmojis(ranges, 'italic');
-  splittedRanges = splitRangesOnEmojis(splittedRanges, 'strikethrough');
-
-  const sortedRanges = sortRanges(splittedRanges);
+  let markdownRanges = ranges;
+  // Blocks applying italic and strikethrough styles to emojis on Android
+  // TODO: Remove this condition when splitting emojis inside the inline code block will be fixed on the web
+  if (Platform.OS === 'android') {
+    markdownRanges = splitRangesOnEmojis(markdownRanges, 'italic');
+    markdownRanges = splitRangesOnEmojis(markdownRanges, 'strikethrough');
+  }
+  const sortedRanges = sortRanges(markdownRanges);
   const groupedRanges = groupRanges(sortedRanges);
 
   return groupedRanges;

--- a/src/parseExpensiMark.ts
+++ b/src/parseExpensiMark.ts
@@ -254,9 +254,9 @@ function parseExpensiMark(markdown: string): MarkdownRange[] {
   }
   const sortedRanges = sortRanges(ranges);
   let markdownRanges = sortedRanges;
-  // Blocks applying italic and strikethrough styles to emojis on Android
-  // TODO: Remove this condition when splitting emojis inside the inline code block will be fixed on the web
   if (Platform.OS === 'android') {
+    // Blocks applying italic and strikethrough styles to emojis on Android
+    // TODO: Remove this condition when splitting emojis inside the inline code block will be fixed on the web
     markdownRanges = splitRangesOnEmojis(markdownRanges, 'italic');
     markdownRanges = splitRangesOnEmojis(markdownRanges, 'strikethrough');
   }

--- a/src/web/utils/blockUtils.ts
+++ b/src/web/utils/blockUtils.ts
@@ -29,8 +29,8 @@ function addStyleToBlock(targetElement: HTMLElement, type: NodeType, markdownSty
       Object.assign(node.style, {
         ...markdownStyle.emoji,
         verticalAlign: 'middle',
-        fontStyle: 'normal',
-        textDecoration: 'none',
+        fontStyle: 'normal', // remove italic
+        textDecoration: 'none', // remove strikethrough
         display: 'inline-block',
       });
       break;

--- a/src/web/utils/blockUtils.ts
+++ b/src/web/utils/blockUtils.ts
@@ -26,7 +26,13 @@ function addStyleToBlock(targetElement: HTMLElement, type: NodeType, markdownSty
       node.style.textDecoration = 'line-through';
       break;
     case 'emoji':
-      Object.assign(node.style, {...markdownStyle.emoji, verticalAlign: 'middle'});
+      Object.assign(node.style, {
+        ...markdownStyle.emoji,
+        verticalAlign: 'middle',
+        fontStyle: 'normal',
+        textDecoration: 'none',
+        display: 'inline-block',
+      });
       break;
     case 'mention-here':
       Object.assign(node.style, markdownStyle.mentionHere);


### PR DESCRIPTION
<!-- If necessary, assign reviewers who know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Details
<!-- Explanation of the change or anything fishy that is going on -->
This PR fixes the problem with triplicating syntaxes inside the Live Markdown Input, by removing range-splitting logic from the web platform and replacing it with the fix based on CSS styles. In the future, we will focus on fixing the web parser to support splitting emojis among all other styles (especially inline code block) and properly handle tag hierarchy edge cases when building HTML structure. 

### Related Issues
<!-- Please replace GH_LINK with the link to the GitHub issue this Pull Request is related to -->
https://github.com/Expensify/App/issues/55115


### Manual Tests
<!---
Most changes should have accompanying tests. Describe the tests you added or if no tests were added an explanation about why one was not needed.
--->
1. To the text that contains emojis, add italics styling, e.g. `_🥰 test 😇 test 🥹_`
2. Verify if the text has italics style and emojis don't
3. Verify if it still works when adding other styles around it, e.g. `# *~_🥰 test 😇 test 🥹_~*`
4. Verify if emojis aren't strikethrough
5. Test it with different style combinations


### Linked PRs
<!---
Please include links to any updated PRs in repos that must change their package.json version.
--->
https://github.com/Expensify/react-native-live-markdown/pull/597