### PR TITLE
Fix inline images in multiple Live Markdown inputs

### DIFF
--- a/src/MarkdownTextInput.web.tsx
+++ b/src/MarkdownTextInput.web.tsx
@@ -21,7 +21,7 @@ import {getCurrentCursorPosition, removeSelection, setCursorPosition} from './we
 import './web/MarkdownTextInput.css';
 import type {MarkdownStyle} from './MarkdownTextInputDecoratorViewNativeComponent';
 import {getElementHeight, getPlaceholderValue, isEventComposing, normalizeValue, parseInnerHTMLToText} from './web/utils/inputUtils';
-import {parseToReactDOMStyle, processMarkdownStyle} from './web/utils/webStyleUtils';
+import {idGenerator, parseToReactDOMStyle, processMarkdownStyle} from './web/utils/webStyleUtils';
 import {forceRefreshAllImages} from './web/inputElements/inlineImage';
 import type {MarkdownRange, InlineImagesInputProps} from './commonTypes';
 
@@ -69,6 +69,7 @@ let focusTimeout: NodeJS.Timeout | null = null;
 type MarkdownTextInputElement = HTMLDivElement &
   HTMLInputElement & {
     tree: TreeNode;
+    uniqueId: string;
     selection: Selection;
     imageElements: HTMLImageElement[];
   };
@@ -736,6 +737,7 @@ const MarkdownTextInput = React.forwardRef<MarkdownTextInput, MarkdownTextInputP
       if (autoFocus) {
         divRef.current.focus();
       }
+      divRef.current.uniqueId = idGenerator.next().value as string;
       // eslint-disable-next-line react-hooks/exhaustive-deps
     }, []);
 

--- a/src/web/inputElements/inlineImage.ts
+++ b/src/web/inputElements/inlineImage.ts
@@ -24,6 +24,56 @@ function getImagePreviewElement(targetElement: HTMLMarkdownElement) {
   return Array.from(targetElement?.childNodes || []).find((el) => (el as HTMLElement)?.contentEditable === 'false') as HTMLMarkdownElement | undefined;
 }
 
+function scaleImageDimensions(imgElement: HTMLImageElement) {
+  const {height, width} = imgElement;
+  const {maxHeight, maxWidth, minHeight, minWidth} = imgElement.style || {};
+  const maxHeightValue = parseStringWithUnitToNumber(maxHeight);
+  const maxWidthValue = parseStringWithUnitToNumber(maxWidth);
+  const minHeightValue = parseStringWithUnitToNumber(minHeight);
+  const minWidthValue = parseStringWithUnitToNumber(minWidth);
+
+  // Calculate the initial aspect ratio
+  const aspectRatio = width / height;
+
+  // Define scaled dimensions initializing with original dimensions.
+  let scaledWidth = width;
+  let scaledHeight = height;
+
+  // Check and apply maxWidth and maxHeight constraints
+  if (maxWidthValue && scaledWidth > maxWidthValue) {
+    scaledWidth = maxWidthValue;
+    scaledHeight = scaledWidth / aspectRatio;
+  }
+  if (maxHeight && scaledHeight > maxHeightValue) {
+    scaledHeight = maxHeightValue;
+    scaledWidth = scaledHeight * aspectRatio;
+  }
+
+  // Double-check dimensions after first scaling
+  if (scaledWidth > maxWidthValue) {
+    scaledWidth = maxWidthValue;
+    scaledHeight = scaledWidth / aspectRatio;
+  }
+
+  // Check and apply minWidth and minHeight constraints
+  if (minWidthValue && scaledWidth < minWidthValue) {
+    scaledWidth = minWidthValue;
+    scaledHeight = scaledWidth / aspectRatio;
+  }
+  if (minHeightValue && scaledHeight < minHeightValue) {
+    scaledHeight = minHeightValue;
+    scaledWidth = scaledHeight * aspectRatio;
+  }
+
+  // Double-check dimensions after second scaling
+  if (scaledHeight < minHeightValue) {
+    scaledHeight = minHeightValue;
+    scaledWidth = scaledHeight * aspectRatio;
+  }
+
+  return {height, width};
+}
+
 function handleOnLoad(
   currentInput: MarkdownTextInputElement,
   target: HTMLMarkdownElement,
@@ -86,14 +136,14 @@ function handleOnLoad(
     currentInputElement.imageElements = [img];
   }
 
-  const imageClientHeight = Math.max(img.clientHeight, imageContainer.clientHeight);
+  const scaledImageHeight = scaleImageDimensions(img).height;
   Object.assign(imageContainer.style, {
-    height: `${imageClientHeight}px`,
+    height: `${scaledImageHeight}px`,
   });
   // Set paddingBottom to the height of the image so it's displayed under the block
   const imageMarginTop = parseStringWithUnitToNumber(`${markdownStyle.inlineImage?.marginTop}`);
   Object.assign(targetElement.style, {
-    paddingBottom: `${imageClientHeight + imageMarginTop}px`,
+    paddingBottom: `${scaledImageHeight + imageMarginTop}px`,
   });
 }
 

--- a/src/web/inputElements/inlineImage.ts
+++ b/src/web/inputElements/inlineImage.ts
@@ -71,7 +71,7 @@ function scaleImageDimensions(imgElement: HTMLImageElement) {
     scaledWidth = scaledHeight * aspectRatio;
   }
 
-  return {height, width};
+  return {height: scaledHeight, width: scaledWidth};
 }
 
 function handleOnLoad(

--- a/src/web/inputElements/inlineImage.ts
+++ b/src/web/inputElements/inlineImage.ts
@@ -174,7 +174,7 @@ function createImageElement(currentInput: MarkdownTextInputElement, targetNode: 
     img.src = url;
     timeoutMap.delete(targetNode.orderIndex);
   }, INLINE_IMAGE_PREVIEW_DEBOUNCE_TIME_MS);
-  timeoutMap.set(targetNode.orderIndex, {
+  timeoutMap.set(`${currentInput.uniqueId}-${targetNode.orderIndex}`, {
     timeout,
     url,
   });

--- a/src/web/utils/webStyleUtils.ts
+++ b/src/web/utils/webStyleUtils.ts
@@ -51,4 +51,13 @@ function parseToReactDOMStyle(style: TextStyle): any {
   return createReactDOMStyle(preprocessStyle(style));
 }
 
-export {parseToReactDOMStyle, processMarkdownStyle};
+function* generateUniqueId() {
+  let idCounter = 0;
+  while (true) {
+    yield `live-markdown-input-${idCounter++}`;
+  }
+}
+
+const idGenerator = generateUniqueId();
+
+export {parseToReactDOMStyle, processMarkdownStyle, idGenerator};


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Details
<!-- Explanation of the change or anything fishy that is going on -->
This PR fixes the problem with infinite loading indicators when two Live Markdown inputs with the same content are present. Also it changes the way how we calculate scaled image height to fix problems related to handling multiple inputs.

### Related Issues
<!-- Please replace GH_LINK with the link to the GitHub issue this Pull Request is related to -->
https://github.com/Expensify/App/issues/56739

### Manual Tests
<!---
Most changes should have accompanying tests. Describe the tests you added or if no tests were added an explanation about why one was not needed.
--->
1. Add multiple live markdown inputs that have the same input value with inline image markdown
2. Refresh the page
3. Verify if inline images are loaded in both inputs

### Linked PRs
<!---
Please include links to any update PRs in repos that must change their package.json version.
--->