### PR TITLE
Fix linking error `error: undefined symbol: worklets::extractWorkletRuntime` on Android

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -9,6 +9,10 @@ buildscript {
   }
 }
 
+task prepareKotlinBuildScriptModel {
+  // This task is run during Gradle Sync in Android Studio.
+}
+
 def reactNativeArchitectures() {
   def value = project.getProperties().get("reactNativeArchitectures")
   return value ? value.split(",") : ["armeabi-v7a", "x86", "x86_64", "arm64-v8a"]
@@ -192,4 +196,13 @@ if (isNewArchitectureEnabled()) {
     libraryName = "LiveMarkdown"
     codegenJavaPackageName = "com.expensify.livemarkdown"
   }
+}
+
+// This fixes linking errors due to undefined symbols from libworklets.so.
+// During Gradle Sync, Android Gradle Plugin runs Prefab and treats worklets
+// like a header-only library. During build, config files are not regenerated
+// because the cache key does not change and AGP thinks that they are up-to-date.
+afterEvaluate {
+  prepareKotlinBuildScriptModel.dependsOn(":react-native-reanimated:prefabDebugPackage")
+  prepareKotlinBuildScriptModel.dependsOn(":react-native-reanimated:prefabReleasePackage")
 }


### PR DESCRIPTION
Co-authored-by: Łukasz Kosmaty <lukasz.kosmaty@swmansion.com>

### Details
This PR fixes building RN apps with `@expensify/react-native-live-markdown` on Android after Gradle Sync.

Big kudos to @lukmccall for investigating this issue and coming up with a clever fix!

### Related Issues
Fixes https://github.com/Expensify/react-native-live-markdown/issues/602.

### Manual Tests
<!---
Most changes should have accompanying tests. Describe the tests you added or if no tests were added an explanation about why one was not needed.
--->

### Linked PRs
<!---
Please include links to any update PRs in repos that must change their package.json version.
--->