### PR TITLE
fix: replace removed `ShadowNode::Shared` with `std::shared_ptr<const ShadowNode>`

### DIFF
--- a/apple/MarkdownTextInputDecoratorShadowNode.h
+++ b/apple/MarkdownTextInputDecoratorShadowNode.h
@@ -26,9 +26,9 @@ public:
   MarkdownTextInputDecoratorShadowNode(ShadowNode const &sourceShadowNode,
                                        ShadowNodeFragment const &fragment);
 
-  void appendChild(const ShadowNode::Shared &child) override;
+  void appendChild(const std::shared_ptr<const ShadowNode> &child) override;
   void replaceChild(const ShadowNode &oldChild,
-                    const ShadowNode::Shared &newChild,
+                    const std::shared_ptr<const ShadowNode> &newChild,
                     size_t suggestedIndex = SIZE_MAX) override;
   void layout(LayoutContext layoutContext) override;
   Size

--- a/apple/MarkdownTextInputDecoratorShadowNode.mm
+++ b/apple/MarkdownTextInputDecoratorShadowNode.mm
@@ -93,14 +93,14 @@ void MarkdownTextInputDecoratorShadowNode::overwriteMeasureCallbackConnector() {
 }
 
 void MarkdownTextInputDecoratorShadowNode::appendChild(
-    const ShadowNode::Shared &child) {
+    const std::shared_ptr<const ShadowNode> &child) {
   YogaLayoutableShadowNode::appendChild(child);
 
   overwriteMeasureCallbackConnector();
 }
 
 void MarkdownTextInputDecoratorShadowNode::replaceChild(
-    const ShadowNode &oldChild, const ShadowNode::Shared &newChild,
+    const ShadowNode &oldChild, const std::shared_ptr<const ShadowNode> &newChild,
     size_t suggestedIndex) {
   YogaLayoutableShadowNode::replaceChild(oldChild, newChild, suggestedIndex);
 


### PR DESCRIPTION
### Details
Upstream React Native removed the `ShadowNode::Shared` type alias, which broke the iOS Fabric build on Expo SDK 56+ / RN nightly with errors like `no type named 'Shared' in 'facebook::react::ShadowNode'`. This replaces the four usages of `ShadowNode::Shared` in `MarkdownTextInputDecoratorShadowNode` (`.h` and `.mm`) with `std::shared_ptr<const ShadowNode>`, matching the current `YogaLayoutableShadowNode::appendChild` / `replaceChild` override signatures.

Other `::Shared` usages in the project (`ShadowNodeFamily::Shared`, `Props::Shared`) are still defined upstream and remain unchanged.

### Related Issues
Closes #755

### Manual Tests
- [ ] Build the example app on iOS with the New Architecture enabled against an RN version that removed `ShadowNode::Shared` (Expo SDK 56 / RN nightly).
- [ ] Build the example app on iOS against the currently-pinned RN 0.83.1 to confirm no regression on the older signature.

### Linked PRs
N/A