### PR TITLE
Pin GitHub Actions to immutable commit SHAs

### DIFF
--- a/.github/workflows/build-android.yml
+++ b/.github/workflows/build-android.yml
@@ -31,10 +31,12 @@ jobs:
       cancel-in-progress: true
     steps:
       - name: Check out Git repository
-        uses: actions/checkout@v4
+        # v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
 
       - name: Setup Java 17
-        uses: actions/setup-java@v4
+        # v4
+        uses: actions/setup-java@3a4f6e1af504cf6a31855fa899c6aa5355ba6c12
         with:
           distribution: 'zulu'
           java-version: 17

--- a/.github/workflows/build-ios.yml
+++ b/.github/workflows/build-ios.yml
@@ -31,10 +31,12 @@ jobs:
       cancel-in-progress: true
     steps:
       - name: Check out Git repository
-        uses: actions/checkout@v4
+        # v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
 
       - name: Restore node_modules from cache
-        uses: actions/cache@v4
+        # v4
+        uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684
         with:
           path: |
             node_modules
@@ -46,7 +48,8 @@ jobs:
         run: npm ci
 
       - name: Restore Pods from cache
-        uses: actions/cache@v4
+        # v4
+        uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684
         with:
           path: |
             example/ios/Pods
@@ -66,7 +69,8 @@ jobs:
         run: rm -rf .xcode.env.local
 
       - name: Restore build artifacts from cache
-        uses: actions/cache@v4
+        # v4
+        uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684
         with:
           path: ~/Library/Developer/Xcode/DerivedData
           key: build-ios-derived-data-${{ hashFiles('node_modules/react-native/package.json') }}

--- a/.github/workflows/build-web.yml
+++ b/.github/workflows/build-web.yml
@@ -25,7 +25,8 @@ jobs:
       cancel-in-progress: true
     steps:
       - name: Check out Git repository
-        uses: actions/checkout@v4
+        # v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
 
       - name: Install node_modules
         run: npm ci

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -17,10 +17,12 @@ jobs:
       cancel-in-progress: true
     steps:
       - name: Check out Git repository
-        uses: actions/checkout@v4
+        # v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
 
       - name: Use Node.js 18
-        uses: actions/setup-node@v4
+        # v4
+        uses: actions/setup-node@cdca7365b2dadb8aad0a33bc7601856ffabcc48e
         with:
           node-version: 18
 

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -18,7 +18,8 @@ jobs:
             ${{ runner.os }}-npm-
 
       - name: Setup Node
-        uses: actions/setup-node@v4
+        # v4
+        uses: actions/setup-node@cdca7365b2dadb8aad0a33bc7601856ffabcc48e
         with:
           node-version: '20.x'
 

--- a/.github/workflows/web-e2e-test.yml
+++ b/.github/workflows/web-e2e-test.yml
@@ -26,10 +26,12 @@ jobs:
       cancel-in-progress: true
     steps:
       - name: Check out Git repository
-        uses: actions/checkout@v4
+        # v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
 
       - name: Use Node.js 18
-        uses: actions/setup-node@v4
+        # v4
+        uses: actions/setup-node@cdca7365b2dadb8aad0a33bc7601856ffabcc48e
         with:
           node-version: 18
 


### PR DESCRIPTION
Coming from https://expensify.slack.com/archives/CC7NECV4L/p1743022578963949, this pull request updates all mutable action references to use immutable commit hashes instead. This is a security measure to protect from supply chain attacks.