### PR TITLE
Mention html-entities exact version requirement in README and error message

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,12 +15,12 @@
 First, install the library from npm with the package manager of your choice:
 
 ```sh
-yarn add @expensify/react-native-live-markdown react-native-reanimated expensify-common
-npm install @expensify/react-native-live-markdown react-native-reanimated expensify-common --save
-npx expo install @expensify/react-native-live-markdown react-native-reanimated expensify-common
+yarn add @expensify/react-native-live-markdown react-native-reanimated expensify-common html-entities@2.5.3
+npm install @expensify/react-native-live-markdown react-native-reanimated expensify-common html-entities@2.5.3 --save
+npx expo install @expensify/react-native-live-markdown react-native-reanimated expensify-common html-entities@2.5.3
 ```
 
-React Native Live Markdown requires [react-native-reanimated](https://github.com/software-mansion/react-native-reanimated) 3.17.0 or newer and [expensify-common](https://github.com/Expensify/expensify-common) 2.0.115 or newer.
+React Native Live Markdown requires [react-native-reanimated](https://github.com/software-mansion/react-native-reanimated) 3.17.0 or newer as well as [expensify-common](https://github.com/Expensify/expensify-common) 2.0.115 and [html-entities](https://github.com/mdevils/html-entities) 2.5.3 exactly if using the default built-in ExpensiMark parser.
 
 Then, install the iOS dependencies with CocoaPods:
 

--- a/src/parseExpensiMark.ts
+++ b/src/parseExpensiMark.ts
@@ -19,7 +19,7 @@ function isJest() {
 // eslint-disable-next-line no-underscore-dangle
 if (__DEV__ && !isWeb() && !isJest() && (decode as WorkletFunction).__workletHash === undefined) {
   throw new Error(
-    "[react-native-live-markdown] `parseExpensiMark` requires `html-entities` package to be workletized. Please add `'worklet';` directive at the top of `node_modules/html-entities/lib/index.js` using patch-package.",
+    "[react-native-live-markdown] `parseExpensiMark` requires `html-entities` package to be workletized. Please add `'worklet';` directive at the top of `node_modules/html-entities/lib/index.js` using patch-package. Make sure you've installed `html-entities` version 2.5.3 exactly as otherwise there is no `lib/` directory.",
   );
 }
 


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Details
This PR adds information about the exact required version of `html-entities` in Installation section in the README as well as the error message that appears `decode` function from `html-entities` is not workletized.

### Related Issues
<!-- Please replace GH_LINK with the link to the GitHub issue this Pull Request is related to -->
GH_LINK

### Manual Tests
<!---
Most changes should have accompanying tests. Describe the tests you added or if no tests were added an explanation about why one was not needed.
--->

### Linked PRs
<!---
Please include links to any update PRs in repos that must change their package.json version.
--->