### PR TITLE
Add support for `caretHidden` prop

### DIFF
--- a/example/src/App.tsx
+++ b/example/src/App.tsx
@@ -32,6 +32,7 @@ export default function App() {
   const [linkColorState, setLinkColorState] = React.useState(false);
   const [textFontSizeState, setTextFontSizeState] = React.useState(false);
   const [emojiFontSizeState, setEmojiFontSizeState] = React.useState(false);
+  const [caretHidden, setCaretHidden] = React.useState(false);
   const [selection, setSelection] = React.useState({start: 0, end: 0});
 
   const style = React.useMemo(() => {
@@ -61,6 +62,7 @@ export default function App() {
         multiline
         formatSelection={handleFormatSelection}
         autoCapitalize="none"
+        caretHidden={caretHidden}
         value={value}
         onChangeText={setValue}
         style={[styles.input, style]}
@@ -130,12 +132,17 @@ export default function App() {
         onPress={() => setEmojiFontSizeState(prev => !prev)}
       />
       <Button
+        title="Toggle caret hidden"
+        onPress={() => setCaretHidden(prev => !prev)}
+      />
+      <Button
         title="Toggle all"
         onPress={() => {
           setTextColorState(prev => !prev);
           setLinkColorState(prev => !prev);
           setTextFontSizeState(prev => !prev);
           setEmojiFontSizeState(prev => !prev);
+          setCaretHidden(prev => !prev);
         }}
       />
       <Button

--- a/src/MarkdownTextInput.web.tsx
+++ b/src/MarkdownTextInput.web.tsx
@@ -208,7 +208,7 @@ const MarkdownTextInput = React.forwardRef<MarkdownTextInput, MarkdownTextInputP
           parseToReactDOMStyle(flattenedStyle),
           caretHidden && styles.caretHidden,
         ]) as CSSProperties,
-      [flattenedStyle, multiline, disabled],
+      [flattenedStyle, multiline, disabled, caretHidden],
     );
 
     const undo = useCallback(

--- a/src/MarkdownTextInput.web.tsx
+++ b/src/MarkdownTextInput.web.tsx
@@ -81,6 +81,7 @@ const MarkdownTextInput = React.forwardRef<MarkdownTextInput, MarkdownTextInputP
       autoCapitalize = 'sentences',
       autoCorrect = true,
       blurOnSubmit = false,
+      caretHidden,
       clearTextOnFocus,
       dir = 'auto',
       disabled = false,
@@ -205,6 +206,7 @@ const MarkdownTextInput = React.forwardRef<MarkdownTextInput, MarkdownTextInputP
           {whiteSpace: multiline ? 'pre-wrap' : 'nowrap'},
           disabled && styles.disabledInputStyles,
           parseToReactDOMStyle(flattenedStyle),
+          caretHidden && styles.caretHidden,
         ]) as CSSProperties,
       [flattenedStyle, multiline, disabled],
     );
@@ -820,6 +822,10 @@ const styles = StyleSheet.create({
   disabledInputStyles: {
     opacity: 0.75,
     cursor: 'auto',
+  },
+  caretHidden: {
+    // @ts-expect-error it works on web
+    caretColor: 'transparent',
   },
 });
 


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Details
<!-- Explanation of the change or anything fishy that is going on -->
`caretHidden` prop doesn't hide the caret on the web platform.

### Related Issues
<!-- Please replace GH_LINK with the link to the GitHub issue this Pull Request is related to -->
https://github.com/Expensify/App/pull/55704#issuecomment-2655953155

### Manual Tests
<!---
Most changes should have accompanying tests. Describe the tests you added or if no tests were added an explanation about why one was not needed.
--->
1. Open the web example
2. Focus on the input
3. Verify there is a caret shown
4. Press the "Toggle caret hidden" button
5. Focus on the input again
6. Verify there is no caret shown

https://github.com/user-attachments/assets/b0b72ee1-d46c-4a1d-a18c-d69696d2b1a2


### Linked PRs
<!---
Please include links to any update PRs in repos that must change their package.json version.
--->