### PR TITLE
Clone the child node only when decorator is fully initialized

### DIFF
--- a/android/src/main/new_arch/react/renderer/components/RNLiveMarkdownSpec/MarkdownTextInputDecoratorShadowNode.cpp
+++ b/android/src/main/new_arch/react/renderer/components/RNLiveMarkdownSpec/MarkdownTextInputDecoratorShadowNode.cpp
@@ -14,13 +14,49 @@ namespace react {
 extern const char MarkdownTextInputDecoratorViewComponentName[] =
     "MarkdownTextInputDecoratorView";
 
+MarkdownTextInputDecoratorShadowNode::MarkdownTextInputDecoratorShadowNode(
+    ShadowNodeFragment const &fragment,
+    ShadowNodeFamily::Shared const &family,
+    ShadowNodeTraits traits)
+    : ConcreteViewShadowNode(fragment, family, traits) {
+  initialize();
+  createCustomContextContainer();
+  makeChildNodeMutable();
+
+  if (fragment.children) {
+    overwriteTextLayoutManager();
+  }
+}
+
+MarkdownTextInputDecoratorShadowNode::MarkdownTextInputDecoratorShadowNode(
+    ShadowNode const &sourceShadowNode,
+    ShadowNodeFragment const &fragment)
+    : ConcreteViewShadowNode(sourceShadowNode, fragment) {
+  initialize();
+
+  const auto &sourceDecorator = static_cast<const MarkdownTextInputDecoratorShadowNode &>(sourceShadowNode);
+
+  customContextContainer_ = sourceDecorator.customContextContainer_;
+  previousMarkdownStyle_ = sourceDecorator.previousMarkdownStyle_;
+  previousParserId_ = sourceDecorator.previousParserId_;
+
+  updateCustomContextContainerIfNeeded();
+  makeChildNodeMutable();
+
+  if (fragment.children) {
+    overwriteTextLayoutManager();
+  }
+}
+
 void MarkdownTextInputDecoratorShadowNode::initialize() {
   // Setting display: contents style results in ForceFlattenView trait being set
   // on the shadow node. This trait causes the node not to have a host view. By
   // removing the trait, it's possible to force RN to create a host view, layout
   // of which can then be customized.
   ShadowNode::traits_.unset(ShadowNodeTraits::ForceFlattenView);
+}
 
+void MarkdownTextInputDecoratorShadowNode::makeChildNodeMutable() {
   // When the decorator is cloned and has a child node, the child node should be
   // cloned as well to ensure it is mutable.
   const auto &children = getChildren();
@@ -28,7 +64,7 @@ void MarkdownTextInputDecoratorShadowNode::initialize() {
     react_native_assert(
         children.size() == 1 &&
         "MarkdownTextInputDecoratorView received more than one child");
-    
+
     const auto clonedChild = children[0]->clone({});
     replaceChild(*children[0], clonedChild);
   }

--- a/android/src/main/new_arch/react/renderer/components/RNLiveMarkdownSpec/MarkdownTextInputDecoratorShadowNode.h
+++ b/android/src/main/new_arch/react/renderer/components/RNLiveMarkdownSpec/MarkdownTextInputDecoratorShadowNode.h
@@ -21,33 +21,10 @@ class JSI_EXPORT MarkdownTextInputDecoratorShadowNode final
 public:
   MarkdownTextInputDecoratorShadowNode(ShadowNodeFragment const &fragment,
                                        ShadowNodeFamily::Shared const &family,
-                                       ShadowNodeTraits traits)
-      : ConcreteViewShadowNode(fragment, family, traits) {
-    initialize();
-    createCustomContextContainer();
-
-    if (fragment.children) {
-      overwriteTextLayoutManager();
-    }
-  }
+                                       ShadowNodeTraits traits);
 
   MarkdownTextInputDecoratorShadowNode(ShadowNode const &sourceShadowNode,
-                                       ShadowNodeFragment const &fragment)
-      : ConcreteViewShadowNode(sourceShadowNode, fragment) {
-    initialize();
-
-    const auto &sourceDecorator = static_cast<const MarkdownTextInputDecoratorShadowNode &>(sourceShadowNode);
-
-    customContextContainer_ = sourceDecorator.customContextContainer_;
-    previousMarkdownStyle_ = sourceDecorator.previousMarkdownStyle_;
-    previousParserId_ = sourceDecorator.previousParserId_;
-
-    updateCustomContextContainerIfNeeded();
-
-    if (fragment.children) {
-      overwriteTextLayoutManager();
-    }
-  }
+                                       ShadowNodeFragment const &fragment);
 
   void appendChild(const ShadowNode::Shared &child) override;
 
@@ -69,6 +46,8 @@ private:
   void createCustomContextContainer();
 
   void updateCustomContextContainerIfNeeded();
+
+  void makeChildNodeMutable();
 };
 
 } // namespace react

--- a/apple/MarkdownTextInputDecoratorShadowNode.h
+++ b/apple/MarkdownTextInputDecoratorShadowNode.h
@@ -21,24 +21,10 @@ class JSI_EXPORT MarkdownTextInputDecoratorShadowNode final
 public:
   MarkdownTextInputDecoratorShadowNode(ShadowNodeFragment const &fragment,
                                        ShadowNodeFamily::Shared const &family,
-                                       ShadowNodeTraits traits)
-      : ConcreteViewShadowNode(fragment, family, traits) {
-    initialize();
-
-    if (fragment.children) {
-      overwriteMeasureCallbackConnector();
-    }
-  }
+                                       ShadowNodeTraits traits);
 
   MarkdownTextInputDecoratorShadowNode(ShadowNode const &sourceShadowNode,
-                                       ShadowNodeFragment const &fragment)
-      : ConcreteViewShadowNode(sourceShadowNode, fragment) {
-    initialize();
-
-    if (fragment.children) {
-      overwriteMeasureCallbackConnector();
-    }
-  }
+                                       ShadowNodeFragment const &fragment);
 
   void appendChild(const ShadowNode::Shared &child) override;
   void replaceChild(const ShadowNode &oldChild,
@@ -52,6 +38,7 @@ public:
 private:
   void initialize();
   void overwriteMeasureCallbackConnector();
+  void makeChildNodeMutable();
   void applyMarkdownFormattingToTextInputState(std::shared_ptr<TextInputShadowNode> node,
                      const LayoutContext &layoutContext) const;
   static YGSize yogaNodeMeasureCallbackConnector(YGNodeConstRef yogaNode,

--- a/apple/MarkdownTextInputDecoratorShadowNode.mm
+++ b/apple/MarkdownTextInputDecoratorShadowNode.mm
@@ -15,12 +15,51 @@ namespace react {
 extern const char MarkdownTextInputDecoratorViewComponentName[] =
     "MarkdownTextInputDecoratorView";
 
+MarkdownTextInputDecoratorShadowNode::MarkdownTextInputDecoratorShadowNode(
+    ShadowNodeFragment const &fragment,
+    ShadowNodeFamily::Shared const &family,
+    ShadowNodeTraits traits)
+    : ConcreteViewShadowNode(fragment, family, traits) {
+  initialize();
+  makeChildNodeMutable();
+  
+  if (fragment.children) {
+    overwriteMeasureCallbackConnector();
+  }
+}
+
+MarkdownTextInputDecoratorShadowNode::MarkdownTextInputDecoratorShadowNode(
+    ShadowNode const &sourceShadowNode,
+    ShadowNodeFragment const &fragment)
+    : ConcreteViewShadowNode(sourceShadowNode, fragment) {
+  initialize();
+  makeChildNodeMutable();
+  
+  if (fragment.children) {
+    overwriteMeasureCallbackConnector();
+  }
+}
+
 void MarkdownTextInputDecoratorShadowNode::initialize() {
   // Setting display: contents style results in ForceFlattenView trait being set
   // on the shadow node. This trait causes the node not to have a host view. By
   // removing the trait, it's possible to force RN to create a host view, layout
   // of which can then be customized.
   ShadowNode::traits_.unset(ShadowNodeTraits::ForceFlattenView);
+}
+
+void MarkdownTextInputDecoratorShadowNode::makeChildNodeMutable() {
+  // When the decorator is cloned and has a child node, the child node should be
+  // cloned as well to ensure it is mutable.
+  const auto &children = getChildren();
+  if (!children.empty()) {
+    react_native_assert(
+        children.size() == 1 &&
+        "MarkdownTextInputDecoratorView received more than one child");
+
+    const auto clonedChild = children[0]->clone({});
+    replaceChild(*children[0], clonedChild);
+  }
 }
 
 void MarkdownTextInputDecoratorShadowNode::overwriteMeasureCallbackConnector() {


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Details
https://github.com/Expensify/react-native-live-markdown/pull/707 updated the shadow node to clone the child node during initialization. This was happening too early in some paths, causing `nullptr` to be assigned to the TextInput's context container.

This PR moves the logic to a separate method, which can be invoked when the decorator node is fully initialized. It also moves the constructors implementation to the implementation files from headers.

### Related Issues
<!-- Please replace GH_LINK with the link to the GitHub issue this Pull Request is related to -->
GH_LINK

### Manual Tests
<!---
Most changes should have accompanying tests. Describe the tests you added or if no tests were added an explanation about why one was not needed.
--->

### Linked PRs
<!---
Please include links to any update PRs in repos that must change their package.json version.
--->