### PR TITLE
Fix moving cursor to the end of line

### DIFF
--- a/src/__tests__/parseExpensiMark.test.ts
+++ b/src/__tests__/parseExpensiMark.test.ts
@@ -79,7 +79,6 @@ test('emoji', () => {
 test('emoji and italic', () => {
   expect('_😎_').toBeParsedAs([
     {type: 'syntax', start: 0, length: 1},
-    {type: 'italic', start: 1, length: 2},
     {type: 'emoji', start: 1, length: 2},
     {type: 'syntax', start: 3, length: 1},
   ]);

--- a/src/__tests__/splitRangesOnEmojis.test.ts
+++ b/src/__tests__/splitRangesOnEmojis.test.ts
@@ -1,5 +1,5 @@
 import type {MarkdownRange} from '../commonTypes';
-import {splitRangesOnEmojis} from '../rangeUtils';
+import {excludeRangeTypesFromFormatting, getRangesToExcludeFormatting} from '../rangeUtils';
 
 const sortRanges = (ranges: MarkdownRange[]) => {
   return ranges.sort((a, b) => a.start - b.start);
@@ -11,7 +11,7 @@ test('no overlap', () => {
     {type: 'emoji', start: 12, length: 2},
   ];
 
-  const splittedRanges = splitRangesOnEmojis(markdownRanges, 'strikethrough');
+  const splittedRanges = excludeRangeTypesFromFormatting(markdownRanges, 'strikethrough', getRangesToExcludeFormatting(markdownRanges));
   expect(splittedRanges).toEqual([
     {type: 'strikethrough', start: 0, length: 10},
     {type: 'emoji', start: 12, length: 2},
@@ -24,7 +24,7 @@ test('overlap different type', () => {
     {type: 'emoji', start: 3, length: 4},
   ];
 
-  const splittedRanges = splitRangesOnEmojis(markdownRanges, 'italic');
+  const splittedRanges = excludeRangeTypesFromFormatting(markdownRanges, 'italic', getRangesToExcludeFormatting(markdownRanges));
   expect(splittedRanges).toEqual(markdownRanges);
 });
 
@@ -35,7 +35,7 @@ describe('single overlap', () => {
       {type: 'emoji', start: 0, length: 2},
     ];
 
-    markdownRanges = splitRangesOnEmojis(markdownRanges, 'strikethrough');
+    markdownRanges = excludeRangeTypesFromFormatting(markdownRanges, 'strikethrough', getRangesToExcludeFormatting(markdownRanges));
     sortRanges(markdownRanges);
 
     expect(markdownRanges).toEqual([
@@ -50,7 +50,7 @@ describe('single overlap', () => {
       {type: 'emoji', start: 3, length: 4},
     ];
 
-    markdownRanges = splitRangesOnEmojis(markdownRanges, 'strikethrough');
+    markdownRanges = excludeRangeTypesFromFormatting(markdownRanges, 'strikethrough', getRangesToExcludeFormatting(markdownRanges));
     sortRanges(markdownRanges);
 
     expect(markdownRanges).toEqual([
@@ -66,7 +66,7 @@ describe('single overlap', () => {
       {type: 'emoji', start: 8, length: 2},
     ];
 
-    markdownRanges = splitRangesOnEmojis(markdownRanges, 'strikethrough');
+    markdownRanges = excludeRangeTypesFromFormatting(markdownRanges, 'strikethrough', getRangesToExcludeFormatting(markdownRanges));
     sortRanges(markdownRanges);
 
     expect(markdownRanges).toEqual([
@@ -82,7 +82,7 @@ describe('single overlap', () => {
       {type: 'emoji', start: 5, length: 2},
     ];
 
-    markdownRanges = splitRangesOnEmojis(markdownRanges, 'strikethrough');
+    markdownRanges = excludeRangeTypesFromFormatting(markdownRanges, 'strikethrough', getRangesToExcludeFormatting(markdownRanges));
     sortRanges(markdownRanges);
 
     expect(markdownRanges).toEqual([
@@ -101,7 +101,7 @@ describe('single overlap', () => {
       {type: 'emoji', start: 4, length: 2},
     ];
 
-    markdownRanges = splitRangesOnEmojis(markdownRanges, 'strikethrough');
+    markdownRanges = excludeRangeTypesFromFormatting(markdownRanges, 'strikethrough', getRangesToExcludeFormatting(markdownRanges));
 
     expect(markdownRanges).toEqual([
       {type: 'emoji', start: 0, length: 2},
@@ -121,7 +121,7 @@ describe('multiple overlaps', () => {
       {type: 'strikethrough', start: 22, length: 5},
     ];
 
-    markdownRanges = splitRangesOnEmojis(markdownRanges, 'strikethrough');
+    markdownRanges = excludeRangeTypesFromFormatting(markdownRanges, 'strikethrough', getRangesToExcludeFormatting(markdownRanges));
     sortRanges(markdownRanges);
 
     expect(markdownRanges).toEqual([
@@ -144,8 +144,8 @@ describe('multiple overlaps', () => {
       {type: 'strikethrough', start: 22, length: 5},
     ];
 
-    markdownRanges = splitRangesOnEmojis(markdownRanges, 'strikethrough');
-    markdownRanges = splitRangesOnEmojis(markdownRanges, 'italic');
+    markdownRanges = excludeRangeTypesFromFormatting(markdownRanges, 'strikethrough', getRangesToExcludeFormatting(markdownRanges));
+    markdownRanges = excludeRangeTypesFromFormatting(markdownRanges, 'italic', getRangesToExcludeFormatting(markdownRanges));
     sortRanges(markdownRanges);
 
     expect(markdownRanges).toEqual([

--- a/src/parseExpensiMark.ts
+++ b/src/parseExpensiMark.ts
@@ -6,7 +6,7 @@ import {unescapeText} from 'expensify-common/dist/utils';
 import {decode} from 'html-entities';
 import type {WorkletFunction} from 'react-native-reanimated/lib/typescript/commonTypes';
 import type {MarkdownType, MarkdownRange} from './commonTypes';
-import {groupRanges, sortRanges, excludeRangeTypesFromFormatting} from './rangeUtils';
+import {groupRanges, sortRanges, excludeRangeTypesFromFormatting, getRangesToExcludeFormatting} from './rangeUtils';
 
 function isWeb() {
   return Platform.OS === 'web';
@@ -236,24 +236,6 @@ function parseTreeToTextAndRanges(tree: StackItem): [string, MarkdownRange[]] {
   }
   dfs(tree);
   return [text, ranges];
-}
-
-/**
- * Creates a list of ranges that should not be formatted by certain markdown types (italic, strikethrough).
- * This includes emojis and syntaxes of inline code blocks.
- */
-function getRangesToExcludeFormatting(ranges: MarkdownRange[]) {
-  let closingSyntaxPosition: number | null = null;
-  return ranges.filter((range, index) => {
-    const nextRange = ranges[index + 1];
-    if (nextRange && nextRange.type === 'code' && range.type === 'syntax') {
-      closingSyntaxPosition = nextRange.start + nextRange?.length;
-    } else if (closingSyntaxPosition !== null && range.type === 'syntax' && range.start <= closingSyntaxPosition) {
-      closingSyntaxPosition = null;
-      return true;
-    }
-    return range.type === 'emoji' || (ranges[index + 1]?.type === 'code' && range.type === 'syntax');
-  });
 }
 
 function parseExpensiMark(markdown: string): MarkdownRange[] {

--- a/src/rangeUtils.ts
+++ b/src/rangeUtils.ts
@@ -58,6 +58,24 @@ function ungroupRanges(ranges: MarkdownRange[]): MarkdownRange[] {
 }
 
 /**
+ * Creates a list of ranges that should not be formatted by certain markdown types (italic, strikethrough).
+ * This includes emojis and syntaxes of inline code blocks.
+ */
+function getRangesToExcludeFormatting(ranges: MarkdownRange[]) {
+  let closingSyntaxPosition: number | null = null;
+  return ranges.filter((range, index) => {
+    const nextRange = ranges[index + 1];
+    if (nextRange && nextRange.type === 'code' && range.type === 'syntax') {
+      closingSyntaxPosition = nextRange.start + nextRange.length;
+    } else if (closingSyntaxPosition !== null && range.type === 'syntax' && range.start <= closingSyntaxPosition) {
+      closingSyntaxPosition = null;
+      return true;
+    }
+    return range.type === 'emoji' || (ranges[index + 1]?.type === 'code' && range.type === 'syntax');
+  });
+}
+
+/**
  * Splits ranges of a specific type from being formatted by specified markdown types (e.g., 'emoji', 'syntax').
  * @param ranges - The array of MarkdownRange objects to process.
  * @param baseMarkdownType - The base markdown type to exclude formatting from (e.g., 'italic').
@@ -118,4 +136,4 @@ function excludeRangeTypesFromFormatting(ranges: MarkdownRange[], baseMarkdownTy
   return newRanges;
 }
 
-export {sortRanges, groupRanges, ungroupRanges, excludeRangeTypesFromFormatting};
+export {sortRanges, groupRanges, ungroupRanges, excludeRangeTypesFromFormatting, getRangesToExcludeFormatting};

--- a/src/rangeUtils.ts
+++ b/src/rangeUtils.ts
@@ -57,8 +57,13 @@ function ungroupRanges(ranges: MarkdownRange[]): MarkdownRange[] {
   return ungroupedRanges;
 }
 
-function splitRangesOnEmojis(ranges: MarkdownRange[], type: MarkdownType): MarkdownRange[] {
-  const emojiRanges: MarkdownRange[] = ranges.filter((range) => range.type === 'emoji');
+/**
+ * Splits ranges of a specific type from being formatted by specified markdown types (e.g., 'emoji', 'syntax').
+ * @param ranges - The array of MarkdownRange objects to process.
+ * @param baseMarkdownType - The base markdown type to exclude formatting from (e.g., 'italic').
+ * @param rangesToExclude - The array of MarkdownRange objects representing the ranges to exclude from formatting.
+ */
+function excludeRangeTypesFromFormatting(ranges: MarkdownRange[], baseMarkdownType: MarkdownType, rangesToExclude: MarkdownRange[]): MarkdownRange[] {
   const newRanges: MarkdownRange[] = [];
 
   let i = 0;
@@ -69,33 +74,33 @@ function splitRangesOnEmojis(ranges: MarkdownRange[], type: MarkdownType): Markd
       break;
     }
 
-    if (currentRange.type !== type) {
+    if (currentRange.type !== baseMarkdownType) {
       newRanges.push(currentRange);
       i++;
     } else {
       // Iterate through all emoji ranges before the end of the current range, splitting the current range at each intersection.
-      while (j < emojiRanges.length) {
-        const emojiRange = emojiRanges[j];
-        if (!emojiRange || emojiRange.start > currentRange.start + currentRange.length) {
+      while (j < rangesToExclude.length) {
+        const excludeRange = rangesToExclude[j];
+        if (!excludeRange || excludeRange.start > currentRange.start + currentRange.length) {
           break;
         }
 
         const currentStart: number = currentRange.start;
         const currentEnd: number = currentRange.start + currentRange.length;
-        const emojiStart: number = emojiRange.start;
-        const emojiEnd: number = emojiRange.start + emojiRange.length;
+        const excludeRangeStart: number = excludeRange.start;
+        const excludeRangeEnd: number = excludeRange.start + excludeRange.length;
 
-        if (emojiStart >= currentStart && emojiEnd <= currentEnd) {
+        if (excludeRangeStart >= currentStart && excludeRangeEnd <= currentEnd) {
           // Intersection
           const newRange: MarkdownRange = {
             type: currentRange.type,
             start: currentStart,
-            length: emojiStart - currentStart,
+            length: excludeRangeStart - currentStart,
             ...(currentRange?.depth && {depth: currentRange?.depth}),
           };
 
-          currentRange.start = emojiEnd;
-          currentRange.length = currentEnd - emojiEnd;
+          currentRange.start = excludeRangeEnd;
+          currentRange.length = currentEnd - excludeRangeEnd;
 
           if (newRange.length > 0) {
             newRanges.push(newRange);
@@ -113,4 +118,4 @@ function splitRangesOnEmojis(ranges: MarkdownRange[], type: MarkdownType): Markd
   return newRanges;
 }
 
-export {sortRanges, groupRanges, ungroupRanges, splitRangesOnEmojis};
+export {sortRanges, groupRanges, ungroupRanges, excludeRangeTypesFromFormatting};

--- a/src/web/utils/blockUtils.ts
+++ b/src/web/utils/blockUtils.ts
@@ -31,9 +31,6 @@ function addStyleToBlock(targetElement: HTMLElement, type: NodeType, markdownSty
       Object.assign(node.style, {
         ...markdownStyle.emoji,
         verticalAlign: 'middle',
-        fontStyle: 'normal', // remove italic
-        textDecoration: 'none', // remove strikethrough
-        display: 'inline-block',
       });
       break;
     case 'mention-here':


### PR DESCRIPTION
<!-- If necessary, assign reviewers who know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Details
<!-- Explanation of the change or anything fishy that is going on -->

This PR fixes moving the cursor to the end of the line using CMD + ➡ or the End key. To fix this problem, we implemented splitting italic and strikethrough markdown types on the starting and ending syntax of the inline code. Because of the HTML structure, we couldn't split the range directly on the inline code. So similarly to other applications like Slack, the styles are applied to the text inside inline code separately

### Related Issues
<!-- Please replace GH_LINK with the link to the GitHub issue this Pull Request is related to -->

https://github.com/Expensify/App/issues/69493#issuecomment-3308063242



### Manual Tests
<!---
Most changes should have accompanying tests. Describe the tests you added, or if no tests were added, an explanation about why one was not needed.
--->

### Linked PRs
<!---
Please include links to any updated PRs in repos that must change their package.json version.
--->