### PR TITLE
Fix setting border radius on web in singleline mode

### DIFF
--- a/src/MarkdownTextInputDecoratorViewNativeComponent.ts
+++ b/src/MarkdownTextInputDecoratorViewNativeComponent.ts
@@ -37,14 +37,17 @@ interface MarkdownStyle {
   mentionHere: {
     color: ColorValue;
     backgroundColor: ColorValue;
+    borderRadius?: Float;
   };
   mentionUser: {
     color: ColorValue;
     backgroundColor: ColorValue;
+    borderRadius?: Float;
   };
   mentionReport: {
     color: ColorValue;
     backgroundColor: ColorValue;
+    borderRadius?: Float;
   };
   inlineImage: {
     minWidth: Float;

--- a/src/web/utils/blockUtils.ts
+++ b/src/web/utils/blockUtils.ts
@@ -82,10 +82,11 @@ function addStyleToBlock(targetElement: HTMLElement, type: NodeType, markdownSty
       });
       break;
     case 'text':
-      if (!isMultiline) {
+      if (!isMultiline && targetElement.parentElement?.style) {
         // Move text background styles from parent to the text node
-        Object.assign(node.style, {backgroundColor: targetElement.parentElement?.style.backgroundColor, borderRadius: targetElement.parentElement?.style.borderRadius});
-        Object.assign(targetElement.parentElement?.style ?? {}, {backgroundColor: 'transparent', borderRadius: 'unset'});
+        const parentElement = targetElement.parentElement;
+        node.style.cssText = parentElement.style.cssText;
+        parentElement.style.cssText = '';
       }
       break;
     default:

--- a/src/web/utils/blockUtils.ts
+++ b/src/web/utils/blockUtils.ts
@@ -83,8 +83,9 @@ function addStyleToBlock(targetElement: HTMLElement, type: NodeType, markdownSty
       break;
     case 'text':
       if (!isMultiline) {
-        Object.assign(node.style, {backgroundColor: targetElement.parentElement?.style.backgroundColor});
-        Object.assign(targetElement.parentElement?.style ?? {}, {backgroundColor: 'transparent'});
+        // Move text background styles from parent to the text node
+        Object.assign(node.style, {backgroundColor: targetElement.parentElement?.style.backgroundColor, borderRadius: targetElement.parentElement?.style.borderRadius});
+        Object.assign(targetElement.parentElement?.style ?? {}, {backgroundColor: 'transparent', borderRadius: 'unset'});
       }
       break;
     default:


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->
### Details
<!-- Explanation of the change or anything fishy that is going on -->
This PR fixes adding border radius style to the markdowns in the single line input mode.


### Related Issues
<!-- Please replace GH_LINK with the link to the GitHub issue this Pull Request is related to -->
GH_LINK

### Manual Tests
<!---
Most changes should have accompanying tests. Describe the tests you added or, if no tests were added, an explanation about why one was not needed.
--->
1. Add, for example
```
      mentionUser: {
        borderRadius: 5,
      },
```
 to the `markdownStyles`
2. Change the MarkdownTextInput component to the single line mode by deactivating the `multiline` flag
3. Verify if the border radius style was applied 
 
### Linked PRs
<!---
Please include links to any update PRs in repos that must change their package.json version.
--->