### PR TITLE
Fix applying styles for inline code syntaxes

### DIFF
--- a/src/__tests__/parseExpensiMark.test.ts
+++ b/src/__tests__/parseExpensiMark.test.ts
@@ -1,11 +1,10 @@
 import {expect} from '@jest/globals';
 import type {MarkdownRange} from '../commonTypes';
 import parseExpensiMark from '../parseExpensiMark';
-import type {ExtendedMarkdownRange} from '../rangeUtils';
 
 declare module 'expect' {
   interface Matchers<R> {
-    toBeParsedAs(expectedRanges: ExtendedMarkdownRange[]): R;
+    toBeParsedAs(expectedRanges: MarkdownRange[]): R;
   }
 }
 

--- a/src/commonTypes.ts
+++ b/src/commonTypes.ts
@@ -21,6 +21,7 @@ interface MarkdownRange {
   start: number;
   length: number;
   depth?: number;
+  syntaxType?: 'opening' | 'closing';
 }
 
 type InlineImagesInputProps = {

--- a/src/rangeUtils.ts
+++ b/src/rangeUtils.ts
@@ -2,10 +2,6 @@
 
 import type {MarkdownRange, MarkdownType} from './commonTypes';
 
-type ExtendedMarkdownRange = MarkdownRange & {
-  syntaxType?: 'opening' | 'closing';
-};
-
 // getTagPriority returns a priority for a tag, higher priority means the tag should be processed first
 function getTagPriority(tag: string) {
   switch (tag) {
@@ -64,11 +60,11 @@ function ungroupRanges(ranges: MarkdownRange[]): MarkdownRange[] {
  * Creates a list of ranges that should not be formatted by certain markdown types (italic, strikethrough).
  * This includes emojis and syntaxes of inline code blocks.
  */
-function getRangesToExcludeFormatting(ranges: MarkdownRange[]): ExtendedMarkdownRange[] {
+function getRangesToExcludeFormatting(ranges: MarkdownRange[]): MarkdownRange[] {
   let closingSyntaxPosition: number | null = null;
   return ranges.filter((range, index) => {
     const nextRange = ranges[index + 1];
-    const currentRange = range as ExtendedMarkdownRange;
+    const currentRange = range;
     if (nextRange && nextRange.type === 'code' && range.type === 'syntax') {
       currentRange.syntaxType = 'opening';
       closingSyntaxPosition = nextRange.start + nextRange.length;
@@ -89,7 +85,7 @@ function getRangesToExcludeFormatting(ranges: MarkdownRange[]): ExtendedMarkdown
  * @param baseMarkdownType - The base markdown type to exclude formatting from (e.g., 'italic').
  * @param rangesToExclude - The array of MarkdownRange objects representing the ranges to exclude from formatting.
  */
-function excludeRangeTypesFromFormatting(ranges: MarkdownRange[], baseMarkdownType: MarkdownType, rangesToExclude: ExtendedMarkdownRange[]): MarkdownRange[] {
+function excludeRangeTypesFromFormatting(ranges: MarkdownRange[], baseMarkdownType: MarkdownType, rangesToExclude: MarkdownRange[]): MarkdownRange[] {
   const newRanges: MarkdownRange[] = [];
 
   let i = 0;
@@ -121,10 +117,10 @@ function excludeRangeTypesFromFormatting(ranges: MarkdownRange[], baseMarkdownTy
           const newRange: MarkdownRange = {
             type: currentRange.type,
             start: currentStart,
-            length: excludeRangeStart - currentStart + (excludeRange.syntaxType === 'opening' ? 1 : 0), // Adjust length so opening syntax ends after the opening syntax
+            length: excludeRangeStart - currentStart + (excludeRange.syntaxType === 'opening' ? 1 : 0), // Adjust the length so the new range from the split ends after the opening syntax
             ...(currentRange?.depth && {depth: currentRange?.depth}),
           };
-          currentRange.start = excludeRangeEnd + (excludeRange.syntaxType === 'closing' ? -1 : 0); // Adjust current range to start before closing syntax
+          currentRange.start = excludeRangeEnd + (excludeRange.syntaxType === 'closing' ? -1 : 0); // Adjust the current range to start before the closing syntax
           currentRange.length = currentEnd - excludeRangeEnd + (excludeRange.syntaxType === 'closing' ? 1 : 0);
 
           if (newRange.length > 0) {
@@ -144,4 +140,3 @@ function excludeRangeTypesFromFormatting(ranges: MarkdownRange[], baseMarkdownTy
 }
 
 export {sortRanges, groupRanges, ungroupRanges, excludeRangeTypesFromFormatting, getRangesToExcludeFormatting};
-export type {ExtendedMarkdownRange};


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Details
<!-- Explanation of the change or anything fishy that is going on -->

This is a follow-up PR to the previous [fix for cursor positioning in inline code markdown.](https://github.com/Expensify/react-native-live-markdown/pull/729) Here, I introduced a mechanism that marks opening and closing syntax, and based on that, it extends the range before opening syntax and the range after closing syntax. Thanks to that, styles are continuous  

### Related Issues
<!-- Please replace GH_LINK with the link to the GitHub issue this Pull Request is related to -->

https://github.com/Expensify/App/issues/69493

### Manual Tests
<!---
Most changes should have accompanying tests. Describe the tests you added or if no tests were added, an explanation about why one was not needed.
--->

1. Open the example app
2. Paste the following text:
```
_test🚀_
~🚀test~
~_tes🚀t_~
_`test🚀`_
~`🚀test`~
~_`tes🚀t`_~
```
3. Verify if strikethrough or italic styles aren't applied to any emoji
4. Verify I styles are properly applied on opening and closing syntaxes of inline code markdowns

### Linked PRs
<!---
Please include links to any updated PRs in repos that must change their package.json version.
--->

https://github.com/Expensify/react-native-live-markdown/pull/729