### PR TITLE
fix: clamp markdown cursor range offsets

### DIFF
--- a/src/web/utils/cursorUtils.ts
+++ b/src/web/utils/cursorUtils.ts
@@ -3,6 +3,14 @@ import {isChildOfMultilineMarkdownElement} from './blockUtils';
 import {findHTMLElementInTree, getTreeNodeByIndex} from './treeUtils';
 import type {TreeNode} from './treeUtils';
 
+function getMaxRangeOffset(node: ChildNode): number {
+  return node.nodeType === Node.TEXT_NODE ? (node.textContent ?? '').length : node.childNodes.length;
+}
+
+function getClampedRangeOffset(node: ChildNode, offset: number): number {
+  return Math.max(0, Math.min(offset, getMaxRangeOffset(node)));
+}
+
 function setCursorPosition(target: MarkdownTextInputElement, startIndex: number, endIndex: number | null = null, shouldScrollIntoView = false) {
   // We don't want to move the cursor if the target is not focused
   if (!target.tree || target !== document.activeElement) {
@@ -29,14 +37,16 @@ function setCursorPosition(target: MarkdownTextInputElement, startIndex: number,
     range.setStartBefore(startTreeNode.element);
   } else {
     const startElement = startTreeNode.element;
-    range.setStart((startElement.childNodes[0] || startElement) as ChildNode, start - startTreeNode.start);
+    const startNode = (startElement.childNodes[0] || startElement) as ChildNode;
+    range.setStart(startNode, getClampedRangeOffset(startNode, start - startTreeNode.start));
   }
 
   if (endTreeNode.type === 'br') {
     range.setEndBefore(endTreeNode.element);
   } else {
     const endElement = endTreeNode.element;
-    range.setEnd((endElement.childNodes[0] || endElement) as ChildNode, (end || start) - endTreeNode.start);
+    const endNode = (endElement.childNodes[0] || endElement) as ChildNode;
+    range.setEnd(endNode, getClampedRangeOffset(endNode, (end || start) - endTreeNode.start));
   }
 
   if (!end) {

--- a/src/web/utils/cursorUtils.ts
+++ b/src/web/utils/cursorUtils.ts
@@ -7,6 +7,11 @@ function getMaxRangeOffset(node: ChildNode): number {
   return node.nodeType === Node.TEXT_NODE ? (node.textContent ?? '').length : node.childNodes.length;
 }
 
+/**
+ * Range offsets are applied to the real DOM node, not the parsed markdown tree.
+ * When the tree is temporarily stale, clamp to the DOM node's bounds so cursor
+ * restoration lands at the nearest valid position instead of throwing.
+ */
 function getClampedRangeOffset(node: ChildNode, offset: number): number {
   return Math.max(0, Math.min(offset, getMaxRangeOffset(node)));
 }


### PR DESCRIPTION
### Details

This fixes a web crash during markdown cursor restoration. `setCursorPosition` clamped the cursor index against the markdown tree length, but then passed the derived offset directly to the actual DOM node used by `Range.setStart` / `Range.setEnd`.

When the markdown tree and rendered DOM are temporarily out of sync, the offset can be valid for the tree but invalid for the DOM node, causing `IndexSizeError`.

This change clamps the final offset against the actual Range container node bounds before applying it.

### Related Issues

https://github.com/Expensify/App/issues/95347

### Manual Tests

1. Use the IOU Description repro from Expensify/App.
2. Type text in the markdown description input.
3. Force a stale tree/DOM state by saving a caret, blurring the input, emptying the rendered text node, then focusing/clicking the input again.
4. Verify no `IndexSizeError` is thrown and the editor remains usable.

### Linked PRs

Expensify/App PR: https://github.com/Expensify/App/pull/96638