### PR TITLE
Fix input loses focus when switching to another tab

### DIFF
--- a/src/MarkdownTextInput.web.tsx
+++ b/src/MarkdownTextInput.web.tsx
@@ -605,7 +605,9 @@ const MarkdownTextInput = React.forwardRef<MarkdownTextInput, MarkdownTextInputP
     const handleBlur: FocusEventHandler<HTMLDivElement> = useCallback(
       (event) => {
         const e = event as unknown as NativeSyntheticEvent<TextInputFocusEventData>;
-        RNTextInput.State.blurTextInput?.(e.target);
+        if (event.target !== document.activeElement) {
+          RNTextInput.State.blurTextInput?.(e.target);
+        }
         removeSelection();
         currentlyFocusedField.current = null;
         if (onBlur) {


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Details
<!-- Explanation of the change or anything fishy that is going on -->
This happens after this https://github.com/Expensify/react-native-live-markdown/pull/680. In that PR, we want to save the focused text input as outlined in the proposal https://github.com/Expensify/App/issues/61521#issuecomment-2866029202, so that `Keyboard.dismiss` will work on live markdown. But since we can't directly access the text input state, we do it through `RNTextInput.State.focusTextInput` on focus and `RNTextInput.State.blurTextInput` on blur.

When we switch tabs, the input `onBlur` is triggered, so the input is blurred. In normal cases, the input doesn't lose focus even though `onBlur` is called when switching tabs.

### Related Issues
<!-- Please replace GH_LINK with the link to the GitHub issue this Pull Request is related to -->
Expensify: https://github.com/Expensify/App/issues/72458

### Manual Tests
<!---
Most changes should have accompanying tests. Describe the tests you added or if no tests were added an explanation about why one was not needed.
--->
1. Open Web example
2. Focus on the input
3. Switch to another tab
4. Go back to the example tab
5. Verify the input is still focused


https://github.com/user-attachments/assets/f4cf94b4-5219-419d-9f60-031deff24ad7



### Linked PRs
<!---
Please include links to any update PRs in repos that must change their package.json version.
--->