### PR TITLE
Call `setTextKeepState` instead of `setText` and `setSelection`

### DIFF
--- a/android/src/main/java/com/expensify/livemarkdown/MarkdownTextInputDecoratorView.java
+++ b/android/src/main/java/com/expensify/livemarkdown/MarkdownTextInputDecoratorView.java
@@ -94,10 +94,7 @@ public class MarkdownTextInputDecoratorView extends View {
 
   protected void applyNewStyles() {
     if (mReactEditText != null) {
-      int selectionStart = mReactEditText.getSelectionStart();
-      int selectionEnd = mReactEditText.getSelectionEnd();
-      mReactEditText.setText(mReactEditText.getText()); // trigger update
-      mReactEditText.setSelection(selectionStart, selectionEnd);
+      mReactEditText.setTextKeepState(mReactEditText.getText()); // trigger update
     }
   }
 }


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Details
Currently, in `applyNewStyles` we need to store selection start and end and restore it after `setText` call using `setSelection` method.

This PR makes use of `setTextKeepState` https://developer.android.com/reference/android/widget/TextView#setTextKeepState(java.lang.CharSequence) which sets the text to be displayed but retains the cursor position.

### Related Issues
<!-- Please replace GH_LINK with the link to the GitHub issue this Pull Request is related to -->
GH_LINK

### Manual Tests
<!---
Most changes should have accompanying tests. Describe the tests you added or if no tests were added an explanation about why one was not needed.
--->

### Linked PRs
<!---
Please include links to any update PRs in repos that must change their package.json version.
--->