### PR TITLE
Add basic mock for `getWorkletRuntime`

### DIFF
--- a/mock/index.ts
+++ b/mock/index.ts
@@ -11,4 +11,6 @@ const parseExpensiMarkMock: typeof parseExpensiMark = () => {
   return [];
 };
 
-export {MarkdownTextInput, parseExpensiMarkMock as parseExpensiMark};
+const getWorkletRuntimeMock = () => ({});
+
+export {MarkdownTextInput, parseExpensiMarkMock as parseExpensiMark, getWorkletRuntimeMock as getWorkletRuntime};


### PR DESCRIPTION
### Details
A while ago we added `getWorkletRuntime` function, but we did not add a mock for it.
Since we have mocks for other functions we should add one for this as well.

Tests should (probably) never do anything with runtime, so I'm just mocking with empty object.

Here's an example where I added this mock in Expensify and I have tests passing correctly: https://github.com/Expensify/App/pull/54037/files#diff-19689d115bb960aa8eace61946bf9acbd2d0d8ad6b4b8f67a14dd25e3b6d16a0R3

### Related Issues
N/A

### Manual Tests
N/A

### Linked PRs
N/A