### PR TITLE
Prevent emoji being formatted

### DIFF
--- a/src/__tests__/parseExpensiMark.test.ts
+++ b/src/__tests__/parseExpensiMark.test.ts
@@ -70,6 +70,15 @@ test('emoji', () => {
   expect('Hello, 😎').toBeParsedAs([{type: 'emoji', start: 7, length: 2}]);
 });
 
+test('emoji and italic', () => {
+  expect('_😎_').toBeParsedAs([
+    {type: 'syntax', start: 0, length: 1},
+    {type: 'italic', start: 1, length: 2},
+    {type: 'emoji', start: 1, length: 2},
+    {type: 'syntax', start: 3, length: 1},
+  ]);
+});
+
 describe('mention-here', () => {
   test('normal', () => {
     expect('@here Hello!').toBeParsedAs([{type: 'mention-here', start: 0, length: 5}]);

--- a/src/rangeUtils.ts
+++ b/src/rangeUtils.ts
@@ -6,11 +6,13 @@ import type {MarkdownRange, MarkdownType} from './commonTypes';
 function getTagPriority(tag: string) {
   switch (tag) {
     case 'blockquote':
-      return 2;
+      return 3;
     case 'h1':
-      return 1;
-    default:
+      return 2;
+    case 'emoji':
       return 0;
+    default:
+      return 1;
   }
 }
 

--- a/src/rangeUtils.ts
+++ b/src/rangeUtils.ts
@@ -6,13 +6,13 @@ import type {MarkdownRange, MarkdownType} from './commonTypes';
 function getTagPriority(tag: string) {
   switch (tag) {
     case 'blockquote':
-      return 3;
-    case 'h1':
       return 2;
-    case 'emoji':
-      return 0;
-    default:
+    case 'h1':
       return 1;
+    case 'emoji':
+      return -1;
+    default:
+      return 0;
   }
 }
 


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Details
<!-- Explanation of the change or anything fishy that is going on -->
When emoji is wrapped with a markdown, the emoji is being formatted and we don't want that.

### Related Issues
<!-- Please replace GH_LINK with the link to the GitHub issue this Pull Request is related to -->
$ https://github.com/Expensify/App/issues/62029

### Manual Tests
<!---
Most changes should have accompanying tests. Describe the tests you added or if no tests were added an explanation about why one was not needed.
--->
1. Run the web example
2. Type `_😄_`
3. Verify the emoji is not formatted
 
<img width="424" alt="Screenshot 2025-05-28 at 18 35 59" src="https://github.com/user-attachments/assets/73302cbc-1a9b-4d0b-ab59-c2d702862a60" />

### Linked PRs
<!---
Please include links to any update PRs in repos that must change their package.json version.
--->