### PR TITLE
Fix updating parser when worklet hash doesn't change but closure does change

### DIFF
--- a/src/MarkdownTextInput.tsx
+++ b/src/MarkdownTextInput.tsx
@@ -105,8 +105,7 @@ const MarkdownTextInput = React.forwardRef<MarkdownTextInput, MarkdownTextInputP
 
   const parserId = React.useMemo(() => {
     return registerParser(props.parser);
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [workletHash]);
+  }, [props.parser]);
 
   React.useEffect(() => {
     return () => unregisterParser(parserId);


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Details
@289Adam289 reported that `MarkdownTextInput` formatting does not reflect changes in parser worklet closure after a render. The reason is that currently we call `registerParser` only when `workletHash` changes (ignoring the rules of React and ESLint warning).

This PR changes the dependency array of `useMemo` so that `registerParser` is called when `props.parser` reference changes rather than only `workletHash`.

It is the responsibility of library user to properly memoize the worklet parser

### Related Issues
Requires https://github.com/Expensify/react-native-live-markdown/pull/608.

### Manual Tests
<!---
Most changes should have accompanying tests. Describe the tests you added or if no tests were added an explanation about why one was not needed.
--->

### Linked PRs
<!---
Please include links to any update PRs in repos that must change their package.json version.
--->