### PR TITLE
chore: build iOS with `USE_FRAMEWORKS: static`

### DIFF
--- a/.github/workflows/build-ios.yml
+++ b/.github/workflows/build-ios.yml
@@ -66,6 +66,8 @@ jobs:
         run: |
           bundler install
           bundler exec pod install
+        env:
+          USE_FRAMEWORKS: static
 
       - name: Remove .xcode.env.local
         working-directory: example/ios


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Details
<!-- Explanation of the change or anything fishy that is going on -->

PR setting `USE_FRAMEWORKS: static` in iOS GH action to align with Expensify setup

### Related Issues
<!-- Please replace GH_LINK with the link to the GitHub issue this Pull Request is related to -->

no issue

### Manual Tests
<!---
Most changes should have accompanying tests. Describe the tests you added or if no tests were added an explanation about why one was not needed.
--->

Build iOS on Ci and verify it works fine

### Linked PRs
<!---
Please include links to any update PRs in repos that must change their package.json version.
--->