### PR TITLE
Fix removing first new line when pasting text on Android mWeb

### DIFF
--- a/src/web/utils/inputUtils.ts
+++ b/src/web/utils/inputUtils.ts
@@ -65,8 +65,9 @@ function parseInnerHTMLToText(target: MarkdownTextInputElement, cursorPosition: 
     // If we are operating on the nodes that are children of the MarkdownTextInputElement, we need to add a newline after each
     const isTopComponent = node.parentElement?.contentEditable === 'true';
     if (isTopComponent) {
-      // Replaced text is beeing added as text node, so we need to not add the newline before and after it
-      if (node.nodeType === Node.TEXT_NODE) {
+      // When inputType is undefined, the first part of the replaced text is added as a text node.
+      // Because of it, we need to prevent adding new lines in this case
+      if (!inputType && node.nodeType === Node.TEXT_NODE) {
         shouldAddNewline = false;
       } else {
         const firstChild = node.firstChild as HTMLElement;


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Details
<!-- Explanation of the change or anything fishy that is going on -->
This PR fixes a problem with removing the first new line when pasting text using the Android keyboard. It changes the condition on when we want to cancel adding new lines. We should skip new lines only when the `inputType` is undefined. It happens when some custom events appear (like [here](https://github.com/software-mansion-labs/expensify-app-fork/blob/38e45de114be2f2ab9602b33e2320cd0142086bc/src/hooks/useHtmlPaste/index.ts#L24) in custom pasting logic in E/App)
### Related Issues
<!-- Please replace GH_LINK with the link to the GitHub issue this Pull Request is related to -->
https://github.com/Expensify/App/issues/60442

### Manual Tests
<!---
Most changes should have accompanying tests. Describe the tests you added, or if no tests were added, an explanation about why one was not needed.
--->
1. Open the mWeb example app
2. Write some text with new lines, for example:
```
123
456
789
```
3. Select it and cut it
4. Click the copied text that appears above the Android native keyboard
5. Verify if the pasted text is correct

### Linked PRs
<!---
Please include links to updated PRs in repos that must change their package.json version.
--->