### PR TITLE
Add missing property `ios.componentProvider` in `codegenConfig`

### DIFF
--- a/package.json
+++ b/package.json
@@ -168,6 +168,11 @@
     "jsSrcsDir": "src",
     "android": {
       "javaPackageName": "com.expensify.livemarkdown"
+    },
+    "ios": {
+      "componentProvider": {
+        "MarkdownTextInputDecoratorView": "MarkdownTextInputDecoratorComponentView"
+      }
     }
   }
 }


### PR DESCRIPTION
### Details
This PR eliminates the following warning during pod install:
```
[Codegen] [DEPRECATED] @expensify/react-native-live-markdown should add the 'ios.componentProvider' property in their codegenConfig
```

### Related Issues
<!-- Please replace GH_LINK with the link to the GitHub issue this Pull Request is related to -->
GH_LINK

### Manual Tests
<!---
Most changes should have accompanying tests. Describe the tests you added or if no tests were added an explanation about why one was not needed.
--->

### Linked PRs
<!---
Please include links to any update PRs in repos that must change their package.json version.
--->