### PR TITLE
Updates url to match case

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
   ],
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/expensify/react-native-live-markdown.git"
+    "url": "git+https://github.com/Expensify/react-native-live-markdown.git"
   },
   "author": "Expensify, Inc.",
   "license": "MIT",


### PR DESCRIPTION
### Details
The npm publish workflow is failing because we added provenance to our command but it seems to use case sensitive checks. We need to update the URL so that it matches the case and can pass the provenance check.

### Related Issues
https://expensify.slack.com/archives/C06BDSWLDPB/p1739793644035839

### Manual Tests
Merge this PR
Verify that the npm publish workflow works

### Linked PRs