### PR TITLE
Fix pasting in composition mode

### DIFF
--- a/src/MarkdownTextInput.web.tsx
+++ b/src/MarkdownTextInput.web.tsx
@@ -38,6 +38,8 @@ interface MarkdownTextInputProps extends TextInputProps, InlineImagesInputProps 
 
 interface MarkdownNativeEvent extends Event {
   inputType?: string;
+  isComposing?: boolean;
+  keyCode?: number;
 }
 
 type MarkdownTextInput = TextInput & React.Component<MarkdownTextInputProps>;
@@ -120,7 +122,6 @@ const MarkdownTextInput = React.forwardRef<MarkdownTextInput, MarkdownTextInputP
       throw new Error('[react-native-live-markdown] `parser` is not a function');
     }
 
-    const compositionRef = useRef<boolean>(false);
     const divRef = useRef<MarkdownTextInputElement | null>(null);
     const currentlyFocusedField = useRef<HTMLDivElement | null>(null);
     const contentSelection = useRef<Selection | null>(null);
@@ -370,7 +371,7 @@ const MarkdownTextInput = React.forwardRef<MarkdownTextInput, MarkdownTextInputP
             ? Math.max(contentSelection.current.start, 0) // Don't move the caret when deleting forward with no characters selected
             : Math.max(Math.max(contentSelection.current.end, 0) + (parsedText.length - previousText.length), 0);
 
-        if (compositionRef.current) {
+        if (isEventComposing(nativeEvent)) {
           updateTextColor(divRef.current, parsedText);
           updateSelection(e, {
             start: newCursorPosition,
@@ -657,13 +658,8 @@ const MarkdownTextInput = React.forwardRef<MarkdownTextInput, MarkdownTextInputP
       [insertText],
     );
 
-    const startComposition = useCallback(() => {
-      compositionRef.current = true;
-    }, []);
-
     const endComposition = useCallback(
       (e: React.CompositionEvent<HTMLDivElement>) => {
-        compositionRef.current = false;
         handleOnChangeText(e);
       },
       [handleOnChangeText],
@@ -788,7 +784,6 @@ const MarkdownTextInput = React.forwardRef<MarkdownTextInput, MarkdownTextInputP
         autoCapitalize={autoCapitalize}
         className={className}
         onKeyDown={handleKeyPress}
-        onCompositionStart={startComposition}
         onCompositionEnd={endComposition}
         onInput={handleOnChangeText}
         onClick={handleClick}
@@ -829,4 +824,4 @@ const styles = StyleSheet.create({
 
 export default MarkdownTextInput;
 
-export type {MarkdownTextInputProps, MarkdownTextInputElement, HTMLMarkdownElement};
+export type {MarkdownNativeEvent, MarkdownTextInputProps, MarkdownTextInputElement, HTMLMarkdownElement};

--- a/src/MarkdownTextInput.web.tsx
+++ b/src/MarkdownTextInput.web.tsx
@@ -350,6 +350,7 @@ const MarkdownTextInput = React.forwardRef<MarkdownTextInput, MarkdownTextInputP
         }
         const nativeEvent = e.nativeEvent as MarkdownNativeEvent;
         const inputType = nativeEvent.inputType;
+        const isComposing = isEventComposing(nativeEvent);
 
         updateTextColor(divRef.current, e.target.textContent ?? '');
         const previousText = divRef.current.value;
@@ -371,7 +372,7 @@ const MarkdownTextInput = React.forwardRef<MarkdownTextInput, MarkdownTextInputP
             ? Math.max(contentSelection.current.start, 0) // Don't move the caret when deleting forward with no characters selected
             : Math.max(Math.max(contentSelection.current.end, 0) + (parsedText.length - previousText.length), 0);
 
-        if (isEventComposing(nativeEvent)) {
+        if (isComposing) {
           updateTextColor(divRef.current, parsedText);
           updateSelection(e, {
             start: newCursorPosition,

--- a/src/web/utils/inputUtils.ts
+++ b/src/web/utils/inputUtils.ts
@@ -1,11 +1,11 @@
 import type {CSSProperties} from 'react';
-import type {MarkdownTextInputElement} from '../../MarkdownTextInput.web';
+import type {MarkdownNativeEvent, MarkdownTextInputElement} from '../../MarkdownTextInput.web';
 
 const ZERO_WIDTH_SPACE = '\u200B';
 
 // If an Input Method Editor is processing key input, the 'keyCode' is 229.
 // https://www.w3.org/TR/uievents/#determine-keydown-keyup-keyCode
-function isEventComposing(nativeEvent: globalThis.KeyboardEvent) {
+function isEventComposing(nativeEvent: globalThis.KeyboardEvent | MarkdownNativeEvent) {
   return nativeEvent.isComposing || nativeEvent.keyCode === 229;
 }
 


### PR DESCRIPTION
### Details

#### Issues
In the web example app, pasting doesn’t work after typing with Samsung keyboard.

In Expensify app, pasting works, but the caret position is wrong in the case of issue https://github.com/Expensify/App/issues/40025.

#### Cause
When pasting, mobile browsers don’t fire the `compositionend` event, so the component handles the pasting event in composition mode,

https://github.com/Expensify/react-native-live-markdown/blob/76258f11b45d5b549f625916fc70bbb15a84df7d/src/MarkdownTextInput.web.tsx#L373-L384

and the normal process doesn’t execute.
https://github.com/Expensify/react-native-live-markdown/blob/76258f11b45d5b549f625916fc70bbb15a84df7d/src/MarkdownTextInput.web.tsx#L399

#### Solution
This PR fixes the issue by detecting composition mode with the `isEventComposing()` function.

### Related Issues
https://github.com/Expensify/App/issues/40025

PROPOSAL: https://github.com/Expensify/App/issues/40025#issuecomment-2581666403

### Manual Tests
**Precondition:** Use a soft keyboard in composition mode, such as Samsung keyboard with autocorrection enabled.

1. Launch the web example app in Android Chrome.
2. Copy some text.
3. Clear the textbox.
4. Type "aaa".
5. Long press the caret until the context menu pops up.
6. Tap Paste.
7. Verify that the copied text pastes into the textbox.

| Before | After |
| -- | -- |
| <video alt="Before" src="https://github.com/user-attachments/assets/e790d8ae-9c5c-46bc-9e59-92e91bde6080" /> | <video alt="After" src="https://github.com/user-attachments/assets/2bce4fa4-bbb2-48e5-be03-33cca0db5f6c" /> |

### Linked PRs