### PR TITLE
Fix type of backed text input view on iOS

### DIFF
--- a/apple/RCTTextInputComponentView+Markdown.mm
+++ b/apple/RCTTextInputComponentView+Markdown.mm
@@ -1,6 +1,6 @@
 #import <RNLiveMarkdown/RCTTextInputComponentView+Markdown.h>
 #import <RNLiveMarkdown/RCTMarkdownUtils.h>
-#import <React/RCTUITextField.h>
+#import <React/RCTUITextView.h>
 #import <objc/message.h>
 
 @implementation RCTTextInputComponentView (Markdown)
@@ -13,15 +13,15 @@
   return objc_getAssociatedObject(self, @selector(getMarkdownUtils));
 }
 
-- (RCTUITextField *)getBackedTextInputView {
-  RCTUITextField *backedTextInputView = [self valueForKey:@"_backedTextInputView"];
+- (RCTUITextView *)getBackedTextInputView {
+  RCTUITextView *backedTextInputView = [self valueForKey:@"wView"];
   return backedTextInputView;
 }
 
 - (void)markdown__setAttributedString:(NSAttributedString *)attributedString
 {
   RCTMarkdownUtils *markdownUtils = [self getMarkdownUtils];
-  RCTUITextField *backedTextInputView = [self getBackedTextInputView];
+  RCTUITextView *backedTextInputView = [self getBackedTextInputView];
   if (markdownUtils != nil && backedTextInputView != nil) {
     attributedString = [markdownUtils parseMarkdown:attributedString withDefaultTextAttributes:backedTextInputView.defaultTextAttributes];
   }

--- a/apple/RCTTextInputComponentView+Markdown.mm
+++ b/apple/RCTTextInputComponentView+Markdown.mm
@@ -14,7 +14,7 @@
 }
 
 - (RCTUITextView *)getBackedTextInputView {
-  RCTUITextView *backedTextInputView = [self valueForKey:@"wView"];
+  RCTUITextView *backedTextInputView = [self valueForKey:@"_backedTextInputView"];
   return backedTextInputView;
 }
 

--- a/apple/RCTTextInputComponentView+Markdown.mm
+++ b/apple/RCTTextInputComponentView+Markdown.mm
@@ -13,10 +13,14 @@
   return objc_getAssociatedObject(self, @selector(getMarkdownUtils));
 }
 
+- (RCTUITextView *)getBackedTextInputView {
+  return [self valueForKey:@"_backedTextInputView"];
+}
+
 - (void)markdown__setAttributedString:(NSAttributedString *)attributedString
 {
   RCTMarkdownUtils *markdownUtils = [self getMarkdownUtils];
-  RCTUITextView *backedTextInputView = [self valueForKey:@"_backedTextInputView"];
+  RCTUITextView *backedTextInputView = [self getBackedTextInputView];
   if (markdownUtils != nil && backedTextInputView != nil) {
     attributedString = [markdownUtils parseMarkdown:attributedString withDefaultTextAttributes:backedTextInputView.defaultTextAttributes];
   }

--- a/apple/RCTTextInputComponentView+Markdown.mm
+++ b/apple/RCTTextInputComponentView+Markdown.mm
@@ -13,15 +13,10 @@
   return objc_getAssociatedObject(self, @selector(getMarkdownUtils));
 }
 
-- (RCTUITextView *)getBackedTextInputView {
-  RCTUITextView *backedTextInputView = [self valueForKey:@"_backedTextInputView"];
-  return backedTextInputView;
-}
-
 - (void)markdown__setAttributedString:(NSAttributedString *)attributedString
 {
   RCTMarkdownUtils *markdownUtils = [self getMarkdownUtils];
-  RCTUITextView *backedTextInputView = [self getBackedTextInputView];
+  RCTUITextView *backedTextInputView = [self valueForKey:@"_backedTextInputView"];
   if (markdownUtils != nil && backedTextInputView != nil) {
     attributedString = [markdownUtils parseMarkdown:attributedString withDefaultTextAttributes:backedTextInputView.defaultTextAttributes];
   }


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Details
This PR fixes the variable type of `_backedTextInputView` in case of multiline `MarkdownTextInput` which should be `RCTUITextView` instead of `RCTUITextField`.

### Related Issues
<!-- Please replace GH_LINK with the link to the GitHub issue this Pull Request is related to -->
GH_LINK

### Manual Tests
<!---
Most changes should have accompanying tests. Describe the tests you added or if no tests were added an explanation about why one was not needed.
--->

### Linked PRs
<!---
Please include links to any update PRs in repos that must change their package.json version.
--->