### PR TITLE
Fix crash when invoking destructor from other threads than JS

### DIFF
--- a/android/src/main/new_arch/react/renderer/components/RNLiveMarkdownSpec/MarkdownTextInputDecoratorShadowNode.cpp
+++ b/android/src/main/new_arch/react/renderer/components/RNLiveMarkdownSpec/MarkdownTextInputDecoratorShadowNode.cpp
@@ -3,6 +3,7 @@
 #include <fbjni/fbjni.h>
 #include <react/fabric/JFabricUIManager.h>
 #include <react/jni/ReadableNativeMap.h>
+#include <react/jni/SafeReleaseJniRef.h>
 #include <react/renderer/components/view/conversions.h>
 #include <react/renderer/core/ComponentDescriptor.h>
 #include <yoga/Yoga.h>
@@ -45,9 +46,9 @@ void MarkdownTextInputDecoratorShadowNode::createCustomContextContainer() {
   const auto &fabricUIManager =
       this->getContextContainer()->at<JFabricUIManager::javaobject>("FabricUIManager");
 
-  const auto customFabricUIManager = jni::make_global(createMethod(
+  const auto customFabricUIManager = SafeReleaseJniRef(jni::make_global(createMethod(
       customFabricUIManagerClass, fabricUIManager,
-      decoratorPropsRM.get(), parserId));
+      decoratorPropsRM.get(), parserId)));
   const auto contextContainer =
       std::make_shared<ContextContainer const>();
   contextContainer->insert("FabricUIManager", customFabricUIManager);


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Details
After migration to implementation based on `display: contents`, decorator shadow nodes started keeping some JNI references. In some cases, those nodes can be deallocated on the JS garbage collection thread, where the JNI context is missing, resulting in a crash. This PR fixes that by guarding the reference behind a `SafeReleaseJniRef` struct which makes sure that the thread has JNI context before invoking desctructor.

### Related Issues
<!-- Please replace GH_LINK with the link to the GitHub issue this Pull Request is related to -->
GH_LINK

### Manual Tests
<!---
Most changes should have accompanying tests. Describe the tests you added or if no tests were added an explanation about why one was not needed.
--->

### Linked PRs
<!---
Please include links to any update PRs in repos that must change their package.json version.
--->