### PR TITLE
Eliminate `setText` call in `applyNewStyles` on Android

### DIFF
--- a/android/src/main/java/com/expensify/livemarkdown/MarkdownTextInputDecoratorView.java
+++ b/android/src/main/java/com/expensify/livemarkdown/MarkdownTextInputDecoratorView.java
@@ -4,6 +4,8 @@ import androidx.annotation.Nullable;
 
 import android.content.Context;
 import android.content.res.AssetManager;
+import android.text.Editable;
+import android.text.SpannableStringBuilder;
 import android.text.TextWatcher;
 import android.util.AttributeSet;
 
@@ -93,11 +95,11 @@ public class MarkdownTextInputDecoratorView extends View {
   }
 
   protected void applyNewStyles() {
-    if (mReactEditText != null) {
-      int selectionStart = mReactEditText.getSelectionStart();
-      int selectionEnd = mReactEditText.getSelectionEnd();
-      mReactEditText.setText(mReactEditText.getText()); // trigger update
-      mReactEditText.setSelection(selectionStart, selectionEnd);
+    if (mReactEditText != null && mMarkdownUtils != null) {
+      Editable editable = mReactEditText.getText();
+      if (editable instanceof SpannableStringBuilder ssb) {
+        mMarkdownUtils.applyMarkdownFormatting(ssb);
+      }
     }
   }
 }


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Details
This PR refactors the implementation of `applyNewStyles` method on Android.

Currently, in `applyNewStyles` we obtain the current value using `getText` method and pass it to `setText` method in order to trigger `MarkdownTextWatcher`. This works fine but can lead to infinite loop because calling `setText` (or even `setTextKeepState`) generates a selection update event. In live-markdown example app, `onSelectionChange` callback always calls `setSelection` (without comparing `start` and `end` fields so it updates the reference to `selection` state) which results in render that leads to another `applyNewStyles` call (not sure how exactly, though).

Instead, we call `applyMarkdownFormatting` which doesn't emit selection change event.

### Related Issues
Required by https://github.com/Expensify/react-native-live-markdown/pull/607.

### Manual Tests
<!---
Most changes should have accompanying tests. Describe the tests you added or if no tests were added an explanation about why one was not needed.
--->

### Linked PRs
<!---
Please include links to any update PRs in repos that must change their package.json version.
--->