### PR TITLE
fix: update currentlyFocusedNode on focus

### DIFF
--- a/src/MarkdownTextInput.web.tsx
+++ b/src/MarkdownTextInput.web.tsx
@@ -601,7 +601,7 @@ const MarkdownTextInput = React.forwardRef<MarkdownTextInput, MarkdownTextInputP
     const handleBlur: FocusEventHandler<HTMLDivElement> = useCallback(
       (event) => {
         const e = event as unknown as NativeSyntheticEvent<TextInputFocusEventData>;
-        RNTextInput.State.blurTextInput?.(e.target)
+        RNTextInput.State.blurTextInput?.(e.target);
         removeSelection();
         currentlyFocusedField.current = null;
         if (onBlur) {

--- a/src/MarkdownTextInput.web.tsx
+++ b/src/MarkdownTextInput.web.tsx
@@ -13,7 +13,7 @@ import type {
 } from 'react-native';
 import React, {useEffect, useRef, useCallback, useMemo, useLayoutEffect} from 'react';
 import type {CSSProperties, MutableRefObject, ReactEventHandler, FocusEventHandler, MouseEvent, KeyboardEvent, SyntheticEvent, ClipboardEventHandler, TouchEvent} from 'react';
-import {StyleSheet} from 'react-native';
+import {StyleSheet, TextInput as RNTextInput } from 'react-native';
 import {updateInputStructure} from './web/utils/parserUtils';
 import InputHistory from './web/InputHistory';
 import type {TreeNode} from './web/utils/treeUtils';
@@ -553,6 +553,7 @@ const MarkdownTextInput = React.forwardRef<MarkdownTextInput, MarkdownTextInputP
       (event) => {
         hasJustBeenFocused.current = true;
         const e = event as unknown as NativeSyntheticEvent<TextInputFocusEventData>;
+        RNTextInput.State.focusTextInput?.(e.target);
         const hostNode = e.target as unknown as HTMLDivElement;
         currentlyFocusedField.current = hostNode;
         setEventProps(e);
@@ -600,6 +601,7 @@ const MarkdownTextInput = React.forwardRef<MarkdownTextInput, MarkdownTextInputP
     const handleBlur: FocusEventHandler<HTMLDivElement> = useCallback(
       (event) => {
         const e = event as unknown as NativeSyntheticEvent<TextInputFocusEventData>;
+        RNTextInput.State.blurTextInput?.(e.target)
         removeSelection();
         currentlyFocusedField.current = null;
         if (onBlur) {

--- a/src/MarkdownTextInput.web.tsx
+++ b/src/MarkdownTextInput.web.tsx
@@ -13,7 +13,7 @@ import type {
 } from 'react-native';
 import React, {useEffect, useRef, useCallback, useMemo, useLayoutEffect} from 'react';
 import type {CSSProperties, MutableRefObject, ReactEventHandler, FocusEventHandler, MouseEvent, KeyboardEvent, SyntheticEvent, ClipboardEventHandler, TouchEvent} from 'react';
-import {StyleSheet, TextInput as RNTextInput } from 'react-native';
+import {StyleSheet, TextInput as RNTextInput} from 'react-native';
 import {updateInputStructure} from './web/utils/parserUtils';
 import InputHistory from './web/InputHistory';
 import type {TreeNode} from './web/utils/treeUtils';


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Details
<!-- Explanation of the change or anything fishy that is going on -->
- This PR implements the solution described in [this proposal](https://github.com/Expensify/App/issues/61521#issuecomment-2866029202), combined with [this suggestion](https://github.com/Expensify/App/issues/61521#issuecomment-2878112758).
- It attempts to update the `_currentlyFocusedNode` when the markdown text input receives focus.
### Related Issues
<!-- Please replace GH_LINK with the link to the GitHub issue this Pull Request is related to -->
https://github.com/Expensify/App/issues/61521

### Manual Tests
<!---
Most changes should have accompanying tests. Describe the tests you added or if no tests were added an explanation about why one was not needed.
--->
1. Go to ND
2. Login account with more chats
3. Tap search
4. Scroll the page up and down
5. Verify: In search, scrolling the page must close the keypad.
### Linked PRs
<!---
Please include links to any update PRs in repos that must change their package.json version.
--->


### Result:


https://github.com/user-attachments/assets/4ed57083-5253-4253-80b3-943ed9737a6d

