### PR TITLE
Handle `std::out_of_range` exception thrown in `getMarkdownWorklet` on iOS

### DIFF
--- a/apple/MarkdownParser.mm
+++ b/apple/MarkdownParser.mm
@@ -23,7 +23,15 @@
     const auto &markdownRuntime = expensify::livemarkdown::getMarkdownRuntime();
     jsi::Runtime &rt = markdownRuntime->getJSIRuntime();
 
-    const auto &markdownWorklet = expensify::livemarkdown::getMarkdownWorklet([parserId intValue]);
+    std::shared_ptr<ShareableWorklet> markdownWorklet;
+    try {
+      markdownWorklet = expensify::livemarkdown::getMarkdownWorklet([parserId intValue]);
+    } catch (const std::out_of_range &error) {
+      _prevText = text;
+      _prevParserId = parserId;
+      _prevMarkdownRanges = @[];
+      return _prevMarkdownRanges;
+    }
 
     const auto &input = jsi::String::createFromUtf8(rt, [text UTF8String]);
 


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Details
When parser worklet is not found, `.at()` method throws `std::out_of_range` exception which currently crashes the app. This PR adds `try/catch` block around `expensify::livemarkdown::getMarkdownWorklet()` call in MarkdownParser.mm. After this change, we will skip formatting instead of crashing the app. This is only a partial fix to unify iOS and Android implementation in their current shapes. The root cause will be addressed separately.

### Related Issues
Partially fixes https://github.com/Expensify/react-native-live-markdown/issues/609.

### Manual Tests
<!---
Most changes should have accompanying tests. Describe the tests you added or if no tests were added an explanation about why one was not needed.
--->

### Linked PRs
<!---
Please include links to any update PRs in repos that must change their package.json version.
--->