### PR TITLE
fix: Turning online causes an null error

### DIFF
--- a/src/web/inputElements/inlineImage.ts
+++ b/src/web/inputElements/inlineImage.ts
@@ -195,7 +195,7 @@ function addInlineImagePreview(
 }
 
 function forceRefreshAllImages(currentInput: MarkdownTextInputElement, markdownStyle: PartialMarkdownStyle) {
-  currentInput.querySelectorAll('img').forEach((img) => {
+  currentInput?.querySelectorAll('img').forEach((img) => {
     // force image reload only if broken image icon is displayed
     if (img.naturalWidth > 0) {
       return;


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Details
<!-- Explanation of the change or anything fishy that is going on -->
This checks if `divRef.current` is defined or not when `forceRefreshAllImages` runs with event `online`. 

### Related Issues
<!-- Please replace GH_LINK with the link to the GitHub issue this Pull Request is related to -->
https://github.com/Expensify/react-native-live-markdown/issues/630

### Manual Tests
<!---
Most changes should have accompanying tests. Describe the tests you added or if no tests were added an explanation about why one was not needed.
--->
On Expensify app's dev mode(~version 9.1.7-1),

1. Turn off the network at inbox(There must be a component with `MarkdownTextInput`).
2. On offline, go to settings on bottom tab.
3. Turn on the network.
4. Any error doesn't occurs.

### Linked PRs
<!---
Please include links to any update PRs in repos that must change their package.json version.
--->
