### PR TITLE
Remove leftover `AssetManager` import

### DIFF
--- a/android/src/main/java/com/expensify/livemarkdown/MarkdownTextInputDecoratorView.java
+++ b/android/src/main/java/com/expensify/livemarkdown/MarkdownTextInputDecoratorView.java
@@ -3,7 +3,6 @@ package com.expensify.livemarkdown;
 import androidx.annotation.Nullable;
 
 import android.content.Context;
-import android.content.res.AssetManager;
 import android.text.TextWatcher;
 import android.util.AttributeSet;
 


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Details
This PR removes leftover `AssetManager` import in MarkdownTextInputDecoratorView.java.

### Related Issues
<!-- Please replace GH_LINK with the link to the GitHub issue this Pull Request is related to -->
GH_LINK

### Manual Tests
<!---
Most changes should have accompanying tests. Describe the tests you added or if no tests were added an explanation about why one was not needed.
--->

### Linked PRs
<!---
Please include links to any update PRs in repos that must change their package.json version.
--->