### PR TITLE
Remove global worklet runtime mutex

### DIFF
--- a/android/src/main/cpp/MarkdownParser.cpp
+++ b/android/src/main/cpp/MarkdownParser.cpp
@@ -11,9 +11,6 @@ namespace livemarkdown {
       jni::alias_ref<jhybridobject> jThis,
       jni::alias_ref<jni::JString> text,
       const int parserId) {
-    static std::mutex workletRuntimeMutex; // this needs to be global since the worklet runtime is also global
-    const auto lock = std::lock_guard<std::mutex>(workletRuntimeMutex);
-
     const auto markdownRuntime = expensify::livemarkdown::getMarkdownRuntime();
     jsi::Runtime &rt = markdownRuntime->getJSIRuntime();
 

--- a/apple/MarkdownParser.mm
+++ b/apple/MarkdownParser.mm
@@ -1,7 +1,6 @@
 #import "MarkdownParser.h"
 #import <RNLiveMarkdown/MarkdownGlobal.h>
 #import <React/RCTLog.h>
-#import <mutex>
 
 @implementation MarkdownParser {
   NSString *_prevText;
@@ -16,9 +15,6 @@
     if ([text isEqualToString:_prevText] && [parserId isEqualToNumber:_prevParserId]) {
       return _prevMarkdownRanges;
     }
-
-    static std::mutex workletRuntimeMutex; // this needs to be global since the worklet runtime is also global
-    const auto lock = std::lock_guard<std::mutex>(workletRuntimeMutex);
 
     const auto &markdownRuntime = expensify::livemarkdown::getMarkdownRuntime();
     jsi::Runtime &rt = markdownRuntime->getJSIRuntime();


### PR DESCRIPTION
### Details

This PR removes additional external synchronization for Markdown worklet runtime since it will be automatically handled internally by `WorkletRuntime`.

⚠️ Requires https://github.com/software-mansion/react-native-reanimated/pull/7033

### Related Issues

### Manual Tests

### Linked PRs