### PR TITLE
Don't recreate the layout context on every measure

### DIFF
--- a/apple/MarkdownTextInputDecoratorShadowNode.mm
+++ b/apple/MarkdownTextInputDecoratorShadowNode.mm
@@ -15,6 +15,9 @@ namespace react {
 extern const char MarkdownTextInputDecoratorViewComponentName[] =
     "MarkdownTextInputDecoratorView";
 
+thread_local LayoutContext decoratorLayoutContext{.fontSizeMultiplier =
+                                                      RCTFontSizeMultiplier()};
+
 void MarkdownTextInputDecoratorShadowNode::initialize() {
   // Setting display: contents style results in ForceFlattenView trait being set
   // on the shadow node. This trait causes the node not to have a host view. By
@@ -93,6 +96,7 @@ Size MarkdownTextInputDecoratorShadowNode::measureContent(
 
 void MarkdownTextInputDecoratorShadowNode::layout(LayoutContext layoutContext) {
   YogaLayoutableShadowNode::layout(layoutContext);
+  decoratorLayoutContext = layoutContext;
 
   const auto &children = getChildren();
   react_native_assert(
@@ -250,10 +254,8 @@ YGSize MarkdownTextInputDecoratorShadowNode::yogaNodeMeasureCallbackConnector(
   const auto &decoratorYogaNode = YGNodeGetParent(const_cast<YGNodeRef>(yogaNode));
   const auto &decoratorShadowNode = shadowNodeFromContext(decoratorYogaNode);
 
-  LayoutContext context{};
-  context.fontSizeMultiplier = RCTFontSizeMultiplier();
-
-  const auto size = decoratorShadowNode.measureContent(context, {minimumSize, maximumSize});
+  const auto size = decoratorShadowNode.measureContent(
+      decoratorLayoutContext, {minimumSize, maximumSize});
 
   return YGSize{yogaFloatFromFloat(size.width),
                 yogaFloatFromFloat(size.height)};


### PR DESCRIPTION
### Details
In the current implementation, `layoutContext` is created for every measure of the markdown text input. To construct the context, we need the font size multiplier, which should be read from the UI thread (which we cannot really do by the time we need the result).

This PR updates the implementation to use a thread-local instance of the layout context, which is then updated inside `layout` method, which receives up-to-date info from React Native. A similar mechanism is used in the RN itself: https://github.com/facebook/react-native/blob/12b2b5610263cb145d1ade8eaf06d8a6e015b10e/packages/react-native/ReactCommon/react/renderer/components/view/YogaLayoutableShadowNode.cpp#L63. This way, the font size multiplier is read only once.

A potential downside to this approach is that when the multiplier changes, the layout context is updated after the measure, potentially leaving a single tree version where the input is measured with the wrong text scale. It's hard to confirm this, though, since React Native doesn't currently support responding to font scale changes correctly ([it will be handled in 0.80 behind a feature flag](https://github.com/facebook/react-native/pull/45978)).

### Related Issues
GH_LINK

### Manual Tests

### Linked PRs