### PR TITLE
Remove `newarch` subspec on iOS

### DIFF
--- a/RNLiveMarkdown.podspec
+++ b/RNLiveMarkdown.podspec
@@ -43,9 +43,4 @@ Pod::Spec.new do |s|
     ])
     add_dependency(s, "React-rendererconsistency")
   end
-
-  s.subspec "newarch" do |ss|
-    ss.source_files         = "cpp/**/*.{cpp,h}"
-    ss.header_dir           = "RNLiveMarkdown"
-  end
 end


### PR DESCRIPTION
### Details
Previously, we would have a separate subspec for new-arch only files on iOS. Now that we only support the New Architecture, this level of separation is not needed. This PR removes `newarch` subspec. The source files are already covered by the wildcard in main spec so there's no need for any changes. Luckily, the headers in `cpp` are not nested so `#import <RNLiveMarkdown/SomeHeader.h>` still works thanks to the way how CocoaPods flattens header files in Pods.

### Related Issues
<!-- Please replace GH_LINK with the link to the GitHub issue this Pull Request is related to -->
GH_LINK

### Manual Tests
<!---
Most changes should have accompanying tests. Describe the tests you added or if no tests were added an explanation about why one was not needed.
--->

### Linked PRs
<!---
Please include links to any update PRs in repos that must change their package.json version.
--->