### PR TITLE
fix: Android build with React Native 0.86

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -129,6 +129,8 @@ android {
           java.srcDirs += "src/reactNativeVersionPatch/CustomMountingManager/79"
       } else if (REACT_NATIVE_MINOR_VERSION == 80) {
           java.srcDirs += "src/reactNativeVersionPatch/CustomMountingManager/80"
+      } else if (REACT_NATIVE_MINOR_VERSION <= 85) {
+          java.srcDirs += "src/reactNativeVersionPatch/CustomMountingManager/81"
       } else {
           java.srcDirs += "src/reactNativeVersionPatch/CustomMountingManager/latest"
       }

--- a/android/src/reactNativeVersionPatch/CustomMountingManager/81/com/expensify/livemarkdown/CustomFabricUIManager.java
+++ b/android/src/reactNativeVersionPatch/CustomMountingManager/81/com/expensify/livemarkdown/CustomFabricUIManager.java
@@ -7,11 +7,15 @@ import android.text.SpannableStringBuilder;
 
 import androidx.annotation.Nullable;
 
+import com.facebook.infer.annotation.Assertions;
 import com.facebook.jni.annotations.DoNotStrip;
 import com.facebook.react.bridge.ReactApplicationContext;
+import com.facebook.react.bridge.ReactContext;
 import com.facebook.react.bridge.ReadableMap;
 import com.facebook.react.common.mapbuffer.ReadableMapBuffer;
 import com.facebook.react.fabric.FabricUIManager;
+import com.facebook.react.fabric.mounting.MountingManager;
+import com.facebook.react.fabric.mounting.SurfaceMountingManager;
 import com.facebook.react.uimanager.ViewManagerRegistry;
 import com.facebook.react.uimanager.events.BatchEventDispatchedListener;
 import com.facebook.react.views.text.TextLayoutManager;
@@ -22,26 +26,29 @@ import java.lang.reflect.Field;
 public class CustomFabricUIManager extends FabricUIManager {
 
   private final ReactApplicationContext mReactApplicationContext;
+  private final MountingManager mMountingManager;
   private final MarkdownUtils mMarkdownUtils;
 
   public CustomFabricUIManager(
     ReactApplicationContext reactContext,
     ViewManagerRegistry viewManagerRegistry,
     BatchEventDispatchedListener batchEventDispatchedListener,
+    MountingManager mountingManager,
     ReadableMap markdownProps,
     int parserId
   ) {
     super(reactContext, viewManagerRegistry, batchEventDispatchedListener);
 
     this.mReactApplicationContext = reactContext;
+    this.mMountingManager = mountingManager;
 
     this.mMarkdownUtils = new MarkdownUtils(reactContext);
     this.mMarkdownUtils.setMarkdownStyle(new MarkdownStyle(markdownProps, reactContext));
     this.mMarkdownUtils.setParserId(parserId);
   }
 
-  @Override
   public long measureText(
+    int surfaceId,
     ReadableMapBuffer attributedString,
     ReadableMapBuffer paragraphAttributes,
     float minWidth,
@@ -50,8 +57,22 @@ public class CustomFabricUIManager extends FabricUIManager {
     float maxHeight,
     @Nullable float[] attachmentsPositions) {
 
+    ReactContext context;
+    if (surfaceId > 0) {
+      SurfaceMountingManager surfaceMountingManager =
+        mMountingManager.getSurfaceManagerEnforced(surfaceId, "measureText");
+      if (surfaceMountingManager.isStopped()) {
+        return 0;
+      }
+      context = surfaceMountingManager.getContext();
+      Assertions.assertNotNull(
+        context, "Context in SurfaceMountingManager is null. surfaceId: " + surfaceId);
+    } else {
+      context = mReactApplicationContext;
+    }
+
     return TextLayoutManager.measureText(
-      mReactApplicationContext.getAssets(),
+      context,
       attributedString,
       paragraphAttributes,
       getYogaSize(minWidth, maxWidth),
@@ -65,18 +86,27 @@ public class CustomFabricUIManager extends FabricUIManager {
   }
 
   public static FabricUIManager create(FabricUIManager source, ReadableMap markdownProps, int parserId) {
+    Class<? extends FabricUIManager> uiManagerClass = source.getClass();
+
     try {
+      Field mountingManagerField = uiManagerClass.getDeclaredField("mMountingManager");
+      mountingManagerField.setAccessible(true);
+
+      MountingManager sourceMountingManager = readPrivateField(source, "mMountingManager");
       ReactApplicationContext reactContext = readPrivateField(source, "mReactApplicationContext");
       ViewManagerRegistry viewManagerRegistry = readPrivateField(source, "mViewManagerRegistry");
       BatchEventDispatchedListener batchEventDispatchedListener = readPrivateField(source, "mBatchEventDispatchedListener");
 
-      return new CustomFabricUIManager(
+      FabricUIManager customFabricUIManager = new CustomFabricUIManager(
         reactContext,
         viewManagerRegistry,
         batchEventDispatchedListener,
+        sourceMountingManager,
         markdownProps,
         parserId
       );
+
+      return customFabricUIManager;
     } catch (NoSuchFieldException | IllegalAccessException e) {
       throw new RuntimeException("[LiveMarkdown] Cannot read data from FabricUIManager");
     }

--- a/android/src/reactNativeVersionPatch/CustomMountingManager/81/com/expensify/livemarkdown/CustomFabricUIManager.java
+++ b/android/src/reactNativeVersionPatch/CustomMountingManager/81/com/expensify/livemarkdown/CustomFabricUIManager.java
@@ -47,6 +47,7 @@ public class CustomFabricUIManager extends FabricUIManager {
     this.mMarkdownUtils.setParserId(parserId);
   }
 
+  @Override
   public long measureText(
     int surfaceId,
     ReadableMapBuffer attributedString,
@@ -86,12 +87,7 @@ public class CustomFabricUIManager extends FabricUIManager {
   }
 
   public static FabricUIManager create(FabricUIManager source, ReadableMap markdownProps, int parserId) {
-    Class<? extends FabricUIManager> uiManagerClass = source.getClass();
-
     try {
-      Field mountingManagerField = uiManagerClass.getDeclaredField("mMountingManager");
-      mountingManagerField.setAccessible(true);
-
       MountingManager sourceMountingManager = readPrivateField(source, "mMountingManager");
       ReactApplicationContext reactContext = readPrivateField(source, "mReactApplicationContext");
       ViewManagerRegistry viewManagerRegistry = readPrivateField(source, "mViewManagerRegistry");
@@ -108,7 +104,7 @@ public class CustomFabricUIManager extends FabricUIManager {
 
       return customFabricUIManager;
     } catch (NoSuchFieldException | IllegalAccessException e) {
-      throw new RuntimeException("[LiveMarkdown] Cannot read data from FabricUIManager");
+      throw new RuntimeException("[LiveMarkdown] Cannot read data from FabricUIManager", e);
     }
   }
 

--- a/android/src/reactNativeVersionPatch/CustomMountingManager/latest/com/expensify/livemarkdown/CustomFabricUIManager.java
+++ b/android/src/reactNativeVersionPatch/CustomMountingManager/latest/com/expensify/livemarkdown/CustomFabricUIManager.java
@@ -78,7 +78,7 @@ public class CustomFabricUIManager extends FabricUIManager {
         parserId
       );
     } catch (NoSuchFieldException | IllegalAccessException e) {
-      throw new RuntimeException("[LiveMarkdown] Cannot read data from FabricUIManager");
+      throw new RuntimeException("[LiveMarkdown] Cannot read data from FabricUIManager", e);
     }
   }
 


### PR DESCRIPTION
### Details
React Native 0.86 changed the signature of `FabricUIManager.measureText` on Android – it no longer takes `surfaceId` and passes `AssetManager` instead of `ReactContext` to `TextLayoutManager.measureText`, which broke compilation of `CustomFabricUIManager`.

This PR renames the current `latest` version patch to `81` (valid for RN 0.81–0.85) and adds a new `latest` patch matching the RN 0.86+ signature.

### Related Issues
Closes #761.

### Manual Tests
- Compiled the new `latest` patch against `react-android:0.86.0` – builds successfully (previously failed with `ReactContext cannot be converted to AssetManager`)
- Compiled the `81` patch against `react-android:0.85.3` and ran `:expensify_react-native-live-markdown:compileDebugJavaWithJavac` in the example app – no regression

### Linked PRs
None

🤖 Generated with [Claude Code](https://claude.com/claude-code)