### PR TITLE
Fix unrecognized selector `-[MarkdownBackedTextInputDelegate textInputDidPaste:withData:]` on iOS

### DIFF
--- a/apple/MarkdownBackedTextInputDelegate.mm
+++ b/apple/MarkdownBackedTextInputDelegate.mm
@@ -1,5 +1,7 @@
 #import "MarkdownBackedTextInputDelegate.h"
 
+#import <objc/message.h>
+
 @implementation MarkdownBackedTextInputDelegate {
   __weak RCTUITextView *_textView;
   id<RCTBackedTextInputDelegate> _originalTextInputDelegate;
@@ -87,6 +89,14 @@
 - (BOOL)textInputShouldSubmitOnReturn
 {
   return [_originalTextInputDelegate textInputShouldSubmitOnReturn];
+}
+
+// This method is added as a patch in the New Expensify app.
+// See https://github.com/Expensify/App/blob/fd4b9adc22144cb99db1a5634f8828a13fa8c374/patches/react-native%2B0.77.1%2B011%2BAdd-onPaste-to-TextInput.patch#L239
+- (void)textInputDidPaste:(NSString *)type withData:(NSString *)data
+{
+  void (*func)(id, SEL, NSString*, NSString*) = (void (*)(id, SEL, NSString*, NSString*))objc_msgSend;
+  func(_originalTextInputDelegate, @selector(textInputDidPaste:withData:), type, data);
 }
 
 @end


### PR DESCRIPTION
### Details
This PR fixes the following crash on iOS:

```
*** Terminating app due to uncaught exception 'NSInvalidArgumentException', reason: '-[MarkdownBackedTextInputDelegate textInputDidPaste:withData:]: unrecognized selector sent to instance 0x304dd8d80'
```

### Related Issues
<!-- Please replace GH_LINK with the link to the GitHub issue this Pull Request is related to -->
GH_LINK

### Manual Tests
<!---
Most changes should have accompanying tests. Describe the tests you added or if no tests were added an explanation about why one was not needed.
--->

### Linked PRs
<!---
Please include links to any update PRs in repos that must change their package.json version.
--->