### PR TITLE
Revert "Add font support for emojis"

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,12 +66,6 @@ const FONT_FAMILY_MONOSPACE = Platform.select({
   default: 'monospace',
 });
 
-const FONT_FAMILY_EMOJI = Platform.select({
-  ios: 'Apple Color Emoji',
-  android: 'Noto Color Emoji',
-  default: 'Apple Color Emoji, Segoe UI Emoji, Noto Color Emoji',
-});
-
 const markdownStyle: MarkdownStyle = {
   syntax: {
     color: 'gray',
@@ -84,7 +78,6 @@ const markdownStyle: MarkdownStyle = {
   },
   emoji: {
     fontSize: 20,
-    fontFamily: FONT_FAMILY_EMOJI,
   },
   blockquote: {
     borderColor: 'gray',

--- a/android/src/main/java/com/expensify/livemarkdown/MarkdownFormatter.java
+++ b/android/src/main/java/com/expensify/livemarkdown/MarkdownFormatter.java
@@ -70,8 +70,7 @@ public class MarkdownFormatter {
         setSpan(ssb, new MarkdownStrikethroughSpan(), start, end);
         break;
       case "emoji":
-        setSpan(ssb, new MarkdownFontFamilySpan(markdownStyle.getEmojiFontFamily(), mAssetManager), start, end);
-        setSpan(ssb, new MarkdownFontSizeSpan(markdownStyle.getEmojiFontSize()), start, end);
+        setSpan(ssb, new MarkdownEmojiSpan(markdownStyle.getEmojiFontSize()), start, end);
         break;
       case "mention-here":
         setSpan(ssb, new MarkdownForegroundColorSpan(markdownStyle.getMentionHereColor()), start, end);

--- a/android/src/main/java/com/expensify/livemarkdown/MarkdownStyle.java
+++ b/android/src/main/java/com/expensify/livemarkdown/MarkdownStyle.java
@@ -21,9 +21,6 @@ public class MarkdownStyle {
 
   private final float mH1FontSize;
 
-  @NonNull
-  private final String mEmojiFontFamily;
-
   private final float mEmojiFontSize;
 
   @ColorInt
@@ -80,7 +77,6 @@ public class MarkdownStyle {
     mLinkColor = parseColor(map, "link", "color", context);
     mH1FontSize = parseFloat(map, "h1", "fontSize");
     mEmojiFontSize = parseFloat(map, "emoji", "fontSize");
-    mEmojiFontFamily = parseString(map, "emoji", "fontFamily");
     mBlockquoteBorderColor = parseColor(map, "blockquote", "borderColor", context);
     mBlockquoteBorderWidth = parseFloat(map, "blockquote", "borderWidth");
     mBlockquoteMarginLeft = parseFloat(map, "blockquote", "marginLeft");
@@ -144,10 +140,6 @@ public class MarkdownStyle {
 
   public float getEmojiFontSize() {
     return mEmojiFontSize;
-  }
-
-  public String getEmojiFontFamily() {
-    return mEmojiFontFamily;
   }
 
   @ColorInt

--- a/android/src/main/java/com/expensify/livemarkdown/spans/MarkdownEmojiSpan.java
+++ b/android/src/main/java/com/expensify/livemarkdown/spans/MarkdownEmojiSpan.java
@@ -1,0 +1,11 @@
+package com.expensify.livemarkdown.spans;
+
+import android.text.style.AbsoluteSizeSpan;
+
+import com.facebook.react.uimanager.PixelUtil;
+
+public class MarkdownEmojiSpan extends AbsoluteSizeSpan implements MarkdownSpan {
+  public MarkdownEmojiSpan(float fontSize) {
+    super((int) PixelUtil.toPixelFromDIP(fontSize), false);
+  }
+}

--- a/apple/MarkdownFormatter.mm
+++ b/apple/MarkdownFormatter.mm
@@ -72,7 +72,7 @@
                                           variant:nil
                                   scaleMultiplier:0];
     } else if (type == "emoji") {
-      font = [RCTFont updateFont:font withFamily:markdownStyle.emojiFontFamily
+      font = [RCTFont updateFont:font withFamily:nil
                                             size:[NSNumber numberWithFloat:markdownStyle.emojiFontSize]
                                           weight:nil
                                             style:nil

--- a/apple/RCTMarkdownStyle.h
+++ b/apple/RCTMarkdownStyle.h
@@ -10,7 +10,6 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic) UIColor *linkColor;
 @property (nonatomic) CGFloat h1FontSize;
 @property (nonatomic) CGFloat emojiFontSize;
-@property (nonatomic) NSString *emojiFontFamily;
 @property (nonatomic) UIColor *blockquoteBorderColor;
 @property (nonatomic) CGFloat blockquoteBorderWidth;
 @property (nonatomic) CGFloat blockquoteMarginLeft;

--- a/apple/RCTMarkdownStyle.mm
+++ b/apple/RCTMarkdownStyle.mm
@@ -14,7 +14,6 @@
     _h1FontSize = style.h1.fontSize;
 
     _emojiFontSize = style.emoji.fontSize;
-    _emojiFontFamily = RCTNSStringFromString(style.emoji.fontFamily);
 
     _blockquoteBorderColor = RCTUIColorFromSharedColor(style.blockquote.borderColor);
     _blockquoteBorderWidth = style.blockquote.borderWidth;

--- a/src/MarkdownTextInputDecoratorViewNativeComponent.ts
+++ b/src/MarkdownTextInputDecoratorViewNativeComponent.ts
@@ -9,7 +9,6 @@ interface MarkdownStyle {
   };
   emoji: {
     fontSize: Float;
-    fontFamily: string;
   };
   link: {
     color: ColorValue;

--- a/src/styleUtils.ts
+++ b/src/styleUtils.ts
@@ -10,12 +10,6 @@ const FONT_FAMILY_MONOSPACE = Platform.select({
   default: 'monospace',
 });
 
-const FONT_FAMILY_EMOJI = Platform.select({
-  ios: 'Apple Color Emoji',
-  android: 'Noto Color Emoji',
-  default: 'Apple Color Emoji, Segoe UI Emoji, Noto Color Emoji',
-});
-
 function makeDefaultMarkdownStyle(): MarkdownStyle {
   return {
     syntax: {
@@ -29,7 +23,6 @@ function makeDefaultMarkdownStyle(): MarkdownStyle {
     },
     emoji: {
       fontSize: 20,
-      fontFamily: FONT_FAMILY_EMOJI,
     },
     blockquote: {
       borderColor: 'gray',


### PR DESCRIPTION
Reverts Expensify/react-native-live-markdown#661

This PR led to [deploy-blocker](https://github.com/Expensify/App/issues/62410) in the E/App repo

After reverting it, the emoji isn't cut off


https://github.com/user-attachments/assets/5057e6c4-6bfd-49de-8fe6-27176585f3c2

