### PR TITLE
Add 0.77 to compatibility table in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,10 +179,11 @@ Currently, `react-native-live-markdown` supports only [ExpensiMark](https://gith
 
 ## Compatibility
 
-`react-native-live-markdown` requires React Native 0.75 or newer.
+`react-native-live-markdown` supports two latest React Native minor releases.
 
 | react-native | @expensify/react-native-live-markdown |
 | :----------: | :-----------------------------------: |
+|     0.77     |               0.1.235+                |
 |     0.76     |               0.1.141+                |
 |     0.75     |               0.1.129+                |
 |     0.74     |           0.1.122 – 0.1.128           |


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Details
This PR adds a row with React Native 0.77 in the compatibility table in README.

### Related Issues
<!-- Please replace GH_LINK with the link to the GitHub issue this Pull Request is related to -->
GH_LINK

### Manual Tests
<!---
Most changes should have accompanying tests. Describe the tests you added or if no tests were added an explanation about why one was not needed.
--->

### Linked PRs
<!---
Please include links to any update PRs in repos that must change their package.json version.
--->