### PR TITLE
Upgrade expensify-common to 2.0.189

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -46,7 +46,7 @@
         "eslint-plugin-promise": "^6.1.1",
         "eslint-plugin-react-native": "^5.0.0",
         "eslint-plugin-tsdoc": "^0.2.17",
-        "expensify-common": "2.0.148",
+        "expensify-common": "2.0.189",
         "jest": "^29.6.3",
         "jest-environment-jsdom": "^29.7.0",
         "nodemon": "^3.1.3",
@@ -66,7 +66,7 @@
         "node": ">= 18.0.0"
       },
       "peerDependencies": {
-        "expensify-common": ">=2.0.148",
+        "expensify-common": ">=2.0.189",
         "react": "*",
         "react-native": "*",
         "react-native-worklets": ">=0.7.0"
@@ -114,6 +114,66 @@
       "license": "MIT",
       "dependencies": {
         "@types/react": "*"
+      }
+    },
+    "example/node_modules/expensify-common": {
+      "version": "2.0.148",
+      "resolved": "https://registry.npmjs.org/expensify-common/-/expensify-common-2.0.148.tgz",
+      "integrity": "sha512-0FhpNGukBeAiRNSLflPVD5ofXuns6gLcp+/onwuAHQvlueugTk1tMrvx622EAXVoXwndpcJpTX0w8TQDOFc6lQ==",
+      "license": "MIT",
+      "dependencies": {
+        "awesome-phonenumber": "^5.4.0",
+        "classnames": "2.5.0",
+        "clipboard": "2.0.11",
+        "html-entities": "^2.5.2",
+        "jquery": "3.6.0",
+        "localforage": "^1.10.0",
+        "lodash": "4.17.21",
+        "prop-types": "15.8.1",
+        "react": "16.12.0",
+        "react-dom": "16.12.0",
+        "semver": "^7.6.3",
+        "simply-deferred": "git+https://github.com/Expensify/simply-deferred.git#77a08a95754660c7bd6e0b6979fdf84e8e831bf5",
+        "ua-parser-js": "^1.0.38"
+      }
+    },
+    "example/node_modules/expensify-common/node_modules/react": {
+      "version": "16.12.0",
+      "resolved": "https://registry.npmjs.org/react/-/react-16.12.0.tgz",
+      "integrity": "sha512-fglqy3k5E+81pA8s+7K0/T3DBCF0ZDOher1elBFzF7O6arXJgzyu/FW+COxFvAWXJoJN9KIZbT2LXlukwphYTA==",
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.1.0",
+        "object-assign": "^4.1.1",
+        "prop-types": "^15.6.2"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "example/node_modules/expensify-common/node_modules/react-dom": {
+      "version": "16.12.0",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-16.12.0.tgz",
+      "integrity": "sha512-LMxFfAGrcS3kETtQaCkTKjMiifahaMySFDn71fZUNpPHZQEzmk/GiAeIT8JSOrHB23fnuCOMruL2a8NYlw+8Gw==",
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.1.0",
+        "object-assign": "^4.1.1",
+        "prop-types": "^15.6.2",
+        "scheduler": "^0.18.0"
+      },
+      "peerDependencies": {
+        "react": "^16.0.0"
+      }
+    },
+    "example/node_modules/scheduler": {
+      "version": "0.18.0",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.18.0.tgz",
+      "integrity": "sha512-agTSHR1Nbfi6ulI0kYNK0203joW2Y5W4po4l+v03tOoiJKpTBbxpNhWDvqc/4IcOw+KLmSiQLTasZ4cab2/UWQ==",
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.1.0",
+        "object-assign": "^4.1.1"
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -197,7 +257,6 @@
       "integrity": "sha512-dtnzmSjXfgL/HDgMcmsLSzyGbEosi4DrGWoCNfuI+W4IkVJw6izpTe7LtOdwAXnkDqw5yweboYCTkM2rQizCng==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@nicolo-ribaudo/eslint-scope-5-internals": "5.1.1-v1",
         "eslint-visitor-keys": "^2.1.0",
@@ -2269,7 +2328,6 @@
       "integrity": "sha512-269Z39MS6wVJtsoUl10L60WdkhJVdPG24Q4eZTH3nnF6lpvSShEK3wQjDX9JRWAUPvPh7COouPpU9IrqaZFvtQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "ajv": "^6.12.4",
         "debug": "^4.3.2",
@@ -3876,7 +3934,6 @@
       "integrity": "sha512-rYKilwgzQ7/imScn3M9/pFfUf4I1AZEH3KhyJmtPdE2zfaXAn2mFfUy4FbKewzc2We5y/LlKLj36fWJLKC2SIQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@octokit/auth-token": "^3.0.0",
         "@octokit/graphql": "^5.0.0",
@@ -6190,7 +6247,6 @@
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.14.1.tgz",
       "integrity": "sha512-OvQ/2pUDKmgfCg++xsTX1wGxfTaszcHVcTctW4UJB4hibJx2HXxxO5UmVgyjMa+ZDsiaf5wWLXYpRWMmBI0QHg==",
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -7429,7 +7485,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -10037,7 +10092,6 @@
       "deprecated": "This version is no longer supported. Please see https://eslint.org/version-support for other options.",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.6.1",
@@ -10501,7 +10555,6 @@
       "integrity": "sha512-ixmkI62Rbc2/w8Vfxyh1jQRTdRTF52VxwRVHl/ykPAmqG+Nb7/kNn+byLP0LxPgI7zWA16Jt82SybJInmMia3A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@rtsao/scc": "^1.1.0",
         "array-includes": "^3.1.8",
@@ -10786,7 +10839,6 @@
       "integrity": "sha512-scB3nz4WmG75pV8+3eRUQOHZlNSUhFNq37xnpgRkCCELU3XMvXAxLk1eqWWyE22Ki4Q01Fnsw9BA3cJHDPgn2Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "aria-query": "^5.3.2",
         "array-includes": "^3.1.8",
@@ -10879,7 +10931,6 @@
       "integrity": "sha512-Qteup0SqU15kdocexFNAJMvCJEfa2xUKNV4CC1xsVMrIIqEy3SQ/rqyxCWNzfrd3/ldy6HMlD2e0JDVpDg2qIA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "array-includes": "^3.1.8",
         "array.prototype.findlast": "^1.2.5",
@@ -10913,7 +10964,6 @@
       "integrity": "sha512-QzliNJq4GinDBcD8gPB5v0wh6g8q3SUi6EFF0x8N/BL9PoVs0atuGc47ozMRyOWAKdwaZ5OnbOEa3WR+dSGKuQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=10"
       },
@@ -11353,9 +11403,10 @@
       }
     },
     "node_modules/expensify-common": {
-      "version": "2.0.148",
-      "resolved": "https://registry.npmjs.org/expensify-common/-/expensify-common-2.0.148.tgz",
-      "integrity": "sha512-0FhpNGukBeAiRNSLflPVD5ofXuns6gLcp+/onwuAHQvlueugTk1tMrvx622EAXVoXwndpcJpTX0w8TQDOFc6lQ==",
+      "version": "2.0.189",
+      "resolved": "https://registry.npmjs.org/expensify-common/-/expensify-common-2.0.189.tgz",
+      "integrity": "sha512-w7AJQDpRdeyCvWxOhGPeWTckmVKOH2RBN2/dwUkNCm5tszeS2ELissz3YoQt02Meon14CXEbC1SAqiUw7Kca8w==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "awesome-phonenumber": "^5.4.0",
@@ -11364,8 +11415,9 @@
         "html-entities": "^2.5.2",
         "jquery": "3.6.0",
         "localforage": "^1.10.0",
-        "lodash": "4.17.21",
+        "lodash": "4.18.1",
         "prop-types": "15.8.1",
+        "punycode": "^2.3.1",
         "react": "16.12.0",
         "react-dom": "16.12.0",
         "semver": "^7.6.3",
@@ -11373,12 +11425,19 @@
         "ua-parser-js": "^1.0.38"
       }
     },
+    "node_modules/expensify-common/node_modules/lodash": {
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
+      "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/expensify-common/node_modules/react": {
       "version": "16.12.0",
       "resolved": "https://registry.npmjs.org/react/-/react-16.12.0.tgz",
       "integrity": "sha512-fglqy3k5E+81pA8s+7K0/T3DBCF0ZDOher1elBFzF7O6arXJgzyu/FW+COxFvAWXJoJN9KIZbT2LXlukwphYTA==",
+      "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
         "object-assign": "^4.1.1",
@@ -11392,6 +11451,7 @@
       "version": "16.12.0",
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-16.12.0.tgz",
       "integrity": "sha512-LMxFfAGrcS3kETtQaCkTKjMiifahaMySFDn71fZUNpPHZQEzmk/GiAeIT8JSOrHB23fnuCOMruL2a8NYlw+8Gw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "loose-envify": "^1.1.0",
@@ -11407,6 +11467,7 @@
       "version": "0.18.0",
       "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.18.0.tgz",
       "integrity": "sha512-agTSHR1Nbfi6ulI0kYNK0203joW2Y5W4po4l+v03tOoiJKpTBbxpNhWDvqc/4IcOw+KLmSiQLTasZ4cab2/UWQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "loose-envify": "^1.1.0",
@@ -18145,7 +18206,6 @@
       "integrity": "sha512-tdN8qQGvNjw4CHbY+XXk0JgCXn9QiF21a55rBe5LJAU+kDyC4WQn4+awm2Xfk2lQMk5fKup9XgzTZtGkjBdP9Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "prettier": "bin-prettier.js"
       },
@@ -18574,7 +18634,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.3.tgz",
       "integrity": "sha512-Ku/hhYbVjOQnXDZFv2+RibmLFGwFdeeKHFcOTlrt7xplBnya5OGn/hIRDsqDiSUcfORsDC7MPxwork8jBwsIWA==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -18615,7 +18674,6 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.3.tgz",
       "integrity": "sha512-yELu4WmLPw5Mr/lmeEpox5rw3RETacE++JgHqQzd2dg+YbJuat3jH4ingc+WPZhxaoFzdv9y33G+F7Nl5O0GBg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -19465,7 +19523,6 @@
       "resolved": "https://registry.npmjs.org/react-native-web/-/react-native-web-0.20.0.tgz",
       "integrity": "sha512-OOSgrw+aON6R3hRosCau/xVxdLzbjEcsLysYedka0ZON4ZZe6n9xgeN9ZkoejhARM36oTlUgHIQqxGutEJ9Wxg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.18.6",
         "@react-native/normalize-colors": "^0.74.1",
@@ -19657,7 +19714,6 @@
       "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.14.2.tgz",
       "integrity": "sha512-jCvmsr+1IUSMUyzOkRcvnVbX3ZYC6g9TDrDbFuFmRDq7PD4yaGbLKNQL6k2jnArV8hjYxh7hVhAZB6s9HDGpZA==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -20046,7 +20102,6 @@
       "integrity": "sha512-lZwoGEnKYKwGnfxxlA7vtR7vvozPrOSsIgQaHO4bgQ5ARbG3IA6Dmo0IVusv6nR1KmnjH70QIeNAgsWs6Ji/tw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@iarna/toml": "2.2.5",
         "@octokit/rest": "19.0.11",
@@ -22629,7 +22684,6 @@
       "integrity": "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==",
       "devOptional": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -23557,7 +23611,6 @@
       "integrity": "sha512-k7Nwx6vuWx1IJ9Bjuf4Zt1PEllcwe7cls3VNzm4CQ1/hgtFUK2bRNG3rvnpPUhFjmqJKAKtjV576KnUkHocg/g==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }
@@ -24141,7 +24194,6 @@
       "resolved": "https://registry.npmjs.org/expo/-/expo-56.0.6.tgz",
       "integrity": "sha512-zcFa/+6hGtzCUlcrGiusvzr/PIoNBAnjj4PlAFrvbAOZcVOj6c9Mp7lRSn9XYJk8Ok6pssQWt6dP4llJlKmYRQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.20.0",
         "@expo/cli": "^56.1.12",
@@ -24228,7 +24280,6 @@
       "resolved": "https://registry.npmjs.org/expo-server/-/expo-server-56.0.4.tgz",
       "integrity": "sha512-4dJ57KuAwDl7eQGD6aG9kTzBIftWAfHH1+6Zxy7NcPCBrKYis3/H5enGUz1asH8HHhONXfJ5BdJqfEWAEAgWxA==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=20.16.0"
       }
@@ -24537,7 +24588,6 @@
       "resolved": "https://registry.npmjs.org/expo-constants/-/expo-constants-56.0.16.tgz",
       "integrity": "sha512-6tsiN+gmTUPp/atyA+uY9Tg8VOdXdmb4s/3TVGolfn6A/oCAraw1pcPZX5XllyD+xUguxB6eBSFAT8494hZVMA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@expo/env": "~2.3.0"
       },
@@ -24561,7 +24611,6 @@
       "resolved": "https://registry.npmjs.org/expo-font/-/expo-font-56.0.5.tgz",
       "integrity": "sha512-WLoDu9hlEgPRKXJRR01HFLJ6Z2tFcORX/WFPRYBndmYc5kjQrFGH/j4BRaF3aBRPyYEAUXiUJybNLXkKCwEXQw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "fontfaceobserver": "^2.1.0"
       },

--- a/package.json
+++ b/package.json
@@ -92,7 +92,7 @@
     "eslint-plugin-promise": "^6.1.1",
     "eslint-plugin-react-native": "^5.0.0",
     "eslint-plugin-tsdoc": "^0.2.17",
-    "expensify-common": "2.0.148",
+    "expensify-common": "2.0.189",
     "jest": "^29.6.3",
     "jest-environment-jsdom": "^29.7.0",
     "nodemon": "^3.1.3",
@@ -109,7 +109,7 @@
     "typescript": "^5.8.3"
   },
   "peerDependencies": {
-    "expensify-common": ">=2.0.148",
+    "expensify-common": ">=2.0.189",
     "react": "*",
     "react-native": "*",
     "react-native-worklets": ">=0.7.0"

--- a/src/__tests__/parseExpensiMark.test.ts
+++ b/src/__tests__/parseExpensiMark.test.ts
@@ -39,12 +39,10 @@ test('no formatting', () => {
 
 describe('parsing error', () => {
   expect(`> [exa\nmple.com](https://example.com)`).toBeParsedAs([
-    {type: 'blockquote', start: 0, length: 37},
+    {type: 'blockquote', start: 0, length: 6},
     {type: 'syntax', start: 0, length: 1},
-    {type: 'syntax', start: 2, length: 1},
-    {type: 'syntax', start: 15, length: 2},
+    {type: 'link', start: 7, length: 8},
     {type: 'link', start: 17, length: 19},
-    {type: 'syntax', start: 36, length: 1},
   ]);
 });
 

--- a/src/parseExpensiMark.ts
+++ b/src/parseExpensiMark.ts
@@ -2,7 +2,7 @@
 
 import {Platform} from 'react-native';
 import {ExpensiMark} from 'expensify-common';
-import {unescapeText} from 'expensify-common/dist/utils';
+import {unescapeText} from 'expensify-common/utils';
 import {decode} from 'html-entities';
 import type {WorkletFunction} from 'react-native-worklets';
 import {groupRanges, sortRanges, excludeRangeTypesFromFormatting, getRangesToExcludeFormatting} from './rangeUtils';

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -11,7 +11,7 @@
     "jsx": "react",
     "lib": ["esnext", "dom"],
     "module": "esnext",
-    "moduleResolution": "node",
+    "moduleResolution": "bundler",
     "noFallthroughCasesInSwitch": true,
     "noImplicitReturns": true,
     "noImplicitUseStrict": false,


### PR DESCRIPTION
### Details
Upgrades `expensify-common` from 2.0.148 to 2.0.189 to pick up canonical subpath package exports ([expensify-common#924](https://github.com/Expensify/expensify-common/pull/924)).

- Switches `unescapeText` import from `expensify-common/dist/utils` to `expensify-common/utils`
- Updates TypeScript `moduleResolution` to `bundler` so the new package exports resolve during typechecking
- Updates one `parseExpensiMark` test expectation for newer `ExpensiMark` blockquote/link parsing behavior

This unblocks removing the `expensify-common/dist/utils` webpack/jest shims in [App#93222](https://github.com/Expensify/App/pull/93222) once a new live-markdown release is published and consumed by App.

### Related Issues
N/A

### Manual Tests
1. Run `npm test` and confirm all test suites pass.
2. Run `npx tsc --noEmit` and confirm typechecking passes.

### Linked PRs
- https://github.com/Expensify/App/pull/93222
