### PR TITLE
fix: unwanted space insertion in single line markdown text input when replacing selected text

### DIFF
--- a/src/MarkdownTextInput.web.tsx
+++ b/src/MarkdownTextInput.web.tsx
@@ -355,7 +355,7 @@ const MarkdownTextInput = React.forwardRef<MarkdownTextInput, MarkdownTextInputP
         updateTextColor(divRef.current, e.target.textContent ?? '');
         const previousText = divRef.current.value;
         let parsedText = normalizeValue(
-          inputType === 'pasteText' ? pasteContent.current || '' : parseInnerHTMLToText(e.target as MarkdownTextInputElement, contentSelection.current.start, inputType),
+          inputType === 'pasteText' ? pasteContent.current || '' : parseInnerHTMLToText(e.target as MarkdownTextInputElement, contentSelection.current.start, inputType, multiline),
         );
 
         if (pasteContent.current) {

--- a/src/__tests__/singleLineInputFix.test.tsx
+++ b/src/__tests__/singleLineInputFix.test.tsx
@@ -1,0 +1,117 @@
+import {expect} from '@jest/globals';
+import {parseRangesToHTMLNodes} from '../web/utils/parserUtils';
+import parseExpensiMark from '../parseExpensiMark';
+
+/**
+ * Focused tests for the single-line input fix
+ * These tests validate the specific fix for unwanted space insertion
+ */
+
+describe('Single-line input fix validation', () => {
+  describe('parseRangesToHTMLNodes with isMultiline parameter', () => {
+    it('should not generate BR elements for single-line text (isMultiline=false)', () => {
+      const text = 'simple text';
+      const ranges = parseExpensiMark(text);
+
+      const result = parseRangesToHTMLNodes(text, ranges, false, {}, true);
+
+      // Should not contain BR elements for single-line input
+      expect(result.dom.innerHTML).not.toContain('<span data-type="br">');
+      expect(result.dom.innerHTML).not.toContain('<br>');
+    });
+
+    it('should generate proper structure for multiline text (isMultiline=true)', () => {
+      const text = 'line 1\nline 2';
+      const ranges = parseExpensiMark(text);
+
+      const result = parseRangesToHTMLNodes(text, ranges, true, {}, true);
+
+      // Should contain proper paragraph structure for multiline
+      expect(result.dom.innerHTML).toContain('<p data-type="line"');
+      // Note: The library may not always use BR elements depending on the implementation
+      // The key is that it handles multiline properly
+      expect(result.dom.innerHTML.split('<p data-type="line"').length - 1).toBeGreaterThan(1);
+    });
+
+    it('should not generate BR elements for single-line markdown (isMultiline=false)', () => {
+      const text = 'hello *world* test';
+      const ranges = parseExpensiMark(text);
+
+      const result = parseRangesToHTMLNodes(text, ranges, false, {}, true);
+
+      // Should not contain BR elements but should have markdown formatting
+      expect(result.dom.innerHTML).not.toContain('<span data-type="br">');
+      expect(result.dom.innerHTML).not.toContain('<br>');
+      expect(result.dom.innerHTML).toContain('data-type="bold"');
+    });
+
+    it('should handle empty single-line input without BR elements (isMultiline=false)', () => {
+      const text = '';
+      const ranges = parseExpensiMark(text);
+
+      const result = parseRangesToHTMLNodes(text, ranges, false, {}, true);
+
+      // For empty input, should either be empty or have minimal structure without BR
+      const html = result.dom.innerHTML;
+      if (html !== '') {
+        // If there's structure, it shouldn't have BR elements for single-line
+        expect(html).not.toContain('<span data-type="br">');
+      }
+    });
+
+    it('should preserve existing multiline behavior when isMultiline=true', () => {
+      const singleLineText = 'test text';
+      const ranges = parseExpensiMark(singleLineText);
+
+      // Compare single-line vs multiline behavior
+      const singleLineResult = parseRangesToHTMLNodes(singleLineText, ranges, false, {}, true);
+      const multilineResult = parseRangesToHTMLNodes(singleLineText, ranges, true, {}, true);
+
+      // Single-line should be more compact than multiline
+      expect(singleLineResult.dom.innerHTML.length).toBeLessThanOrEqual(multilineResult.dom.innerHTML.length);
+
+      // Single-line should not have BR elements
+      expect(singleLineResult.dom.innerHTML).not.toContain('<span data-type="br">');
+    });
+  });
+
+  describe('Integration test for the original bug scenario', () => {
+    it('should demonstrate the fix for typing after selecting all text', () => {
+      // This test validates the core fix: when user types "t" after selecting all,
+      // the generated DOM should not contain elements that would cause space insertion
+
+      const userTypedText = 't';
+      const ranges = parseExpensiMark(userTypedText);
+
+      // Generate DOM with single-line setting (the fix)
+      const result = parseRangesToHTMLNodes(userTypedText, ranges, false, {}, true);
+
+      // Critical assertions for the fix:
+      // 1. Should not contain BR elements that add newlines
+      expect(result.dom.innerHTML).not.toContain('<span data-type="br">');
+      expect(result.dom.innerHTML).not.toContain('<br>');
+
+      // 2. Should contain the text properly structured
+      expect(result.dom.innerHTML).toContain('t');
+
+      // 3. The DOM should be as minimal as possible for single character
+      expect(result.dom.innerHTML.length).toBeLessThan(200); // Reasonable upper bound
+    });
+
+    it('should work correctly with markdown in single-line context', () => {
+      // Test that our fix doesn't break markdown functionality
+      const markdownText = '*bold* normal `code`';
+      const ranges = parseExpensiMark(markdownText);
+
+      const result = parseRangesToHTMLNodes(markdownText, ranges, false, {}, true);
+
+      // Should have proper markdown elements
+      expect(result.dom.innerHTML).toContain('data-type="bold"');
+      expect(result.dom.innerHTML).toContain('data-type="code"');
+
+      // But no BR elements
+      expect(result.dom.innerHTML).not.toContain('<span data-type="br">');
+      expect(result.dom.innerHTML).not.toContain('<br>');
+    });
+  });
+});

--- a/src/web/utils/inputUtils.ts
+++ b/src/web/utils/inputUtils.ts
@@ -67,17 +67,16 @@ function parseInnerHTMLToText(target: MarkdownTextInputElement, cursorPosition: 
     if (isTopComponent) {
       // When inputType is undefined, the first part of the replaced text is added as a text node.
       // Because of it, we need to prevent adding new lines in this case
-      if (!inputType && node.nodeType === Node.TEXT_NODE) {
+      if (!isMultiline || (!inputType && node.nodeType === Node.TEXT_NODE)) {
         shouldAddNewline = false;
       } else {
         const firstChild = node.firstChild as HTMLElement;
         const containsEmptyBlockElement = firstChild?.getAttribute?.('data-type') === 'block' && firstChild.textContent === '';
-        // Only add newlines for multiline inputs
-        if (isMultiline && shouldAddNewline && !containsEmptyBlockElement) {
+        if (shouldAddNewline && !containsEmptyBlockElement) {
           text += '\n';
           shouldAddNewline = false;
         }
-        shouldAddNewline = isMultiline;
+        shouldAddNewline = true;
       }
     }
 

--- a/src/web/utils/inputUtils.ts
+++ b/src/web/utils/inputUtils.ts
@@ -37,7 +37,7 @@ function normalizeValue(value: string) {
 }
 
 // Parses the HTML structure of a MarkdownTextInputElement to a plain text string. Used for getting the correct value of the input element.
-function parseInnerHTMLToText(target: MarkdownTextInputElement, cursorPosition: number, inputType?: string): string {
+function parseInnerHTMLToText(target: MarkdownTextInputElement, cursorPosition: number, inputType?: string, isMultiline = true): string {
   // Returns the parent of a given node that is higher in the hierarchy and is of a different type than 'text', 'br' or 'line'
   function getTopParentNode(node: ChildNode) {
     let currentParentNode = node.parentNode;
@@ -72,11 +72,12 @@ function parseInnerHTMLToText(target: MarkdownTextInputElement, cursorPosition: 
       } else {
         const firstChild = node.firstChild as HTMLElement;
         const containsEmptyBlockElement = firstChild?.getAttribute?.('data-type') === 'block' && firstChild.textContent === '';
-        if (shouldAddNewline && !containsEmptyBlockElement) {
+        // Only add newlines for multiline inputs
+        if (isMultiline && shouldAddNewline && !containsEmptyBlockElement) {
           text += '\n';
           shouldAddNewline = false;
         }
-        shouldAddNewline = true;
+        shouldAddNewline = isMultiline;
       }
     }
 
@@ -85,9 +86,9 @@ function parseInnerHTMLToText(target: MarkdownTextInputElement, cursorPosition: 
       text += node.textContent;
     } else if (node.nodeName === 'BR') {
       const parentNode = getTopParentNode(node);
-      if (parentNode && parentNode.parentElement?.contentEditable !== 'true' && !!(node as HTMLElement).getAttribute('data-id')) {
+      if (isMultiline && parentNode && parentNode.parentElement?.contentEditable !== 'true' && !!(node as HTMLElement).getAttribute('data-id')) {
         // Parse br elements into newlines only if their parent is not a child of the MarkdownTextInputElement (a paragraph when writing or a div when pasting).
-        // It prevents adding extra newlines when entering text
+        // It prevents adding extra newlines when entering text - and now only for multiline inputs
         text += '\n';
       }
     } else {

--- a/src/web/utils/parserUtils.ts
+++ b/src/web/utils/parserUtils.ts
@@ -152,7 +152,8 @@ function addTextToElement(node: TreeNode, text: string, isMultiline = true) {
       }
     }
 
-    if (index < lines.length - 1 || (index === 0 && line === '')) {
+    // Only add BR elements for multiline inputs or when there are actual line breaks
+    if (isMultiline && (index < lines.length - 1 || (index === 0 && line === ''))) {
       addBrElement(node);
     }
   });
@@ -228,7 +229,7 @@ function parseRangesToHTMLNodes(
     }
 
     if (line.markdownRanges.length === 0) {
-      addTextToElement(currentParentNode, line.text);
+      addTextToElement(currentParentNode, line.text, isMultiline);
     }
 
     let wasBlockGenerated = false;
@@ -254,7 +255,7 @@ function parseRangesToHTMLNodes(
       // add text before the markdown range
       const textBeforeRange = line.text.substring(lastRangeEndIndex - line.start, range.start - line.start);
       if (textBeforeRange) {
-        addTextToElement(currentParentNode, textBeforeRange);
+        addTextToElement(currentParentNode, textBeforeRange, isMultiline);
       }
 
       // create markdown span element
@@ -284,7 +285,7 @@ function parseRangesToHTMLNodes(
         while (currentParentNode.parentNode !== null && nextRangeStartIndex >= currentParentNode.start + currentParentNode.length) {
           const textAfterRange = line.text.substring(lastRangeEndIndex - line.start, currentParentNode.start - line.start + currentParentNode.length);
           if (textAfterRange) {
-            addTextToElement(currentParentNode, textAfterRange);
+            addTextToElement(currentParentNode, textAfterRange, isMultiline);
           }
           lastRangeEndIndex = currentParentNode.start + currentParentNode.length;
           if (currentParentNode.parentNode.type !== 'root') {


### PR DESCRIPTION
Fixes https://github.com/Expensify/react-native-live-markdown/issues/716
  <!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

  ### Details
  <!-- Explanation of the change or anything fishy that is going on -->

  This PR fixes a bug where `MarkdownTextInput` with `multiline={false}` incorrectly inserts spaces when users select all text and type a replacement character. The issue was caused by the library treating all text input as potentially multiline during processing, regardless of the `multiline` prop value.

  **Root Cause:**
  The library was adding BR elements (containing `\n` characters) and newlines during both DOM generation and text extraction phases, even for single-line inputs. These newlines then got converted to spaces during text normalization.

  **Changes Made:**

  #### 1. Fixed BR element addition in `addTextToElement()` function (`parserUtils.ts`)
  - Made BR element addition conditional on `isMultiline` parameter
  - Prevents unwanted newline characters in single-line inputs

  #### 2. Updated `addTextToElement()` function calls (`parserUtils.ts`)
  - Pass `isMultiline` parameter to all function calls within `parseRangesToHTMLNodes()`
  - Ensures multiline setting is respected throughout DOM generation

  #### 3. Enhanced `parseInnerHTMLToText()` function (`inputUtils.ts`)
  - Added `isMultiline = true` parameter to maintain backward compatibility
  - Made newline addition conditional in both top-level component processing and BR element parsing
  - Prevents unwanted newlines during text extraction for single-line inputs

  #### 4. Connected multiline prop in `MarkdownTextInput.web.tsx`
  - Pass `multiline` prop to `parseInnerHTMLToText()` function
  - Ensures the component's multiline setting flows through the entire processing chain

  **Impact:**
  - ✅ Single-line inputs no longer get unwanted spaces
  - ✅ Multiline inputs continue to work correctly
  - ✅ Markdown highlighting preserved for both input types
  - ✅ No breaking changes to existing API
  - ✅ Backward compatible (all new parameters have defaults)

  ### Related Issues
  <!-- Please replace GH_LINK with the link to the GitHub issue this Pull Request is related to -->
  GH_LINK

  ### Manual Tests
  <!---
  Most changes should have accompanying tests. Describe the tests you added or if no tests were added an explanation about why one was not needed.
  --->

  **Test Scenarios Covered:**

  1. **Single-line text replacement**:
     - Create `MarkdownTextInput` with `multiline={false}`
     - Enter text, select all, type replacement
     - Verify no extra spaces are added

  2. **Multiline preservation**:
     - Create `MarkdownTextInput` with `multiline={true}`
     - Test that line breaks continue to work correctly

  3. **Markdown highlighting**:
     - Test single-line inputs with various markdown syntax
     - Verify highlighting works without adding unwanted spaces

  4. **Edge cases**:
     - Empty inputs, inputs with only spaces, special characters
     - Mixed markdown content (bold, italic, etc.)

  5. **Regression testing**:
     - Verified existing multiline functionality remains unchanged
     - Confirmed no impact on markdown parsing or rendering

  **Manual Testing Steps:**
  1. Open WebExample or any app using the library
  2. Create a search input with `multiline={false}` and `type="markdown"`
  3. Enter text like "type:expense group-by:reports"
  4. Select all text (Ctrl+A)
  5. Type a single character like "t"
  6. **Before fix**: Shows "t " (with unwanted space)
  7. **After fix**: Shows "t" (clean, no extra space)