### PR TITLE
Migrate `LiveMarkdownModule` to `TurboModuleWithJSIBindings`

### DIFF
--- a/android/src/main/cpp/LiveMarkdownModule.cpp
+++ b/android/src/main/cpp/LiveMarkdownModule.cpp
@@ -1,0 +1,25 @@
+#include "LiveMarkdownModule.h"
+#include "RuntimeDecorator.h"
+
+namespace expensify::livemarkdown {
+
+// static
+void LiveMarkdownModule::registerNatives() {
+  javaClassLocal()->registerNatives({
+      makeNativeMethod(
+          "getBindingsInstaller",
+          LiveMarkdownModule::getBindingsInstaller),
+  });
+}
+
+// static
+jni::local_ref<react::BindingsInstallerHolder::javaobject>
+LiveMarkdownModule::getBindingsInstaller(
+    jni::alias_ref<LiveMarkdownModule> /*jobj*/) {
+  return react::BindingsInstallerHolder::newObjectCxxArgs(
+      [](jsi::Runtime& runtime, const std::shared_ptr<react::CallInvoker>&) {
+        expensify::livemarkdown::injectJSIBindings(runtime);
+      });
+}
+
+} // namespace expensify::livemarkdown

--- a/android/src/main/cpp/LiveMarkdownModule.h
+++ b/android/src/main/cpp/LiveMarkdownModule.h
@@ -1,0 +1,24 @@
+#pragma once
+
+#include <ReactCommon/BindingsInstallerHolder.h>
+#include <fbjni/fbjni.h>
+
+using namespace facebook;
+
+namespace expensify::livemarkdown {
+
+class LiveMarkdownModule : public jni::JavaClass<LiveMarkdownModule> {
+ public:
+  static constexpr auto kJavaDescriptor =
+      "Lcom/expensify/livemarkdown/LiveMarkdownModule;";
+
+  LiveMarkdownModule() = default;
+
+  static void registerNatives();
+
+ private:
+  static jni::local_ref<react::BindingsInstallerHolder::javaobject>
+  getBindingsInstaller(jni::alias_ref<LiveMarkdownModule> jobj);
+};
+
+} // namespace expensify::livemarkdown

--- a/android/src/main/cpp/OnLoad.cpp
+++ b/android/src/main/cpp/OnLoad.cpp
@@ -1,14 +1,11 @@
 #include <fbjni/fbjni.h>
 
+#include "LiveMarkdownModule.h"
 #include "MarkdownParser.h"
-#include "RuntimeDecorator.h"
 
 JNIEXPORT jint JNICALL JNI_OnLoad(JavaVM *vm, void *reserved) {
-    return facebook::jni::initialize(
-            vm, [] { expensify::livemarkdown::MarkdownParser::registerNatives(); });
-}
-
-extern "C" JNIEXPORT void JNICALL Java_com_expensify_livemarkdown_LiveMarkdownModule_injectJSIBindings(JNIEnv *env, jobject thiz, jlong jsiRuntime) {
-  jsi::Runtime &rt = *reinterpret_cast<jsi::Runtime*>(jsiRuntime);
-  expensify::livemarkdown::injectJSIBindings(rt);
+    return facebook::jni::initialize(vm, [] {
+        expensify::livemarkdown::LiveMarkdownModule::registerNatives();
+        expensify::livemarkdown::MarkdownParser::registerNatives();
+    });
 }

--- a/android/src/main/java/com/expensify/livemarkdown/LiveMarkdownModule.java
+++ b/android/src/main/java/com/expensify/livemarkdown/LiveMarkdownModule.java
@@ -1,11 +1,14 @@
 package com.expensify.livemarkdown;
 
+import androidx.annotation.NonNull;
+
+import com.facebook.proguard.annotations.DoNotStrip;
 import com.facebook.react.bridge.ReactApplicationContext;
+import com.facebook.react.turbomodule.core.interfaces.BindingsInstallerHolder;
+import com.facebook.react.turbomodule.core.interfaces.TurboModuleWithJSIBindings;
 import com.facebook.soloader.SoLoader;
 
-import java.util.Objects;
-
-public class LiveMarkdownModule extends NativeLiveMarkdownModuleSpec {
+public class LiveMarkdownModule extends NativeLiveMarkdownModuleSpec implements TurboModuleWithJSIBindings {
   static {
     SoLoader.loadLibrary("livemarkdown");
   }
@@ -14,13 +17,8 @@ public class LiveMarkdownModule extends NativeLiveMarkdownModuleSpec {
     super(reactContext);
   }
 
+  @DoNotStrip
+  @NonNull
   @Override
-  public boolean install() {
-    long jsiRuntime = Objects.requireNonNull(getReactApplicationContext().getJavaScriptContextHolder(), "[react-native-live-markdown] JavaScriptContextHolder is null").get();
-    injectJSIBindings(jsiRuntime);
-
-    return true;
-  }
-
-  private native void injectJSIBindings(long jsiRuntime);
+  public native BindingsInstallerHolder getBindingsInstaller();
 }

--- a/apple/LiveMarkdownModule.h
+++ b/apple/LiveMarkdownModule.h
@@ -1,8 +1,9 @@
 #import <RNLiveMarkdownSpec/RNLiveMarkdownSpec.h>
 
 #import <React/RCTEventEmitter.h>
+#import <ReactCommon/RCTTurboModuleWithJSIBindings.h>
 
 // Without inheriting after RCTEventEmitter we don't get access to bridge
-@interface LiveMarkdownModule : RCTEventEmitter <NativeLiveMarkdownModuleSpec>
+@interface LiveMarkdownModule : RCTEventEmitter <NativeLiveMarkdownModuleSpec, RCTTurboModuleWithJSIBindings>
 
 @end

--- a/apple/LiveMarkdownModule.mm
+++ b/apple/LiveMarkdownModule.mm
@@ -11,12 +11,10 @@ using namespace expensify::livemarkdown;
 
 RCT_EXPORT_MODULE()
 
-RCT_EXPORT_BLOCKING_SYNCHRONOUS_METHOD(install)
+- (void)installJSIBindingsWithRuntime:(facebook::jsi::Runtime &)runtime
+                          callInvoker:(const std::shared_ptr<facebook::react::CallInvoker> &)callinvoker
 {
-  RCTCxxBridge *cxxBridge = (RCTCxxBridge *)self.bridge;
-  jsi::Runtime &rt = *(jsi::Runtime *)cxxBridge.runtime;
-  expensify::livemarkdown::injectJSIBindings(rt);
-  return @(1);
+  expensify::livemarkdown::injectJSIBindings(runtime);
 }
 
 - (std::shared_ptr<facebook::react::TurboModule>)getTurboModule:

--- a/src/MarkdownTextInput.tsx
+++ b/src/MarkdownTextInput.tsx
@@ -37,8 +37,8 @@ function initializeLiveMarkdownIfNeeded() {
   if (initialized) {
     return;
   }
-  if (NativeLiveMarkdownModule) {
-    NativeLiveMarkdownModule.install();
+  if (!NativeLiveMarkdownModule) {
+    throw new Error('[react-native-live-markdown] NativeLiveMarkdownModule is not available');
   }
   if (!global.jsi_setMarkdownRuntime) {
     throw new Error('[react-native-live-markdown] global.jsi_setMarkdownRuntime is not available');

--- a/src/NativeLiveMarkdownModule.ts
+++ b/src/NativeLiveMarkdownModule.ts
@@ -1,8 +1,7 @@
 import type {TurboModule} from 'react-native';
 import {TurboModuleRegistry} from 'react-native';
 
-interface Spec extends TurboModule {
-  install: () => boolean;
-}
+// eslint-disable-next-line @typescript-eslint/no-empty-interface
+interface Spec extends TurboModule {}
 
 export default TurboModuleRegistry.get<Spec>('LiveMarkdownModule');


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Details
This PR refactors `LiveMarkdownModule` so that it implements `RCTTurboModuleWithJSIBindings` and `TurboModuleWithJSIBindings` on iOS and Android, respectively. 

### Related Issues
<!-- Please replace GH_LINK with the link to the GitHub issue this Pull Request is related to -->
GH_LINK

### Manual Tests
<!---
Most changes should have accompanying tests. Describe the tests you added or if no tests were added an explanation about why one was not needed.
--->

### Linked PRs
<!---
Please include links to any update PRs in repos that must change their package.json version.
--->