### PR TITLE
Add 0.78 to compatibility table in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,6 +183,7 @@ Currently, `react-native-live-markdown` supports only [ExpensiMark](https://gith
 
 | react-native | @expensify/react-native-live-markdown |
 | :----------: | :-----------------------------------: |
+|     0.78     |               0.1.260+                |
 |     0.77     |               0.1.235+                |
 |     0.76     |               0.1.141+                |
 |     0.75     |               0.1.129+                |


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Details
This PR adds React Native 0.78 to the compatibility table in the README.

### Related Issues
<!-- Please replace GH_LINK with the link to the GitHub issue this Pull Request is related to -->
GH_LINK

### Manual Tests
<!---
Most changes should have accompanying tests. Describe the tests you added or if no tests were added an explanation about why one was not needed.
--->

### Linked PRs
<!---
Please include links to any update PRs in repos that must change their package.json version.
--->