### PR TITLE
Fix cursor position problems on mWeb

### DIFF
--- a/src/MarkdownTextInput.web.tsx
+++ b/src/MarkdownTextInput.web.tsx
@@ -314,19 +314,10 @@ const MarkdownTextInput = React.forwardRef<MarkdownTextInput, MarkdownTextInputP
 
     const handleOnSelect = useCallback(
       (e: React.SyntheticEvent<HTMLDivElement>) => {
-        if (!divRef.current) {
-          return;
-        }
-        // contentSelection has already been updated in the onKeyDown event (handleOnChangeText).
-        // We need to force a reset of the already known selection since keyup can break it
-        if (contentSelection.current && e.nativeEvent.type === 'keyup') {
-          setCursorPosition(divRef.current, contentSelection.current?.start, contentSelection.current?.end, false);
-        } else {
-          updateSelection(e);
-        }
+        updateSelection(e);
 
         // If the input has just been focused, we need to scroll the cursor into view
-        if (contentSelection.current && hasJustBeenFocused.current) {
+        if (divRef.current && contentSelection.current && hasJustBeenFocused.current) {
           setCursorPosition(divRef.current, contentSelection.current?.start, contentSelection.current?.end, true);
           hasJustBeenFocused.current = false;
         }

--- a/src/MarkdownTextInput.web.tsx
+++ b/src/MarkdownTextInput.web.tsx
@@ -314,10 +314,19 @@ const MarkdownTextInput = React.forwardRef<MarkdownTextInput, MarkdownTextInputP
 
     const handleOnSelect = useCallback(
       (e: React.SyntheticEvent<HTMLDivElement>) => {
-        updateSelection(e);
+        if (!divRef.current) {
+          return;
+        }
+        // contentSelection has already been updated in the onKeyDown event (handleOnChangeText).
+        // We need to force a reset of the already known selection since keyup can break it
+        if (contentSelection.current && e.nativeEvent.type === 'keyup') {
+          setCursorPosition(divRef.current, contentSelection.current?.start, contentSelection.current?.end, false);
+        } else {
+          updateSelection(e);
+        }
 
         // If the input has just been focused, we need to scroll the cursor into view
-        if (divRef.current && contentSelection.current && hasJustBeenFocused.current) {
+        if (contentSelection.current && hasJustBeenFocused.current) {
           setCursorPosition(divRef.current, contentSelection.current?.start, contentSelection.current?.end, true);
           hasJustBeenFocused.current = false;
         }

--- a/src/__tests__/normalizeLines.test.tsx
+++ b/src/__tests__/normalizeLines.test.tsx
@@ -1,0 +1,165 @@
+import type {MarkdownRange} from '../commonTypes';
+import {normalizeLines} from '../web/utils/parserUtils';
+import type {Paragraph} from '../web/utils/parserUtils';
+
+describe('normalizeLines', () => {
+  it('should handle single line markdown with no multi-line ranges', () => {
+    const lines: Paragraph[] = [
+      {
+        text: '*Hello, world!*',
+        start: 0,
+        length: 13,
+        markdownRanges: [],
+      },
+    ];
+
+    const ranges: MarkdownRange[] = [
+      {
+        type: 'syntax',
+        start: 0,
+        length: 1,
+      },
+      {
+        type: 'bold',
+        start: 1,
+        length: 11,
+      },
+      {
+        type: 'syntax',
+        start: 12,
+        length: 1,
+      },
+    ];
+
+    const result = normalizeLines(lines, ranges);
+    const paragraph = result[0] as Paragraph;
+    expect(paragraph.markdownRanges).toEqual([
+      {length: 1, start: 0, type: 'syntax'},
+      {length: 11, start: 1, type: 'bold'},
+      {length: 1, start: 12, type: 'syntax'},
+    ]);
+    expect(paragraph.text).toEqual('*Hello, world!*');
+  });
+
+  it('should handle multiline line markdown with no multi-line ranges', () => {
+    const lines: Paragraph[] = [
+      {
+        text: '*Hello',
+        start: 0,
+        length: 6,
+        markdownRanges: [],
+      },
+      {
+        text: 'world!*',
+        start: 7,
+        length: 7,
+        markdownRanges: [],
+      },
+    ];
+
+    const ranges: MarkdownRange[] = [
+      {
+        type: 'syntax',
+        start: 0,
+        length: 1,
+      },
+      {
+        type: 'bold',
+        start: 0,
+        length: 13,
+      },
+      {
+        type: 'syntax',
+        start: 13,
+        length: 1,
+      },
+    ];
+
+    const result = normalizeLines(lines, ranges);
+    expect(result.length).toBe(2);
+    const firstParagraph = result[0] as Paragraph;
+    const secondParagraph = result[1] as Paragraph;
+    expect(firstParagraph.text).toEqual('*Hello');
+    expect(secondParagraph.text).toEqual('world!*');
+    expect(firstParagraph.markdownRanges).toContainEqual({type: 'bold', start: 0, length: 6});
+    expect(secondParagraph.markdownRanges).toContainEqual({type: 'bold', start: 7, length: 6});
+  });
+
+  it('should merge lines when handling multi-line markdown ranges', () => {
+    const lines: Paragraph[] = [
+      {
+        text: 'Here is some code:',
+        start: 0,
+        length: 18,
+        markdownRanges: [],
+      },
+      {
+        text: '```',
+        start: 19,
+        length: 3,
+        markdownRanges: [],
+      },
+      {
+        text: "const text = 'Hello, World!';",
+        start: 23,
+        length: 29,
+        markdownRanges: [],
+      },
+      {
+        text: 'console.log(text);',
+        start: 53,
+        length: 18,
+        markdownRanges: [],
+      },
+      {
+        text: '```',
+        start: 72,
+        length: 3,
+        markdownRanges: [],
+      },
+    ];
+
+    const ranges: MarkdownRange[] = [
+      {
+        type: 'syntax',
+        start: 19,
+        length: 3,
+      },
+      {
+        type: 'pre',
+        start: 22,
+        length: 50, // This range spans across multiple lines
+      },
+      {
+        type: 'syntax',
+        start: 72,
+        length: 3,
+      },
+    ];
+
+    const result = normalizeLines(lines, ranges);
+
+    expect(result.length).toBe(2);
+    const paragraph = result[1] as Paragraph;
+    expect(paragraph.text).toEqual("```\nconst text = 'Hello, World!';\nconsole.log(text);\n```");
+    expect(paragraph.markdownRanges.length).toEqual(3);
+    expect((paragraph.markdownRanges[1] as MarkdownRange).type).toEqual('pre');
+  });
+
+  it('should correctly handle multiple adjacent ranges', () => {
+    const lines: Paragraph[] = [
+      {
+        text: 'Link: www.example.com',
+        start: 0,
+        length: 21,
+        markdownRanges: [],
+      },
+    ];
+
+    const ranges: MarkdownRange[] = [{type: 'link', start: 6, length: 15}];
+
+    const result = normalizeLines(lines, ranges);
+    const paragraph = result[0] as Paragraph;
+    expect(paragraph.markdownRanges).toContainEqual({type: 'link', start: 6, length: 15});
+  });
+});

--- a/src/web/utils/blockUtils.ts
+++ b/src/web/utils/blockUtils.ts
@@ -96,9 +96,14 @@ function addStyleToBlock(targetElement: HTMLElement, type: NodeType, markdownSty
 
 const BLOCK_MARKDOWN_TYPES = ['inline-image'];
 const FULL_LINE_MARKDOWN_TYPES = ['blockquote'];
+const MULTILINE_MARKDOWN_TYPES = ['pre'];
 
 function isBlockMarkdownType(type: NodeType) {
   return BLOCK_MARKDOWN_TYPES.includes(type);
+}
+
+function isMultilineMarkdownType(type: NodeType) {
+  return MULTILINE_MARKDOWN_TYPES.includes(type);
 }
 
 function getFirstBlockMarkdownRange(ranges: MarkdownRange[]) {
@@ -125,4 +130,4 @@ function extendBlockStructure(
   return targetNode;
 }
 
-export {addStyleToBlock, extendBlockStructure, isBlockMarkdownType, getFirstBlockMarkdownRange};
+export {addStyleToBlock, extendBlockStructure, isBlockMarkdownType, isMultilineMarkdownType, getFirstBlockMarkdownRange};

--- a/src/web/utils/parserUtils.ts
+++ b/src/web/utils/parserUtils.ts
@@ -31,8 +31,9 @@ function splitTextIntoLines(text: string): Paragraph[] {
   return lines;
 }
 
-/** For singleline markdown types, the function splits markdown ranges that spread beyond the line length into separate lines.
- * For multiline markdown types (like `pre`), it merges them into one line.
+/**
+ * For singleline markdown types, the function splits markdown ranges that spread beyond the line length into separate lines.
+ * For multiline markdown types (like `pre`), it merges them and corresponsing text into one line.
  */
 function normalizeLines(lines: Paragraph[], ranges: MarkdownRange[]) {
   let mergedLines = [...lines];

--- a/src/web/utils/parserUtils.ts
+++ b/src/web/utils/parserUtils.ts
@@ -364,4 +364,5 @@ function updateInputStructure(
   return {text, cursorPosition: cursorPosition || 0};
 }
 
-export {updateInputStructure, parseRangesToHTMLNodes};
+export {updateInputStructure, parseRangesToHTMLNodes, normalizeLines};
+export type {Paragraph};


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Details
<!-- Explanation of the change or anything fishy that is going on -->
This PR fixes issues with invalid cursor position on Android mWeb in cases when multiline markdown syntax is being removed. The problem lay in the current Live Markdown Input structure, where after splitting text into lines, we were merging all lines that contained ranges that go beyond the line length into one line.  Now, if the markdown type isn't marked as a multiline type (the one that can have `<br>` tags in it), we are corresponding ranges into separate lines.


https://github.com/user-attachments/assets/d56b59d1-824b-4801-9b34-f3e0c6050a70


### Related Issues
<!-- Please replace GH_LINK with the link to the GitHub issue this Pull Request is related to -->
https://github.com/Expensify/App/issues/57024

### Manual Tests
<!---
Most changes should have accompanying tests. Describe the tests you added, or if no tests were added, an explanation about why one was not needed.
--->

### Linked PRs
<!---
Please include links to any updated PRs in repos that must change their package.json version.
--->