### PR TITLE
Expose worklet runtime

### DIFF
--- a/src/MarkdownTextInput.tsx
+++ b/src/MarkdownTextInput.tsx
@@ -27,7 +27,7 @@ let workletRuntime: WorkletRuntime | undefined;
 function getWorkletRuntime(): WorkletRuntime {
   if (workletRuntime === undefined) {
     throw new Error(
-      "[react-native-live-markdown] Worklet runtime hasn't been created yet. Please avoid calling `getWorkletRuntime()` in top-level scope. Instead, call `runOnRuntime()` directly in `runOnRuntime` arguments list.",
+      "[react-native-live-markdown] Worklet runtime hasn't been created yet. Please avoid calling `getWorkletRuntime()` in top-level scope. Instead, call `getWorkletRuntime()` directly in `runOnRuntime` arguments list.",
     );
   }
   return workletRuntime;

--- a/src/MarkdownTextInput.tsx
+++ b/src/MarkdownTextInput.tsx
@@ -24,6 +24,15 @@ declare global {
 let initialized = false;
 let workletRuntime: WorkletRuntime | undefined;
 
+function getWorkletRuntime(): WorkletRuntime {
+  if (workletRuntime === undefined) {
+    throw new Error(
+      "[react-native-live-markdown] Worklet runtime hasn't been created yet. Please avoid calling `getWorkletRuntime()` in top-level scope. Instead, call `runOnRuntime()` directly in `runOnRuntime` arguments list.",
+    );
+  }
+  return workletRuntime;
+}
+
 function initializeLiveMarkdownIfNeeded() {
   if (initialized) {
     return;
@@ -132,3 +141,5 @@ const styles = StyleSheet.create({
 export type {PartialMarkdownStyle as MarkdownStyle, MarkdownTextInputProps};
 
 export default MarkdownTextInput;
+
+export {getWorkletRuntime};

--- a/src/MarkdownTextInput.web.tsx
+++ b/src/MarkdownTextInput.web.tsx
@@ -832,7 +832,7 @@ export default MarkdownTextInput;
 export type {MarkdownTextInputProps, MarkdownTextInputElement, HTMLMarkdownElement};
 
 function getWorkletRuntime() {
-  throw new Error('[react-native-live-markdown] getWorkletRuntime is not available on web. Please make sure to use it only on native Android and iOS.');
+  throw new Error('[react-native-live-markdown] `getWorkletRuntime` is not available on web. Please make sure to use it only on native Android or iOS.');
 }
 
 export {getWorkletRuntime};

--- a/src/MarkdownTextInput.web.tsx
+++ b/src/MarkdownTextInput.web.tsx
@@ -830,3 +830,9 @@ const styles = StyleSheet.create({
 export default MarkdownTextInput;
 
 export type {MarkdownTextInputProps, MarkdownTextInputElement, HTMLMarkdownElement};
+
+function getWorkletRuntime() {
+  throw new Error('[react-native-live-markdown] getWorkletRuntime is not available on web. Please make sure to use it only on native Android and iOS.');
+}
+
+export {getWorkletRuntime};

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,4 +1,4 @@
-export {default as MarkdownTextInput} from './MarkdownTextInput';
+export {default as MarkdownTextInput, getWorkletRuntime} from './MarkdownTextInput';
 export type {MarkdownTextInputProps, MarkdownStyle} from './MarkdownTextInput';
 export type {MarkdownType, MarkdownRange} from './commonTypes';
 export {default as parseExpensiMark} from './parseExpensiMark';


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Details
When you write to a shared value in the RN runtime using `sv.value = 42;` or `sv.value(42);` syntax, the call is scheduled to be run on the UI runtime. This means that the shared value doesn't update its value on other worklet runtimes.

As a workaround, instead of calling `sv.value = 42` in the RN runtime which simply calls `runOnUI` under the hood, you can call `runOnRuntime` on your own like this:
```tsx
runOnRuntime(workletRuntime, () => {
  'worklet';
  sv.value = 42;
})();
```

However, currently there's no way to obtain `workletRuntime`. This PR exposes `workletRuntime` used by `MarkdownTextInput` component using `getWorkletRuntime()` function.

Because worklet runtime creation is lazy (since we really shouldn't call native/turbo modules in the top-level scope so we delay the creation till `MarkdownTextInput` is first rendered), please make sure to call `getWorkletRuntime()` function only when the worklet runtime has already been initialized. This means you cannot call `getWorkletRuntime()` in top-level scope of your code. Also, please make sure not to memoize or even store its result since since this affects the lifetime of `WorkletRuntime` instance which should be managed only by `react-native-live-markdown`. Finally, please do not call `getWorkletRuntime()` on web where parsers are run directly on the same JS runtime and there's no concept of worklet runtimes.

As for `runOnRuntime`, this function is sadly not available on web. Also, keep in mind that `runOnRuntime(worklet)` itself doesn't schedule the worklet to be run; it just creates a JS function that, when called, will schedule the call. So if you want to immediately schedule the worklet, please use the following syntax: `runOnRuntime(() => { ... }))();` with `()` at the end of the line.

### Related Issues
<!-- Please replace GH_LINK with the link to the GitHub issue this Pull Request is related to -->
GH_LINK

### Manual Tests
<!---
Most changes should have accompanying tests. Describe the tests you added or if no tests were added an explanation about why one was not needed.
--->

App.tsx

```tsx
import * as React from 'react';
import {Button, StyleSheet, View} from 'react-native';
import {runOnRuntime, useSharedValue} from 'react-native-reanimated';

import {
  getWorkletRuntime,
  MarkdownTextInput,
  parseExpensiMark,
} from '@expensify/react-native-live-markdown';

export default function App() {
  const sv = useSharedValue('before');

  React.useEffect(() => {
    runOnRuntime(getWorkletRuntime(), () => {
      'worklet';
      sv.value = 'after';
    })();
  }, [sv]);

  return (
    <View style={styles.container}>
      <MarkdownTextInput parser={parseExpensiMark} />
      <Button
        title="Press me"
        onPress={() => {
          runOnRuntime(getWorkletRuntime(), () => {
            'worklet';
            console.log(sv.value);
          })();
        }}
      />
    </View>
  );
}

const styles = StyleSheet.create({
  container: {
    flex: 1,
    justifyContent: 'center',
    alignItems: 'center',
  },
});
```

### Linked PRs
<!---
Please include links to any update PRs in repos that must change their package.json version.
--->