### PR TITLE
fix(ios): persist RCTMarkdownUtils across shadow node clones to prevent AppHang

### DIFF
--- a/apple/MarkdownTextInputDecoratorShadowNode.h
+++ b/apple/MarkdownTextInputDecoratorShadowNode.h
@@ -48,6 +48,12 @@ private:
                                                  YGMeasureMode heightMode);
   static YogaLayoutableShadowNode &
   shadowNodeFromContext(YGNodeConstRef yogaNode);
+
+  // Persisted RCTMarkdownUtils instance shared across shadow node clones so
+  // that MarkdownParser's one-entry memo cache (keyed on text + parserId)
+  // survives repeated Yoga measure callbacks instead of being discarded on
+  // every call to applyMarkdownFormattingToTextInputState.
+  mutable std::shared_ptr<void> markdownUtils_;
 };
 
 } // namespace react

--- a/apple/MarkdownTextInputDecoratorShadowNode.mm
+++ b/apple/MarkdownTextInputDecoratorShadowNode.mm
@@ -32,6 +32,13 @@ MarkdownTextInputDecoratorShadowNode::MarkdownTextInputDecoratorShadowNode(
     ShadowNode const &sourceShadowNode,
     ShadowNodeFragment const &fragment)
     : ConcreteViewShadowNode(sourceShadowNode, fragment) {
+  // Carry the persisted RCTMarkdownUtils over from the source node so the
+  // MarkdownParser memo cache survives the frequent cloning that happens
+  // during layout and re-render cycles.
+  const auto &source =
+      static_cast<const MarkdownTextInputDecoratorShadowNode &>(sourceShadowNode);
+  markdownUtils_ = source.markdownUtils_;
+
   initialize();
   makeChildNodeMutable();
   
@@ -182,10 +189,19 @@ void MarkdownTextInputDecoratorShadowNode::applyMarkdownFormattingToTextInputSta
   const auto defaultNSTextAttributes =
       RCTNSTextAttributesFromTextAttributes(defaultTextAttributes);
 
-  // this can possibly be optimized
+  // Lazily create and persist the RCTMarkdownUtils instance so the MarkdownParser
+  // one-entry memo cache (keyed on text + parserId) survives repeated Yoga measure
+  // callbacks. Previously a fresh utils/parser was allocated on every call,
+  // discarding the cache and forcing a full JSI re-parse each time.
+  if (!markdownUtils_) {
+    RCTMarkdownUtils *freshUtils = [[RCTMarkdownUtils alloc] init];
+    markdownUtils_ = std::shared_ptr<void>(
+        (__bridge_retained void *)freshUtils, [](void *p) { CFRelease(p); });
+  }
+  RCTMarkdownUtils *utils = (__bridge RCTMarkdownUtils *)markdownUtils_.get();
+
   RCTMarkdownStyle *markdownStyle =
       [[RCTMarkdownStyle alloc] initWithStruct:decoratorProps.markdownStyle];
-  RCTMarkdownUtils *utils = [[RCTMarkdownUtils alloc] init];
   [utils setMarkdownStyle:markdownStyle];
   [utils setParserId:[NSNumber numberWithInt:decoratorProps.parserId]];
 

--- a/apple/MarkdownTextInputDecoratorShadowNode.mm
+++ b/apple/MarkdownTextInputDecoratorShadowNode.mm
@@ -202,8 +202,7 @@ void MarkdownTextInputDecoratorShadowNode::applyMarkdownFormattingToTextInputSta
 
   RCTMarkdownStyle *markdownStyle =
       [[RCTMarkdownStyle alloc] initWithStruct:decoratorProps.markdownStyle];
-  [utils setMarkdownStyle:markdownStyle];
-  [utils setParserId:[NSNumber numberWithInt:decoratorProps.parserId]];
+  NSNumber *parserId = [NSNumber numberWithInt:decoratorProps.parserId];
 
   // convert the attibuted string stored in state to
   // NSAttributedString
@@ -244,7 +243,10 @@ void MarkdownTextInputDecoratorShadowNode::applyMarkdownFormattingToTextInputSta
 
     // apply markdown
     NSMutableAttributedString *newString = [nsAttributedString mutableCopy];
-    [utils applyMarkdownFormatting:newString withDefaultTextAttributes:defaultNSTextAttributes];
+    [utils applyMarkdownFormatting:newString
+        withDefaultTextAttributes:defaultNSTextAttributes
+                    markdownStyle:markdownStyle
+                         parserId:parserId];
 
     // create a clone of the old TextInputState and update the
     // attributed string box to point to the string with markdown
@@ -256,7 +258,10 @@ void MarkdownTextInputDecoratorShadowNode::applyMarkdownFormattingToTextInputSta
 
     // apply markdown
     NSMutableAttributedString *newString = [nsAttributedString mutableCopy];
-    [utils applyMarkdownFormatting:newString withDefaultTextAttributes:defaultNSTextAttributes];
+    [utils applyMarkdownFormatting:newString
+        withDefaultTextAttributes:defaultNSTextAttributes
+                    markdownStyle:markdownStyle
+                         parserId:parserId];
 
     // create a clone of the old TextInputState and update the
     // attributed string box to point to the string with markdown

--- a/apple/RCTMarkdownUtils.h
+++ b/apple/RCTMarkdownUtils.h
@@ -11,6 +11,15 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)applyMarkdownFormatting:(nonnull NSMutableAttributedString *)attributedString
       withDefaultTextAttributes:(nonnull NSDictionary<NSAttributedStringKey, id> *)defaultTextAttributes;
 
+// Atomically sets the style/parser and applies formatting under a single lock.
+// Use this from the shadow node measure path, where one RCTMarkdownUtils
+// instance is shared across shadow node clones and may be accessed from
+// concurrent Fabric commits/layout passes.
+- (void)applyMarkdownFormatting:(nonnull NSMutableAttributedString *)attributedString
+      withDefaultTextAttributes:(nonnull NSDictionary<NSAttributedStringKey, id> *)defaultTextAttributes
+                  markdownStyle:(nonnull RCTMarkdownStyle *)markdownStyle
+                       parserId:(nonnull NSNumber *)parserId;
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/apple/RCTMarkdownUtils.mm
+++ b/apple/RCTMarkdownUtils.mm
@@ -34,4 +34,22 @@
                            withMarkdownStyle:_markdownStyle];
 }
 
+- (void)applyMarkdownFormatting:(nonnull NSMutableAttributedString *)attributedString
+      withDefaultTextAttributes:(nonnull NSDictionary<NSAttributedStringKey, id> *)defaultTextAttributes
+                  markdownStyle:(nonnull RCTMarkdownStyle *)markdownStyle
+                       parserId:(nonnull NSNumber *)parserId
+{
+  // Keep the style/parserId assignment and the parse+format together under a
+  // single lock. The shadow node shares one instance across clones, and Fabric
+  // runs commits/layout optimistically on multiple threads, so without this the
+  // setters could interleave with another thread's parse/format and apply the
+  // wrong parserId/style for a frame. `@synchronized` is recursive, so nesting
+  // with `MarkdownParser`'s own `@synchronized(self)` in `parse:` is safe.
+  @synchronized (self) {
+    _markdownStyle = markdownStyle;
+    _parserId = parserId;
+    [self applyMarkdownFormatting:attributedString withDefaultTextAttributes:defaultTextAttributes];
+  }
+}
+
 @end


### PR DESCRIPTION
### Details

On every Yoga measure pass, `applyMarkdownFormattingToTextInputState` was allocating a **fresh** `RCTMarkdownUtils` / `MarkdownParser` instance. `MarkdownParser` has a one-entry memo cache keyed on `{text, parserId}` — because a new instance was created on each call, the cache was discarded immediately after every parse, forcing a **full JSI re-parse** of the entire input string on the main thread every time.

Yoga calls the measure callback **multiple times per layout pass**. For inputs with complex markdown, the cumulative cost of `N × full-parse` exceeded iOS's ~2 s watchdog → AppHang.

**Fix:** Add a `mutable std::shared_ptr<void> markdownUtils_` member to `MarkdownTextInputDecoratorShadowNode`:
- Lazily initialised on first use inside `applyMarkdownFormattingToTextInputState`.
- Carried through the clone constructor — when React clones a shadow node during re-render / layout, the new instance inherits the pointer, so the `RCTMarkdownUtils` (and its parser cache) is never discarded mid-layout.

Unchanged text now hits the parser's cache and skips the expensive JSI call entirely.

### Related Issues

https://github.com/Expensify/App/issues/93831

### Manual Tests

1. Paste the following comment into the composer input: https://expensify.slack.com/archives/C05LX9D6E07/p1782316444025709?thread_ts=1782312343.503839&cid=C05LX9D6E07
2. Open and close the keyboard.
3. Verify that the app doesn't crash.


https://github.com/user-attachments/assets/5f1623b4-5e0b-4472-b984-1957f83d4258

https://github.com/user-attachments/assets/86c13fef-f6cc-4aaf-9c9a-3bd595ee238b