### PR TITLE
Remove support for RN 0.75 from CMakeLists.txt on Android

### DIFF
--- a/android/src/main/cpp/CMakeLists.txt
+++ b/android/src/main/cpp/CMakeLists.txt
@@ -25,18 +25,6 @@ target_link_libraries(
         ${CMAKE_PROJECT_NAME}
         fbjni::fbjni
         ReactAndroid::jsi
+        ReactAndroid::reactnative
         react-native-reanimated::worklets
 )
-
-if (ReactAndroid_VERSION_MINOR GREATER_EQUAL 76)
-  target_link_libraries(${CMAKE_PROJECT_NAME} ReactAndroid::reactnative)
-elseif (ReactAndroid_VERSION_MINOR GREATER_EQUAL 75)
-  target_link_libraries(
-          ${CMAKE_PROJECT_NAME}
-          ReactAndroid::react_nativemodule_core
-          ReactAndroid::reactnativejni
-          ReactAndroid::runtimeexecutor
-  )
-else ()
-  message(FATAL_ERROR "react-native-live-markdown requires react-native 0.75 or newer.")
-endif ()

--- a/android/src/main/new_arch/CMakeLists.txt
+++ b/android/src/main/new_arch/CMakeLists.txt
@@ -39,40 +39,8 @@ target_link_libraries(
         ${LIB_TARGET_NAME}
         fbjni::fbjni
         ReactAndroid::jsi
+        ReactAndroid::reactnative
 )
-
-if (ReactAndroid_VERSION_MINOR GREATER_EQUAL 76)
-  target_link_libraries(
-          ${LIB_TARGET_NAME}
-          ReactAndroid::reactnative
-  )
-elseif (ReactAndroid_VERSION_MINOR GREATER_EQUAL 75)
-  target_link_libraries(
-          ${LIB_TARGET_NAME}
-          ReactAndroid::fabricjni
-          ReactAndroid::folly_runtime
-          ReactAndroid::glog
-          ReactAndroid::react_debug
-          ReactAndroid::react_nativemodule_core
-          ReactAndroid::react_performance_timeline
-          ReactAndroid::react_render_consistency
-          ReactAndroid::react_render_core
-          ReactAndroid::react_render_debug
-          ReactAndroid::react_render_graphics
-          ReactAndroid::react_render_imagemanager
-          ReactAndroid::react_render_mapbuffer
-          ReactAndroid::react_render_observers_events
-          ReactAndroid::react_render_textlayoutmanager
-          ReactAndroid::reactnativejni
-          ReactAndroid::rrc_text
-          ReactAndroid::rrc_textinput
-          ReactAndroid::rrc_view
-          ReactAndroid::runtimeexecutor
-          ReactAndroid::yoga
-  )
-else ()
-  message(FATAL_ERROR "react-native-live-markdown requires react-native 0.75 or newer.")
-endif ()
 
 target_compile_options(
         ${LIB_TARGET_NAME}


### PR DESCRIPTION
### Details
This PR removes conditionals in CMakeLists.txt for better readability and drops support for RN 0.75.

### Related Issues
<!-- Please replace GH_LINK with the link to the GitHub issue this Pull Request is related to -->
GH_LINK

### Manual Tests
<!---
Most changes should have accompanying tests. Describe the tests you added or if no tests were added an explanation about why one was not needed.
--->

### Linked PRs
<!---
Please include links to any update PRs in repos that must change their package.json version.
--->