### PR TITLE
Fix cursor height in empty text input with line height set

### DIFF
--- a/apple/MarkdownBackedTextInputDelegate.mm
+++ b/apple/MarkdownBackedTextInputDelegate.mm
@@ -29,10 +29,17 @@
   // After adding a newline at the end of the blockquote, the typing attributes in the next line still contain
   // NSParagraphStyle with non-zero firstLineHeadIndent and headIntent added by `_updateTypingAttributes` call.
   // This causes the cursor to be shifted to the right instead of being located at the beginning of the line.
-  // The following code removes NSParagraphStyle from typing attributes to fix the position of the cursor.
-  NSMutableDictionary *typingAttributes = [_textView.typingAttributes mutableCopy];
-  [typingAttributes removeObjectForKey:NSParagraphStyleAttributeName];
-  _textView.typingAttributes = typingAttributes;
+  // The following code resets firstLineHeadIndent and headIndent in NSParagraphStyle in typing attributes
+  // in order to fix the position of the cursor.
+  NSDictionary<NSAttributedStringKey, id> *typingAttributes = _textView.typingAttributes;
+  if (typingAttributes[NSParagraphStyleAttributeName] != nil) {
+    NSMutableDictionary *mutableTypingAttributes = [typingAttributes mutableCopy];
+    NSMutableParagraphStyle *mutableParagraphStyle = [typingAttributes[NSParagraphStyleAttributeName] mutableCopy];
+    mutableParagraphStyle.firstLineHeadIndent = 0;
+    mutableParagraphStyle.headIndent = 0;
+    mutableTypingAttributes[NSParagraphStyleAttributeName] = mutableParagraphStyle;
+    _textView.typingAttributes = mutableTypingAttributes;
+  }
 }
 
 // Delegate all remaining calls to the original text input delegate

--- a/apple/RCTTextInputComponentView+Markdown.mm
+++ b/apple/RCTTextInputComponentView+Markdown.mm
@@ -49,10 +49,17 @@ using namespace expensify::livemarkdown;
     // After adding a newline at the end of the blockquote, the typing attributes in the next line still contain
     // NSParagraphStyle with non-zero firstLineHeadIndent and headIntent added by `_updateTypingAttributes` call.
     // This causes the cursor to be shifted to the right instead of being located at the beginning of the line.
-    // The following code removes NSParagraphStyle from typing attributes to fix the position of the cursor.
-    NSMutableDictionary *typingAttributes = [backedTextInputView.typingAttributes mutableCopy];
-    [typingAttributes removeObjectForKey:NSParagraphStyleAttributeName];
-    backedTextInputView.typingAttributes = typingAttributes;
+    // The following code resets firstLineHeadIndent and headIndent in NSParagraphStyle in typing attributes
+    // in order to fix the position of the cursor.
+    NSDictionary<NSAttributedStringKey, id> *typingAttributes = backedTextInputView.typingAttributes;
+    if (typingAttributes[NSParagraphStyleAttributeName] != nil) {
+      NSMutableDictionary *mutableTypingAttributes = [typingAttributes mutableCopy];
+      NSMutableParagraphStyle *mutableParagraphStyle = [typingAttributes[NSParagraphStyleAttributeName] mutableCopy];
+      mutableParagraphStyle.firstLineHeadIndent = 0;
+      mutableParagraphStyle.headIndent = 0;
+      mutableTypingAttributes[NSParagraphStyleAttributeName] = mutableParagraphStyle;
+      backedTextInputView.typingAttributes = mutableTypingAttributes;
+    }
   }
 }
 


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Details
This PR fixes a visual regression introduced in https://github.com/Expensify/react-native-live-markdown/pull/642 related to cursor height in empty text input with `lineHeight` set on iOS:

| Incorrect | Correct (after this PR) |
|:-:|:-:|
| <img width="281" alt="Screenshot 2025-03-18 at 12 07 30" src="https://github.com/user-attachments/assets/fd891c69-a4c2-4163-aced-eabf514ecac8" /> | <img width="279" alt="Screenshot 2025-03-18 at 12 00 41" src="https://github.com/user-attachments/assets/5838b429-278a-41e8-9bf1-d5a56f4cbfda" /> |

In https://github.com/Expensify/react-native-live-markdown/pull/642 we added logic that removes `NSParagraphStyle` from `typingAttributes` of `RCTUITextView`. However, `lineHeight` style is applied by react-native using `NSParagraphStyle` so if we can't simply remove it. Instead, we reset `firstLineHeadIndent` and `headIndent` on a copy.

### Related Issues
<!-- Please replace GH_LINK with the link to the GitHub issue this Pull Request is related to -->
GH_LINK

### Manual Tests
Add `lineHeight: 40` in `styles.input` in App.tsx.

### Linked PRs
<!---
Please include links to any update PRs in repos that must change their package.json version.
--->