### PR TITLE
Use `.at()` method instead of `operator[]` for shareable worklet lookup

### DIFF
--- a/cpp/MarkdownGlobal.cpp
+++ b/cpp/MarkdownGlobal.cpp
@@ -36,9 +36,7 @@ void unregisterMarkdownWorklet(const int parserId) {
 
 std::shared_ptr<ShareableWorklet> getMarkdownWorklet(const int parserId) {
   std::unique_lock<std::mutex> lock(globalMarkdownShareableWorkletsMutex);
-  const auto &worklet = globalMarkdownShareableWorklets[parserId];
-  assert(worklet != nullptr);
-  return worklet;
+  return globalMarkdownShareableWorklets.at(parserId);
 }
 
 } // namespace livemarkdown


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Details
This PR partially fixes the following crash on Android:
```
react-native-live-markdown/cpp/MarkdownGlobal.cpp:40: std::shared_ptr<ShareableWorklet> expensify::livemarkdown::getMarkdownWorklet(const int): assertion "worklet != nullptr" failed
```
For some reason, `getMarkdownWorklet` is called for given `parserId` after `unregisterMarkdownWorklet` is called. The reason is currently unknown and will be investigated separately. In such case, `globalMarkdownShareableWorklets[parserId]` returns `nullptr` (and also stores `nullptr` in `globalMarkdownShareableWorklets`, sic!) and the assert fails.

After this change, in such case `globalMarkdownShareableWorklets.at(parserId)` will throw an exception. The exception will be passed through C++ code and then passed to Java side where it is already handled here:
https://github.com/Expensify/react-native-live-markdown/blob/59e749c8eb5c82166aaadea902564f574a5f5968/android/src/main/java/com/expensify/livemarkdown/MarkdownParser.java#L45-L52

### Related Issues
* https://github.com/Expensify/react-native-live-markdown/issues/603
* https://github.com/Expensify/App/issues/55195

### Manual Tests
1. Apply the following changes:
```diff
diff --git a/example/src/App.tsx b/example/src/App.tsx
index 2d48a2b..b9b21e7 100644
--- a/example/src/App.tsx
+++ b/example/src/App.tsx
@@ -54,6 +54,11 @@ export default function App() {
 
   const ref = React.useRef<MarkdownTextInput>(null);
 
+  const parser = (markdown: string) => {
+    'worklet';
+    return parseExpensiMark(markdown);
+  };
+
   return (
     <View style={styles.container}>
       <PlatformInfo />
@@ -66,7 +71,7 @@ export default function App() {
         style={[styles.input, style]}
         ref={ref}
         markdownStyle={markdownStyle}
-        parser={parseExpensiMark}
+        parser={parser}
         placeholder="Type here..."
         onSelectionChange={e => setSelection(e.nativeEvent.selection)}
         selection={selection}
diff --git a/src/MarkdownTextInput.tsx b/src/MarkdownTextInput.tsx
index bff1928..0439547 100644
--- a/src/MarkdownTextInput.tsx
+++ b/src/MarkdownTextInput.tsx
@@ -105,8 +105,7 @@ const MarkdownTextInput = React.forwardRef<MarkdownTextInput, MarkdownTextInputP
 
   const parserId = React.useMemo(() => {
     return registerParser(props.parser);
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [workletHash]);
+  }, [props.parser]);
 
   React.useEffect(() => {
     return () => unregisterParser(parserId);
```
2. Build and launch the app on Android emulator
3. Place your cursor at the end of line `> blockquote`
4. Press `a` key multiple times

### Linked PRs
<!---
Please include links to any update PRs in repos that must change their package.json version.
--->