### PR TITLE
Refactor `formatSelection` callback

### DIFF
--- a/example/src/App.tsx
+++ b/example/src/App.tsx
@@ -15,15 +15,24 @@ import {PlatformInfo} from './PlatformInfo';
 // We don't need this workaround in New Expensify App since Reanimated is imported before Live Markdown.
 console.log(Animated);
 
-function handleFormatSelection(selectedText: string, formatCommand: string) {
-  switch (formatCommand) {
-    case 'formatBold':
-      return `*${selectedText}*`;
-    case 'formatItalic':
-      return `_${selectedText}_`;
-    default:
-      return selectedText;
-  }
+function handleFormatSelection(
+  text: string,
+  selectionStart: number,
+  selectionEnd: number,
+  formatCommand: string,
+) {
+  const prefix = text.slice(0, selectionStart);
+  const suffix = text.slice(selectionEnd);
+  const selectedText = text.slice(selectionStart, selectionEnd);
+  const formattedText =
+    formatCommand === 'formatBold'
+      ? `*${selectedText}*`
+      : formatCommand === 'formatItalic'
+      ? `_${selectedText}_`
+      : selectedText;
+  const updatedText = `${prefix}${formattedText}${suffix}`;
+  const cursorOffset = formattedText.length - selectedText.length;
+  return {updatedText, cursorOffset};
 }
 
 export default function App() {

--- a/src/MarkdownTextInput.tsx
+++ b/src/MarkdownTextInput.tsx
@@ -61,9 +61,14 @@ function unregisterParser(parserId: number) {
 
 interface MarkdownTextInputProps extends TextInputProps, InlineImagesInputProps {
   markdownStyle?: PartialMarkdownStyle;
-  formatSelection?: (selectedText: string, formatCommand: string) => string;
+  formatSelection?: (text: string, selectionStart: number, selectionEnd: number, formatCommand: string) => FormatSelectionResult;
   parser: (value: string) => MarkdownRange[];
 }
+
+type FormatSelectionResult = {
+  updatedText: string;
+  cursorOffset: number;
+};
 
 type MarkdownTextInput = TextInput & React.Component<MarkdownTextInputProps>;
 


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Details
<!-- Explanation of the change or anything fishy that is going on -->
This PR refactors the `formatSelection` callback to make it more generic and possible to support format toggling.

Currently, the interface is as follows:

**Arguments:** `selectedText`, `formatCommand`
**Returns:** `formattedText`

After this change, the interface will be:

**Arguments:** `text`, `selectionStart`, `selectionEnd`, `formatCommand`
**Returns:** `updatedText`, `cursorOffset`

### Related Issues
<!-- Please replace GH_LINK with the link to the GitHub issue this Pull Request is related to -->
https://github.com/Expensify/App/issues/55088
PROPOSAL: https://github.com/Expensify/App/issues/55088#issuecomment-2639014812

### Manual Tests
<!---
Most changes should have accompanying tests. Describe the tests you added or if no tests were added an explanation about why one was not needed.
--->
N/A

This PR is a refactor and doesn't change the current functionality. The feature to toggle format will be implemented separately.

### Linked PRs
<!---
Please include links to any update PRs in repos that must change their package.json version.
--->