### PR TITLE
Fix caret offset after blockquote on iOS

### DIFF
--- a/apple/MarkdownBackedTextInputDelegate.h
+++ b/apple/MarkdownBackedTextInputDelegate.h
@@ -1,0 +1,12 @@
+#import <React/RCTBackedTextInputDelegate.h>
+#import <React/RCTUITextView.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface MarkdownBackedTextInputDelegate : NSObject <RCTBackedTextInputDelegate>
+
+- (instancetype)initWithTextView:(RCTUITextView *)textView;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/apple/MarkdownBackedTextInputDelegate.mm
+++ b/apple/MarkdownBackedTextInputDelegate.mm
@@ -1,0 +1,77 @@
+#import "MarkdownBackedTextInputDelegate.h"
+
+@implementation MarkdownBackedTextInputDelegate {
+  __weak RCTUITextView *_textView;
+  id<RCTBackedTextInputDelegate> _originalTextInputDelegate;
+}
+
+- (instancetype)initWithTextView:(RCTUITextView *)textView
+{
+  if (self = [super init]) {
+    _textView = textView;
+    _originalTextInputDelegate = _textView.textInputDelegate;
+    _textView.textInputDelegate = self;
+  }
+  return self;
+}
+
+- (void)dealloc
+{
+  // Restore original text input delegate
+  _textView.textInputDelegate = _originalTextInputDelegate;
+}
+
+- (void)textInputDidChangeSelection {
+  // Delegate the call to the original text input delegate
+  [_originalTextInputDelegate textInputDidChangeSelection];
+
+  // After adding a newline at the end of the blockquote, the typing attributes in the next line still contain
+  // NSParagraphStyle with non-zero firstLineHeadIndent and headIntent added by `_updateTypingAttributes` call.
+  // This causes the cursor to be shifted to the right instead of being located at the beginning of the line.
+  // The following code removes NSParagraphStyle from typing attributes to fix the position of the cursor.
+  NSMutableDictionary *typingAttributes = [_textView.typingAttributes mutableCopy];
+  [typingAttributes removeObjectForKey:NSParagraphStyleAttributeName];
+  _textView.typingAttributes = typingAttributes;
+}
+
+// Delegate all remaining calls to the original text input delegate
+
+- (void)textInputDidChange
+{
+  // Delegate the call to the original text input delegate
+  [_originalTextInputDelegate textInputDidChange];
+}
+
+- (void)textInputDidBeginEditing {
+  [_originalTextInputDelegate textInputDidBeginEditing];
+}
+
+- (void)textInputDidEndEditing {
+  [_originalTextInputDelegate textInputDidEndEditing];
+}
+
+- (void)textInputDidReturn {
+  [_originalTextInputDelegate textInputDidReturn];
+}
+
+- (BOOL)textInputShouldBeginEditing {
+  return [_originalTextInputDelegate textInputShouldBeginEditing];
+}
+
+- (nonnull NSString *)textInputShouldChangeText:(nonnull NSString *)text inRange:(NSRange)range {
+  return [_originalTextInputDelegate textInputShouldChangeText:text inRange:range];
+}
+
+- (BOOL)textInputShouldEndEditing {
+  return [_originalTextInputDelegate textInputShouldEndEditing];
+}
+
+- (BOOL)textInputShouldReturn {
+  return [_originalTextInputDelegate textInputShouldReturn];
+}
+
+- (BOOL)textInputShouldSubmitOnReturn {
+  return [_originalTextInputDelegate textInputShouldSubmitOnReturn];
+}
+
+@end

--- a/apple/MarkdownBackedTextInputDelegate.mm
+++ b/apple/MarkdownBackedTextInputDelegate.mm
@@ -21,7 +21,8 @@
   _textView.textInputDelegate = _originalTextInputDelegate;
 }
 
-- (void)textInputDidChangeSelection {
+- (void)textInputDidChangeSelection
+{
   // Delegate the call to the original text input delegate
   [_originalTextInputDelegate textInputDidChangeSelection];
 
@@ -38,39 +39,46 @@
 
 - (void)textInputDidChange
 {
-  // Delegate the call to the original text input delegate
   [_originalTextInputDelegate textInputDidChange];
 }
 
-- (void)textInputDidBeginEditing {
+- (void)textInputDidBeginEditing
+{
   [_originalTextInputDelegate textInputDidBeginEditing];
 }
 
-- (void)textInputDidEndEditing {
+- (void)textInputDidEndEditing
+{
   [_originalTextInputDelegate textInputDidEndEditing];
 }
 
-- (void)textInputDidReturn {
+- (void)textInputDidReturn
+{
   [_originalTextInputDelegate textInputDidReturn];
 }
 
-- (BOOL)textInputShouldBeginEditing {
+- (BOOL)textInputShouldBeginEditing
+{
   return [_originalTextInputDelegate textInputShouldBeginEditing];
 }
 
-- (nonnull NSString *)textInputShouldChangeText:(nonnull NSString *)text inRange:(NSRange)range {
+- (nonnull NSString *)textInputShouldChangeText:(nonnull NSString *)text inRange:(NSRange)range
+{
   return [_originalTextInputDelegate textInputShouldChangeText:text inRange:range];
 }
 
-- (BOOL)textInputShouldEndEditing {
+- (BOOL)textInputShouldEndEditing
+{
   return [_originalTextInputDelegate textInputShouldEndEditing];
 }
 
-- (BOOL)textInputShouldReturn {
+- (BOOL)textInputShouldReturn
+{
   return [_originalTextInputDelegate textInputShouldReturn];
 }
 
-- (BOOL)textInputShouldSubmitOnReturn {
+- (BOOL)textInputShouldSubmitOnReturn
+{
   return [_originalTextInputDelegate textInputShouldSubmitOnReturn];
 }
 

--- a/apple/MarkdownTextInputDecoratorComponentView.mm
+++ b/apple/MarkdownTextInputDecoratorComponentView.mm
@@ -3,6 +3,7 @@
 #import <React/RCTFabricComponentsPlugins.h>
 #import <React/RCTUITextField.h>
 
+#import <RNLiveMarkdown/MarkdownBackedTextInputDelegate.h>
 #import <RNLiveMarkdown/MarkdownLayoutManager.h>
 #import <RNLiveMarkdown/MarkdownShadowFamilyRegistry.h>
 #import <RNLiveMarkdown/MarkdownTextInputDecoratorComponentView.h>
@@ -20,6 +21,7 @@ using namespace facebook::react;
   RCTMarkdownUtils *_markdownUtils;
   RCTMarkdownStyle *_markdownStyle;
   NSNumber *_parserId;
+  MarkdownBackedTextInputDelegate *_markdownBackedTextInputDelegate;
   __weak RCTTextInputComponentView *_textInput;
   __weak UIView<RCTBackedTextInputViewProtocol> *_backedTextInputView;
   __weak RCTBackedTextFieldDelegateAdapter *_adapter;
@@ -109,6 +111,9 @@ using namespace facebook::react;
     layoutManager.allowsNonContiguousLayout = NO; // workaround for onScroll issue
     object_setClass(layoutManager, [MarkdownLayoutManager class]);
     [layoutManager setValue:_markdownUtils forKey:@"markdownUtils"];
+
+    // register delegate for fixing cursor position after blockquote
+    _markdownBackedTextInputDelegate = [[MarkdownBackedTextInputDelegate alloc] initWithTextView:_textView];
   } else {
     react_native_assert(false && "Cannot enable Markdown for this type of TextInput.");
   }
@@ -123,6 +128,7 @@ using namespace facebook::react;
     [_adapter setMarkdownUtils:nil];
   }
   if (_textView != nil) {
+    _markdownBackedTextInputDelegate = nil;
     [_textView setMarkdownUtils:nil];
     if (_textView.layoutManager != nil && [object_getClass(_textView.layoutManager) isEqual:[MarkdownLayoutManager class]]) {
       [_textView.layoutManager setValue:nil forKey:@"markdownUtils"];

--- a/apple/RCTTextInputComponentView+Markdown.mm
+++ b/apple/RCTTextInputComponentView+Markdown.mm
@@ -44,6 +44,16 @@ using namespace expensify::livemarkdown;
 
   // Call the original method
   [self markdown__setAttributedString:attributedString];
+  
+  if (markdownUtils != nil && backedTextInputView != nil) {
+    // After adding a newline at the end of the blockquote, the typing attributes in the next line still contain
+    // NSParagraphStyle with non-zero firstLineHeadIndent and headIntent added by `_updateTypingAttributes` call.
+    // This causes the cursor to be shifted to the right instead of being located at the beginning of the line.
+    // The following code removes NSParagraphStyle from typing attributes to fix the position of the cursor.
+    NSMutableDictionary *typingAttributes = [backedTextInputView.typingAttributes mutableCopy];
+    [typingAttributes removeObjectForKey:NSParagraphStyleAttributeName];
+    backedTextInputView.typingAttributes = typingAttributes;
+  }
 }
 
 - (BOOL)markdown__textOf:(NSAttributedString *)newText equals:(NSAttributedString *)oldText

--- a/apple/RCTUITextView+Markdown.mm
+++ b/apple/RCTUITextView+Markdown.mm
@@ -19,7 +19,6 @@
     UITextRange *range = self.selectedTextRange;
     super.attributedText = [markdownUtils parseMarkdown:self.attributedText withDefaultTextAttributes:self.defaultTextAttributes];
     [super setSelectedTextRange:range]; // prevents cursor from jumping at the end when typing in the middle of the text
-    self.typingAttributes = self.defaultTextAttributes; // removes indent in new line when typing after blockquote
   }
 
   // Call the original method


### PR DESCRIPTION
### Details

This PR fixes cursor position (horizontal offset) in a newline after blockquote on iOS.

The incorrect position was mainly caused by two calls to `[RCTTextInputComponentView _updateTypingAttributes]` method in `RCTTextInputComponentView` logic.

The first call comes from `[RCTTextInputComponentView textInputDidChangeSelection]`. We overwrite `typingAttributes` in `[MarkdownBackedTextInputDelegate textInputDidChangeSelection]`.

The second calls comes from `[RCTTextInputComponentView _setAttributedString]`. We overwrite `typingAttributes` after calling the original method from a swizzled method.

| Before | After |
|:-:|:-:|
| <video src="https://github.com/user-attachments/assets/90935526-1bb1-47ea-8703-ddeb6d1d9dce" /> | <video src="https://github.com/user-attachments/assets/d5ac635b-59fb-4a2c-88cc-f904437477c7" /> |

### Related Issues
<!-- Please replace GH_LINK with the link to the GitHub issue this Pull Request is related to -->
https://github.com/Expensify/App/issues/57290

### Manual Tests
<!---
Most changes should have accompanying tests. Describe the tests you added or if no tests were added an explanation about why one was not needed.
--->

### Linked PRs
<!---
Please include links to any update PRs in repos that must change their package.json version.
--->