### PR TITLE
Clone the child node when the decorator is cloned

### DIFF
--- a/android/src/main/new_arch/react/renderer/components/RNLiveMarkdownSpec/MarkdownTextInputDecoratorShadowNode.cpp
+++ b/android/src/main/new_arch/react/renderer/components/RNLiveMarkdownSpec/MarkdownTextInputDecoratorShadowNode.cpp
@@ -20,6 +20,18 @@ void MarkdownTextInputDecoratorShadowNode::initialize() {
   // removing the trait, it's possible to force RN to create a host view, layout
   // of which can then be customized.
   ShadowNode::traits_.unset(ShadowNodeTraits::ForceFlattenView);
+
+  // When the decorator is cloned and has a child node, the child node should be
+  // cloned as well to ensure it is mutable.
+  const auto &children = getChildren();
+  if (!children.empty()) {
+    react_native_assert(
+        children.size() == 1 &&
+        "MarkdownTextInputDecoratorView received more than one child");
+    
+    const auto clonedChild = children[0]->clone({});
+    replaceChild(*children[0], clonedChild);
+  }
 }
 
 void MarkdownTextInputDecoratorShadowNode::createCustomContextContainer() {


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Details
While investigating https://github.com/Expensify/App/issues/65268 I noticed that the node with `display: contents` set can be cloned **without** cloning its children. Currently, the decorator assumes that when it's mutable, its child is mutable as well, which is clearly wrong in some cases.

This PR adds a step cloning the child node when the decorator is cloned, which makes the above assumption correct.

Note that this change **does not** fix the linked issue.

### Related Issues
<!-- Please replace GH_LINK with the link to the GitHub issue this Pull Request is related to -->
GH_LINK

### Manual Tests
<!---
Most changes should have accompanying tests. Describe the tests you added or if no tests were added an explanation about why one was not needed.
--->

### Linked PRs
<!---
Please include links to any update PRs in repos that must change their package.json version.
--->