### PR TITLE
Fix: Android release build issue due to "unused" children variable

### DIFF
--- a/android/src/main/new_arch/react/renderer/components/RNLiveMarkdownSpec/MarkdownTextInputDecoratorShadowNode.cpp
+++ b/android/src/main/new_arch/react/renderer/components/RNLiveMarkdownSpec/MarkdownTextInputDecoratorShadowNode.cpp
@@ -166,7 +166,7 @@ void MarkdownTextInputDecoratorShadowNode::layout(LayoutContext layoutContext) {
       children.size() == 1 &&
       "MarkdownTextInputDecoratorView didn't receive exactly one child");
 
-  auto child = std::static_pointer_cast<const YogaLayoutableShadowNode>(getChildren()[0]);
+  auto child = std::static_pointer_cast<const YogaLayoutableShadowNode>(children[0]);
   child->ensureUnsealed();
   auto mutableChild = std::const_pointer_cast<YogaLayoutableShadowNode>(child);
 


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Details
<!-- Explanation of the change or anything fishy that is going on -->

`MarkdownTextInputDecoratorShadowNode.cpp` has `layout` method which first check if there is only one child returned from `getChildren`

```cpp
const auto &children = getChildren();
  react_native_assert(
      children.size() == 1 &&
      "MarkdownTextInputDecoratorView didn't receive exactly one child");
```

and then gets the children again to extract the child

```cpp
auto child = std::static_pointer_cast<const YogaLayoutableShadowNode>(getChildren()[0]);
```

While I'm migrating Expensify/App to React Native 0.81 I stepped upon this error, which caused adhoc build to crash

```
[14:24:49]: ▸ C/C++: /home/runner/work/App/App/node_modules/@expensify/react-native-live-markdown/android/src/main/new_arch/react/renderer/components/RNLiveMarkdownSpec/MarkdownTextInputDecoratorShadowNode.cpp:164:15: error: unused variable 'children' [-Werror,-Wunused-variable]
[14:24:49]: ▸ C/C++:   164 |   const auto &children = getChildren();
[14:24:49]: ▸ C/C++:       |               ^~~~~~~~
[14:24:49]: ▸ C/C++: 1 error generated.
```

Removing the second `getChildren` call and replacing it with the `children` variable fixed the issue

### Related Issues
<!-- Please replace GH_LINK with the link to the GitHub issue this Pull Request is related to -->

n/a

### Manual Tests
<!---
Most changes should have accompanying tests. Describe the tests you added or if no tests were added an explanation about why one was not needed.
--->

Running the release build of the example app would be the best but I got ` Connect timed out` from sonatype 🤷 
I'll bump the live-markdown to this commit in E/App and link the working adhoc as proof
Adhoc build: https://github.com/Expensify/App/pull/69535#issuecomment-3335224339

### Linked PRs
<!---
Please include links to any update PRs in repos that must change their package.json version.
--->

https://github.com/Expensify/App/pull/69535