### PR TITLE
Hotfix: Bring back placeholders on web

### DIFF
--- a/WebExample/__tests__/styles.spec.ts
+++ b/WebExample/__tests__/styles.spec.ts
@@ -78,9 +78,12 @@ test.describe('empty input styling', () => {
     await page.click('[data-testid="clear"]');
   });
 
-  test('empty input should have a placeholder', async ({page}) => {
+  test('placeholder should have correct text', async ({page}) => {
     const placeholder = await page.$eval(`div#${TEST_CONST.INPUT_ID}`, (el) => el.getAttribute('placeholder'));
     expect(placeholder).toBe('Type here...');
+  });
+
+  test('empty input should have visible placeholder', async ({page}) => {
     const inputLocator = await setupInput(page);
 
     const beforeContent = await inputLocator.evaluate((el) => {

--- a/WebExample/__tests__/styles.spec.ts
+++ b/WebExample/__tests__/styles.spec.ts
@@ -1,4 +1,4 @@
-import {test} from '@playwright/test';
+import {test, expect} from '@playwright/test';
 // eslint-disable-next-line import/no-relative-packages
 import * as TEST_CONST from '../../example/src/testConstants';
 import {testMarkdownContentStyle, testMarkdownElementHasComputedStyle} from './utils';
@@ -70,5 +70,16 @@ test.describe('markdown content styling', () => {
     }
 
     await testMarkdownElementHasComputedStyle({testContent: 'strikethrough_blockquote', propertyName: 'text-decoration', style: blockquoteStyle, page});
+  });
+});
+
+test.describe('empty input styling', () => {
+  test.beforeEach(async ({page}) => {
+    await page.click('[data-testid="clear"]');
+  });
+
+  test('empty input should have a placeholder', async ({page}) => {
+    const placeholder = await page.$eval(`div#${TEST_CONST.INPUT_ID}`, (el) => el.getAttribute('placeholder'));
+    expect(placeholder).toBe('Type here...');
   });
 });

--- a/WebExample/__tests__/styles.spec.ts
+++ b/WebExample/__tests__/styles.spec.ts
@@ -1,7 +1,7 @@
 import {test, expect} from '@playwright/test';
 // eslint-disable-next-line import/no-relative-packages
 import * as TEST_CONST from '../../example/src/testConstants';
-import {testMarkdownContentStyle, testMarkdownElementHasComputedStyle} from './utils';
+import {setupInput, testMarkdownContentStyle, testMarkdownElementHasComputedStyle} from './utils';
 
 test.beforeEach(async ({page}) => {
   await page.goto(TEST_CONST.LOCAL_URL, {waitUntil: 'load'});
@@ -81,5 +81,15 @@ test.describe('empty input styling', () => {
   test('empty input should have a placeholder', async ({page}) => {
     const placeholder = await page.$eval(`div#${TEST_CONST.INPUT_ID}`, (el) => el.getAttribute('placeholder'));
     expect(placeholder).toBe('Type here...');
+    const inputLocator = await setupInput(page);
+
+    const beforeContent = await inputLocator.evaluate((el) => {
+      return window.getComputedStyle(el, '::before').getPropertyValue('content');
+    });
+
+    expect([
+      '"Type here..."', // Chromium/WebKit, resolves attr()
+      'attr(placeholder)', // Firefox, literal
+    ]).toContain(beforeContent);
   });
 });

--- a/src/web/MarkdownTextInput.css
+++ b/src/web/MarkdownTextInput.css
@@ -30,6 +30,13 @@
   padding-right: 1px !important;
 }
 
+.react-native-live-markdown-input-singleline:empty::before,
+.react-native-live-markdown-input-multiline:empty::before {
+  pointer-events: none;
+  display: block; /* For Firefox */
+  content: attr(placeholder);
+}
+
 .react-native-live-markdown-input-multiline *[data-type='pre'] {
   line-height: 1.3;
   display: block;


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Details
<!-- Explanation of the change or anything fishy that is going on -->
This PR brings back placeholder styles.

### Related Issues
<!-- Please replace GH_LINK with the link to the GitHub issue this Pull Request is related to -->

https://github.com/Expensify/App/issues/69048 
and discussion https://swmansion.slack.com/archives/C049HHMV9SM/p1755884247194659

### Manual Tests
<!---
Most changes should have accompanying tests. Describe the tests you added or if no tests were added an explanation about why one was not needed.
--->
1. Have an empty markdown input
2. Placeholder should be present

### Screenshots 

### Before
<img width="513" height="485" alt="image" src="https://github.com/user-attachments/assets/71d0fa3d-a27d-4f81-b7b8-9d16b1eddd39" />


#### After 
<img width="351" height="397" alt="image" src="https://github.com/user-attachments/assets/34d7fed6-51f9-4074-a6ed-5cfa9a2b2d6a" />


### Linked PRs
<!---
Please include links to any update PRs in repos that must change their package.json version.
--->