### PR TITLE
Implement format toggle feature

### DIFF
--- a/src/MarkdownTextInput.web.tsx
+++ b/src/MarkdownTextInput.web.tsx
@@ -24,6 +24,7 @@ import {getElementHeight, getPlaceholderValue, isEventComposing, normalizeValue,
 import {parseToReactDOMStyle, processMarkdownStyle} from './web/utils/webStyleUtils';
 import {forceRefreshAllImages} from './web/inputElements/inlineImage';
 import type {MarkdownRange, InlineImagesInputProps} from './commonTypes';
+import {removeFormat} from './web/utils/formatToggleUtils';
 
 const useClientEffect = typeof window === 'undefined' ? useEffect : useLayoutEffect;
 
@@ -247,6 +248,12 @@ const MarkdownTextInput = React.forwardRef<MarkdownTextInput, MarkdownTextInputP
 
         if (!formatSelection) {
           return parseText(parser, target, parsedText, processedMarkdownStyle, cursorPosition);
+        }
+
+        // Undo the formatting if the selection is already in the given format.
+        const formatRemovalResult = removeFormat(parsedText, contentSelection.current.start, contentSelection.current.end, formatCommand);
+        if (formatRemovalResult) {
+          return parseText(parser, target, formatRemovalResult.updatedText, processedMarkdownStyle, cursorPosition + formatRemovalResult.cursorOffset, true);
         }
 
         const selectedText = parsedText.slice(contentSelection.current.start, contentSelection.current.end);

--- a/src/__tests__/formatToggleUtils.test.ts
+++ b/src/__tests__/formatToggleUtils.test.ts
@@ -1,0 +1,71 @@
+import {ExpensiMark} from 'expensify-common';
+import {expect} from '@jest/globals';
+import {getFormatRule, removeFormat} from '../web/utils/formatToggleUtils';
+
+describe('getFormatRule', () => {
+  test('return regexes consistent with those in expensify-common', () => {
+    const parser = new ExpensiMark();
+
+    const boldRule = getFormatRule('formatBold');
+    const boldRegex = (parser.rules.find((rule) => rule.name === 'bold') as {regex: RegExp}).regex;
+    expect(boldRule?.regex.source).toEqual(boldRegex.source);
+    expect(boldRule?.regex.flags.replace('d', '')).toEqual(boldRegex.flags);
+
+    const italicRule = getFormatRule('formatItalic');
+    const italicRegex = (parser.rules.find((rule) => rule.name === 'italic') as {regex: RegExp}).regex;
+    expect(italicRule?.regex.source).toEqual(italicRegex.source);
+    expect(italicRule?.regex.flags.replace('d', '')).toEqual(italicRegex.flags);
+  });
+});
+
+describe('removeFormat', () => {
+  test('do not remove bold formatting from normal text', () => {
+    const result = removeFormat('*aaa* bbb *ccc*', 6, 9, 'formatBold');
+    expect(result).toBeNull();
+  });
+
+  test('remove bold formatting from bold text', () => {
+    const result = removeFormat('*aaa* *bbb* *ccc*', 7, 10, 'formatBold');
+    expect(result).toEqual({updatedText: '*aaa* bbb *ccc*', cursorOffset: -1});
+  });
+
+  test('remove bold formatting from bold text with markdown symbols', () => {
+    const result = removeFormat('*aaa* *bbb* *ccc*', 6, 11, 'formatBold');
+    expect(result).toEqual({updatedText: '*aaa* bbb *ccc*', cursorOffset: -2});
+  });
+
+  test('do not remove italic formatting from normal text', () => {
+    const result = removeFormat('_aaa_ bbb _ccc_', 6, 9, 'formatItalic');
+    expect(result).toBeNull();
+  });
+
+  test('remove italic formatting from italic text', () => {
+    const result = removeFormat('_aaa_ _bbb_ _ccc_', 7, 10, 'formatItalic');
+    expect(result).toEqual({updatedText: '_aaa_ bbb _ccc_', cursorOffset: -1});
+  });
+
+  test('remove italic formatting from italic text with markdown symbols', () => {
+    const result = removeFormat('_aaa_ _bbb_ _ccc_', 6, 11, 'formatItalic');
+    expect(result).toEqual({updatedText: '_aaa_ bbb _ccc_', cursorOffset: -2});
+  });
+
+  test('do not remove bold formatting from italic text', () => {
+    const result = removeFormat('*aaa* _bbb_ *ccc*', 6, 11, 'formatBold');
+    expect(result).toBeNull();
+  });
+
+  test('remove bold formatting from bold-italic text', () => {
+    const result = removeFormat('*aaa* *_bbb_* *ccc*', 7, 12, 'formatBold');
+    expect(result).toEqual({updatedText: '*aaa* _bbb_ *ccc*', cursorOffset: -1});
+  });
+
+  test('do not remove italic formatting from bold text', () => {
+    const result = removeFormat('_aaa_ *bbb* _ccc_', 6, 11, 'formatItalic');
+    expect(result).toBeNull();
+  });
+
+  test('remove italic formatting from bold-italic text', () => {
+    const result = removeFormat('_aaa_ _*bbb*_ _ccc_', 7, 12, 'formatItalic');
+    expect(result).toEqual({updatedText: '_aaa_ *bbb* _ccc_', cursorOffset: -1});
+  });
+});

--- a/src/web/utils/formatToggleUtils.ts
+++ b/src/web/utils/formatToggleUtils.ts
@@ -1,0 +1,62 @@
+type FormatResult = {
+  updatedText: string;
+  cursorOffset: number;
+};
+
+type FormatRule = {
+  regex: RegExp;
+
+  /** The group number to extract the matched text, excluding the markdown symbols. */
+  matchGroup: number;
+};
+
+function getFormatRule(formatCommand: string): FormatRule | null {
+  // We reuse regexes from expensify-common with modified flags.
+  // If expensify-common updates its regexes, we should update the regex and matchGroup properties here accordingly.
+  if (formatCommand === 'formatBold') {
+    return {
+      regex: /(?<!<[^>]*)(\b_|\B)\*(?![^<]*(?:<\/pre>|<\/code>|<\/a>|<\/video>))((?![\s*])[\s\S]*?[^\s*](?<!\s))\*\B(?![^<]*>)(?![^<]*(<\/pre>|<\/code>|<\/a>|<\/video>))/dg,
+      matchGroup: 2,
+    };
+  }
+  if (formatCommand === 'formatItalic') {
+    return {
+      regex:
+        /(<(pre|code|a|mention-user|video)[^>]*>(.*?)<\/\2>)|((\b_+|\b)_((?![\s_])[\s\S]*?[^\s_](?<!\s))_(?![^\W_])(?![^<]*>)(?![^<]*(<\/pre>|<\/code>|<\/a>|<\/mention-user>|<\/video>)))/dg,
+      matchGroup: 6,
+    };
+  }
+  return null;
+}
+
+function removeFormat(text: string, selectionStart: number, selectionEnd: number, formatCommand: string): FormatResult | null {
+  const formatRule = getFormatRule(formatCommand);
+  if (!formatRule) {
+    return null;
+  }
+
+  const matches = Array.from(text.matchAll(formatRule.regex));
+  for (let i = 0; i < matches.length && matches[i]; i++) {
+    const [matchStart, matchEnd] = matches[i]?.indices?.[formatRule.matchGroup] ?? [];
+    const matchedText = matches[i]?.[formatRule.matchGroup];
+
+    if (matchStart != null && matchEnd != null && matchedText) {
+      const isExactMatch = matchStart === selectionStart && matchEnd === selectionEnd;
+      const isEnclosedMatch = matchStart - 1 === selectionStart && matchEnd + 1 === selectionEnd;
+
+      if (isExactMatch || isEnclosedMatch) {
+        const prefix = text.slice(0, matchStart - 1);
+        const suffix = text.slice(matchEnd + 1);
+        const updatedText = `${prefix}${matchedText}${suffix}`;
+        const cursorOffset = selectionStart - matchStart - 1;
+
+        return {updatedText, cursorOffset};
+      }
+    }
+  }
+
+  return null; // Don't remove formatting if no match.
+}
+
+export type {FormatResult, FormatRule};
+export {getFormatRule, removeFormat};


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Details
<!-- Explanation of the change or anything fishy that is going on -->
This PR implements a new feature to toggle bold and italic formatting using keyboard shortcuts or the context menu.

### Related Issues
<!-- Please replace GH_LINK with the link to the GitHub issue this Pull Request is related to -->
https://github.com/Expensify/App/issues/55088
PROPOSAL: https://github.com/Expensify/App/issues/55088#issuecomment-2639014812

### Manual Tests
<!---
Most changes should have accompanying tests. Describe the tests you added or if no tests were added an explanation about why one was not needed.
--->

1. Open the web example app.
2. Clear the text box.
3. Enter the data and select the text according to the second column of the table below.
4. Press Command+B to toggle bold formatting, or press Command+I to toggle italic formatting.
5. Verify that the result matches the third column.

| Command | Before formatting | After formatting |
| -- | -- | -- |
| `formatBold` | <img width="245" alt="Image" src="https://github.com/user-attachments/assets/ca6f26a8-76b8-487e-9c38-a2a6b8ae224d" /> | <img width="245" alt="Image" src="https://github.com/user-attachments/assets/ba900e98-f7bc-4c44-9b60-9c335e294157" /> |
| `formatBold` | <img width="245" alt="Image" src="https://github.com/user-attachments/assets/1f054b8e-8ce1-4bb4-87bc-e49d62c9c69a" /> | <img width="245" alt="Image" src="https://github.com/user-attachments/assets/cd440833-e4d8-4c15-a857-d251d22cc9c5" /> |
| `formatBold` | <img width="245" alt="Image" src="https://github.com/user-attachments/assets/73eb12d9-d8c1-4773-a25d-aab085e74e4e" /> | <img width="245" alt="Image" src="https://github.com/user-attachments/assets/6a4fce2e-a474-40b0-b5a5-cbf539bda852" /> |
| `formatItalic` | <img width="245" alt="Image" src="https://github.com/user-attachments/assets/a39de88c-e736-4648-93f3-60c320f8311e" /> | <img width="245" alt="Image" src="https://github.com/user-attachments/assets/a36fc402-f4ca-4675-b5d6-aa3e88550c91" /> |
| `formatItalic` | <img width="245" alt="Image" src="https://github.com/user-attachments/assets/8bff8fb4-e81c-48ca-8d16-28ec2f64839e" /> | <img width="245" alt="Image" src="https://github.com/user-attachments/assets/77e2d8df-09cf-4b6d-ad73-d80f258e99d4" /> |
| `formatItalic` | <img width="245" alt="Image" src="https://github.com/user-attachments/assets/21bee30a-d581-4c07-90e2-cff435f8ba69" /> | <img width="245" alt="Image" src="https://github.com/user-attachments/assets/3fd55b9d-8cb5-46c1-9bd4-c6a133a5be9e" /> |
| `formatBold` | <img width="245" alt="Image" src="https://github.com/user-attachments/assets/268e9812-5e25-44eb-946e-6024ce215f80" /> | <img width="245" alt="Image" src="https://github.com/user-attachments/assets/328b96cd-9eb4-49a6-bd9d-7dcd466badc5" /> |
| `formatBold` | <img width="245" alt="Image" src="https://github.com/user-attachments/assets/22cda39d-6f78-4cee-8cd3-cff7ed6a0201" /> | <img width="245" alt="Image" src="https://github.com/user-attachments/assets/bdcacd73-4ae0-4814-baa1-df83ecaa1688" /> |
| `formatItalic` | <img width="245" alt="Image" src="https://github.com/user-attachments/assets/1ce21150-8a4f-4c35-b925-0b8c7bd05455" /> | <img width="245" alt="Image" src="https://github.com/user-attachments/assets/2079ee5e-5cf8-43ca-a4c8-384c03f14cc6" /> |
| `formatItalic` | <img width="245" alt="Image" src="https://github.com/user-attachments/assets/a65c990b-e973-468e-8347-73d352dfda57" /> | <img width="245" alt="Image" src="https://github.com/user-attachments/assets/cace2636-49fc-4c9a-af70-98d9fb3ad016" /> |

https://github.com/user-attachments/assets/98009372-4637-435b-990d-9da5eb0a6c31

### Linked PRs
<!---
Please include links to any update PRs in repos that must change their package.json version.
--->