### PR TITLE
Store previous text as a copy in parser on iOS

### DIFF
--- a/apple/MarkdownParser.mm
+++ b/apple/MarkdownParser.mm
@@ -23,7 +23,7 @@
     try {
       markdownWorklet = expensify::livemarkdown::getMarkdownWorklet([parserId intValue]);
     } catch (const std::out_of_range &error) {
-      _prevText = text;
+      _prevText = [NSString stringWithString:text];
       _prevParserId = parserId;
       _prevMarkdownRanges = @[];
       return _prevMarkdownRanges;
@@ -36,7 +36,7 @@
       output = markdownRuntime->runGuarded(markdownWorklet, input);
     } catch (const jsi::JSError &error) {
       // Skip formatting, runGuarded will show the error in LogBox
-      _prevText = text;
+      _prevText = [NSString stringWithString:text];
       _prevParserId = parserId;
       _prevMarkdownRanges = @[];
       return _prevMarkdownRanges;
@@ -62,13 +62,13 @@
       }
     } catch (const jsi::JSError &error) {
       RCTLogWarn(@"[react-native-live-markdown] Incorrect schema of worklet parser output: %s", error.getMessage().c_str());
-      _prevText = text;
+      _prevText = [NSString stringWithString:text];
       _prevParserId = parserId;
       _prevMarkdownRanges = @[];
       return _prevMarkdownRanges;
     }
 
-    _prevText = text;
+    _prevText = [NSString stringWithString:text];
     _prevParserId = parserId;
     _prevMarkdownRanges = markdownRanges;
     return _prevMarkdownRanges;


### PR DESCRIPTION
### Details
This change has been introduced first as a part of https://github.com/Expensify/react-native-live-markdown/pull/520.

Currently, we store `NSString *text` in `_prevText` field in `MarkdownParser` class on iOS without making a copy during its assignment. This makes it vulnerable to mutable strings if the underlying data changes in other parts of the code (like modifying `NSTextStorage` inplace). Instead, we should make our own copy to prevent unwanted behavior in the future.

### Related Issues
<!-- Please replace GH_LINK with the link to the GitHub issue this Pull Request is related to -->
GH_LINK

### Manual Tests
<!---
Most changes should have accompanying tests. Describe the tests you added or if no tests were added an explanation about why one was not needed.
--->

### Linked PRs
<!---
Please include links to any update PRs in repos that must change their package.json version.
--->