### PR TITLE
Android: Enable 16KB memory page size support

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -163,10 +163,6 @@ android {
       "**/libreact_render*.so",
       "**/librrc_root.so",
     ]
-
-    jniLibs {
-      useLegacyPackaging = true
-    }
   }
 }
 

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -162,6 +162,10 @@ android {
       "**/libreact_render*.so",
       "**/librrc_root.so",
     ]
+
+    jniLibs {
+      useLegacyPackaging = true
+    }
   }
 }
 

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -93,7 +93,8 @@ android {
       cmake {
         arguments "-DANDROID_STL=c++_shared",
           "-DANDROID_TOOLCHAIN=clang",
-          "-DREACT_NATIVE_MINOR_VERSION=${REACT_NATIVE_MINOR_VERSION}"
+          "-DREACT_NATIVE_MINOR_VERSION=${REACT_NATIVE_MINOR_VERSION}",
+          "-DANDROID_SUPPORT_FLEXIBLE_PAGE_SIZES=ON"
         abiFilters (*reactNativeArchitectures())
       }
     }


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

@roryabraham 

### Details
<!-- Explanation of the change or anything fishy that is going on -->

Adds support support for 16KB memory page sizes on Android.


### Related Issues
<!-- Please replace GH_LINK with the link to the GitHub issue this Pull Request is related to -->

https://github.com/Expensify/App/issues/63871

### Manual Tests
<!---
Most changes should have accompanying tests. Describe the tests you added or if no tests were added an explanation about why one was not needed.
--->

Make sure the app builds.

### Linked PRs
<!---
Please include links to any update PRs in repos that must change their package.json version.
--->

https://github.com/Expensify/App/pull/64640