### PR TITLE
fix: add ReactCommon to `HEADER_SEARCH_PATHS`

### DIFF
--- a/RNLiveMarkdown.podspec
+++ b/RNLiveMarkdown.podspec
@@ -6,10 +6,6 @@ react_native_minor_version = react_native_json['version'].split('.')[1].to_i
 
 pods_root = Pod::Config.instance.project_pods_root
 
-worklets_installed = system(%Q[
-  cd "#{Pod::Config.instance.installation_root}" &&
-  node -e "require.resolve('react-native-worklets/package.json')" > /dev/null 2>&1
-])
 react_native_worklets_path = `cd "#{Pod::Config.instance.installation_root.to_s}" && node --print "require.resolve('react-native-worklets/package.json')"`
 worklets_installed = react_native_worklets_path != ""
 worklets_package_name = worklets_installed ? 'react-native-worklets' : 'react-native-reanimated'
@@ -17,6 +13,9 @@ worklets_package_name = worklets_installed ? 'react-native-worklets' : 'react-na
 react_native_worklets_or_reanimated_node_modules_dir = ENV['REACT_NATIVE_WORKLETS_NODE_MODULES_DIR'] || ENV['REACT_NATIVE_REANIMATED_NODE_MODULES_DIR'] ||
  File.dirname(`cd "#{Pod::Config.instance.installation_root.to_s}" && node --print "require.resolve('#{worklets_package_name}/package.json')"`)
 react_native_worklets_or_reanimated_node_modules_dir_from_pods_root = Pathname.new(react_native_worklets_or_reanimated_node_modules_dir).relative_path_from(pods_root).to_s
+
+react_native_react_common_dir = File.join(react_native_node_modules_dir, 'react-native/ReactCommon')
+react_native_react_common_dir_from_pods_root = Pathname.new(react_native_react_common_dir).relative_path_from(pods_root).to_s
 
 package = JSON.parse(File.read(File.join(__dir__, "package.json")))
 folly_compiler_flags = '-DFOLLY_NO_CONFIG -DFOLLY_MOBILE=1 -DFOLLY_USE_LIBCPP=1 -Wno-comma -Wno-shorten-64-to-32'
@@ -45,6 +44,7 @@ Pod::Spec.new do |s|
     "HEADER_SEARCH_PATHS" => [
       "\"$(PODS_ROOT)/#{react_native_worklets_or_reanimated_node_modules_dir_from_pods_root}/apple\"",
       "\"$(PODS_ROOT)/#{react_native_worklets_or_reanimated_node_modules_dir_from_pods_root}/Common/cpp\"",
+      "\"$(PODS_ROOT)/#{react_native_react_common_dir_from_pods_root}\"",
     ].join(' '),
   }
   if worklets_installed


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Details

While [migrating](https://github.com/Expensify/App/pull/69469) to `react-native-reanimated` v4 and `react-native-worklets` we encountered an iOS build error

```
'jsinspector-modern/InspectorInterfaces.h' file not found
```

It turned out that `react-native-live-markdown` has to include `ReactCommon` in its `HEADER_SEARCH_PATHS`

### Related Issues
<!-- Please replace GH_LINK with the link to the GitHub issue this Pull Request is related to -->

https://github.com/Expensify/App/pull/69469#issuecomment-3433294803

### Manual Tests
<!---
Most changes should have accompanying tests. Describe the tests you added or if no tests were added an explanation about why one was not needed.
--->

n/a

### Linked PRs
<!---
Please include links to any update PRs in repos that must change their package.json version.
--->

https://github.com/Expensify/App/pull/69469