### PR TITLE
Add the ability to only parse specific markdown rules

### DIFF
--- a/src/parseExpensiMark.ts
+++ b/src/parseExpensiMark.ts
@@ -28,10 +28,11 @@ const MAX_PARSABLE_LENGTH = 4000;
 type Token = ['TEXT' | 'HTML', string];
 type StackItem = {tag: string; children: Array<StackItem | string>};
 
-function parseMarkdownToHTML(markdown: string): string {
+function parseMarkdownToHTML(markdown: string, filterRules: string[] | undefined): string {
   const parser = new ExpensiMark();
   const html = parser.replace(markdown, {
     shouldKeepRawInput: true,
+    filterRules,
   });
   return html as string;
 }
@@ -240,11 +241,11 @@ function parseTreeToTextAndRanges(tree: StackItem): [string, MarkdownRange[]] {
 
 const isNative = Platform.OS === 'android' || Platform.OS === 'ios';
 
-function parseExpensiMark(markdown: string): MarkdownRange[] {
+function parseExpensiMark(markdown: string, filterRules?: string[]): MarkdownRange[] {
   if (markdown.length > MAX_PARSABLE_LENGTH) {
     return [];
   }
-  const html = parseMarkdownToHTML(markdown);
+  const html = parseMarkdownToHTML(markdown, filterRules);
   const tokens = parseHTMLToTokens(html);
   const tree = parseTokensToTree(tokens);
   const [text, ranges] = parseTreeToTextAndRanges(tree);


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Details
<!-- Explanation of the change or anything fishy that is going on -->
Allow to pass markdown rules that will be parsed. This is for https://github.com/Expensify/App/issues/67976. The proposal detail is [here](https://github.com/Expensify/App/issues/67976#issuecomment-3157300328).

### Related Issues
<!-- Please replace GH_LINK with the link to the GitHub issue this Pull Request is related to -->


### Manual Tests
<!---
Most changes should have accompanying tests. Describe the tests you added or if no tests were added an explanation about why one was not needed.
--->
I test it by updating the parser locally and pass `['emoji']` for the `filterRules`.
https://github.com/Expensify/react-native-live-markdown/blob/e60eefd558d9a817c368ec100e148bf258b7cf74/example/src/App.tsx#L53

```
parser={(value) => parseExpensiMark(value, ['emoji'])}
```

<img width="538" height="662" alt="Screenshot 2025-08-28 at 14 00 15" src="https://github.com/user-attachments/assets/5e4fd52c-4e18-4977-bb16-2392585dc2dc" />

### Linked PRs
<!---
Please include links to any update PRs in repos that must change their package.json version.
--->