### PR TITLE
Fix/68518 - Strike through is not applied for quote markdown text

### DIFF
--- a/WebExample/__tests__/styles.spec.ts
+++ b/WebExample/__tests__/styles.spec.ts
@@ -1,7 +1,7 @@
 import {test} from '@playwright/test';
 // eslint-disable-next-line import/no-relative-packages
 import * as TEST_CONST from '../../example/src/testConstants';
-import {testMarkdownContentStyle} from './utils';
+import {testMarkdownContentStyle, testMarkdownElementHasComputedStyle} from './utils';
 
 test.beforeEach(async ({page}) => {
   await page.goto(TEST_CONST.LOCAL_URL, {waitUntil: 'load'});
@@ -59,5 +59,16 @@ test.describe('markdown content styling', () => {
     const browserStyle = browserName === 'firefox' ? blockquoteStyle.replace('border-left-style: solid', 'border-left: 6px solid gray') : blockquoteStyle;
 
     await testMarkdownContentStyle({testContent: 'blockquote', style: browserStyle, page});
+  });
+
+  test('blockquote with strikethrough', async ({page, browserName}) => {
+    let blockquoteStyle = 'line-through';
+    if (browserName === 'firefox') {
+      blockquoteStyle = 'line-through rgb(0, 0, 0)';
+    } else if (browserName === 'chromium') {
+      blockquoteStyle = 'line-through solid rgb(0, 0, 0)';
+    }
+
+    await testMarkdownElementHasComputedStyle({testContent: 'strikethrough_blockquote', propertyName: 'text-decoration', style: blockquoteStyle, page});
   });
 });

--- a/WebExample/__tests__/utils.ts
+++ b/WebExample/__tests__/utils.ts
@@ -103,4 +103,29 @@ const testMarkdownContentStyle = async ({testContent, style, page, dimmensions}:
   }
 };
 
-export {setupInput, getCursorPosition, setCursorPosition, getElementStyle, pressCmd, getElementValue, changeMarkdownStyle, setSelection, testMarkdownContentStyle};
+const testMarkdownElementHasComputedStyle = async ({testContent, propertyName, style, page}: {testContent: string; propertyName: string; style: string; page: Page}) => {
+  const inputLocator = await setupInput(page);
+
+  const elementHandle = inputLocator.locator('span', {hasText: testContent}).last();
+
+  let elementStyle;
+  if (elementHandle) {
+    await elementHandle.waitFor({state: 'attached'});
+    elementStyle = await elementHandle.evaluate((el, property) => window.getComputedStyle(el).getPropertyValue(property), propertyName);
+  }
+
+  expect(elementStyle).toEqual(style);
+};
+
+export {
+  setupInput,
+  getCursorPosition,
+  setCursorPosition,
+  getElementStyle,
+  pressCmd,
+  getElementValue,
+  changeMarkdownStyle,
+  setSelection,
+  testMarkdownContentStyle,
+  testMarkdownElementHasComputedStyle,
+};

--- a/example/src/testConstants.ts
+++ b/example/src/testConstants.ts
@@ -6,6 +6,7 @@ const EXAMPLE_CONTENT = [
   'https://expensify.com',
   '# header1',
   '> blockquote',
+  '~sb\n*sbb\n_sbi\n> strikethrough_blockquote\nsbi_\nsbb*\nsb~',
   '`inline code`',
   '```\ncodeblock\n```',
   '@here',

--- a/src/web/MarkdownTextInput.css
+++ b/src/web/MarkdownTextInput.css
@@ -76,3 +76,7 @@
   -ms-user-select: none;
   user-select: none;
 }
+
+[class^='react-native-live-markdown-input'] [data-type='strikethrough'] * {
+  text-decoration: inherit;
+}


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Explanation of Change

### Fixed Issues
$ https://github.com/Expensify/App/issues/68518 
PROPOSAL: https://github.com/Expensify/App/issues/68518#issuecomment-3188873536

### Tests
Same as QA Steps

- [x] Verify that no errors appear in the JS console

### Offline tests
Same as QA Steps

### QA Steps
1. Go to https://staging.new.expensify.com/home
2. Open a chat
3. Paste the text
```
~Test
> Test
Test~
```
4. Send the message
5. Note that the preview view and conversation view are consistent.


- [x] Verify that no errors appear in the JS console

### PR Author Checklist
<!--
This is a checklist for PR authors. Please make sure to complete all tasks and check them off once you do, or else your PR will not be merged!
-->

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android: Native
    - [x] Android: mWeb Chrome
    - [x] iOS: Native
    - [x] iOS: mWeb Safari
    - [x] MacOS: Chrome / Safari
    - [x] MacOS: Desktop
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I verified there are no new alerts related to the `canBeMissing` param for `useOnyx`
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text shown in the product is localized by adding it to `src/languages/*` files and using the [translation method](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60)
      - [x] If any non-english text was added/modified, I used [JaimeGPT](https://chatgpt.com/g/g-2dgOQl5VM-english-to-spanish-translator-aka-jaimegpt) to get English > Spanish translation. I then posted it in #expensify-open-source and it was approved by an internal Expensify engineer. Link to Slack message:
    - [x] I verified all numbers, amounts, dates and phone numbers shown in the product are using the [localization methods](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60-L68)
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue)
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.ts or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [x] If the PR modifies the UI (e.g. new buttons, new UI components, changing the padding/spacing/sizing, moving components, etc) or modifies the form input styles:
    - [x] I verified that all the inputs inside a form are aligned with each other.
    - [x] I added `Design` label and/or tagged `@Expensify/design` so the design team can review the changes.
- [x] If a new page is added, I verified it's using the `ScrollView` component to make it scrollable when more elements are added to the page.
- [x] I added [unit tests](https://github.com/Expensify/App/blob/main/tests/README.md) for any new feature or bug fix in this PR to help automatically prevent regressions in this user flow.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.

### Screenshots/Videos
<details>
<summary>Android: Native</summary>

<!-- add screenshots or videos here -->


The issue doesn't occur.


</details>

<details>
<summary>Android: mWeb Chrome</summary>

<!-- add screenshots or videos here -->



<img width="416" height="929" alt="android mweb" src="https://github.com/user-attachments/assets/155e3582-b3fc-4a5f-83de-2d5e3d04286f" />


</details>

<details>
<summary>iOS: Native</summary>

<!-- add screenshots or videos here -->


The issue doesn't occur.


</details>

<details>
<summary>iOS: mWeb Safari</summary>

<!-- add screenshots or videos here -->


<img width="469" height="882" alt="ios safari" src="https://github.com/user-attachments/assets/4345d716-7d34-4a5f-bef2-f54f32ed5d29" />



</details>

<details>
<summary>MacOS: Chrome / Safari</summary>

<!-- add screenshots or videos here -->



<img width="1223" height="903" alt="mac safari" src="https://github.com/user-attachments/assets/75c5ae8e-7173-435e-a7b9-b5652cefbf97" />


</details>

<details>
<summary>MacOS: Desktop</summary>

<!-- add screenshots or videos here -->



<img width="1312" height="987" alt="mac desktop" src="https://github.com/user-attachments/assets/2a02d448-228c-4bb3-8f7e-9e1c36e5ade8" />


</details>
