### PR TITLE
fix: set C++ standard to C++20 in CMakeLists.txt

### DIFF
--- a/android/src/main/cpp/CMakeLists.txt
+++ b/android/src/main/cpp/CMakeLists.txt
@@ -3,6 +3,7 @@ project("livemarkdown")
 cmake_minimum_required(VERSION 3.13)
 
 set(CMAKE_VERBOSE_MAKEFILE on)
+set(CMAKE_CXX_STANDARD 20)
 
 include("${REACT_NATIVE_ROOT_DIR}/ReactAndroid/cmake-utils/folly-flags.cmake")
 add_compile_options(${folly_FLAGS})


### PR DESCRIPTION
react-native-worklets needs c++20 from `0.7.x` cc @tjzel if I'm wrong.


### Manual Tests

Try to build live-markdown with rn-worklets `0.7.x`