### PR TITLE
fix: Ship compiled test mock entry point (fix TS under RN 0.87)

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -8,6 +8,9 @@
 lib/**/*
 scripts/**/*
 
+# Shim entry points that re-export from the build output
+mock/**/*
+
 babel.config.js
 metro.config.js
 react-native.config.js

--- a/mock/index.d.ts
+++ b/mock/index.d.ts
@@ -1,0 +1,1 @@
+export * from '../lib/typescript/src/mock/index';

--- a/mock/index.js
+++ b/mock/index.js
@@ -1,0 +1,1 @@
+module.exports = require('../lib/commonjs/mock/index.js');

--- a/src/mock/index.ts
+++ b/src/mock/index.ts
@@ -1,5 +1,5 @@
-import {MarkdownTextInput} from '../src';
-import type {parseExpensiMark} from '../src';
+import {MarkdownTextInput} from '..';
+import type {parseExpensiMark} from '..';
 
 global.jsi_setMarkdownRuntime = jest.fn();
 global.jsi_registerMarkdownWorklet = jest.fn();

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -26,6 +26,6 @@
     "verbatimModuleSyntax": true,
     "typeRoots": ["node_modules/@types"]
   },
-  "include": ["src/**/*", "mock/**/*"],
+  "include": ["src/**/*"],
   "exclude": ["**/node_modules/**/*", "**/lib/**/*", "example/src/**/*", "WebExample/**/*", "**/Pods"]
 }


### PR DESCRIPTION
### Details

Minimal fix for `@expensify/react-native-live-markdown` compatibility in React Native 0.87+ projects that wire up the test mock from a TypeScript setup file. See https://github.com/react-native-community/template/issues/245.

**Context**

React Native 0.87 ships the [Strict TypeScript API](https://reactnative.dev/docs/next/strict-typescript-api) by default (moving to a user opt-out).

Typically, this change is **scoped to the user's project** (`@react-native/typescript-config` includes [`skipLibCheck: true`](https://www.typescriptlang.org/tsconfig/#skipLibCheck)) and does not reach library source code.

However, this library ships a Jest mock at `@expensify/react-native-live-markdown/mock`, which is an exception that crosses this boundary.

**Problem**

`@expensify/react-native-live-markdown/mock` resolved to raw `mock/index.ts` — no sibling `.d.ts` existed at that path — so it pulled this library's `../src/*` into the scope of the user's TypeScript analysis instead of the compiled `lib/` code. That produces a type error against deep imports such as `react-native/Libraries/Types/CodegenTypes`, which no longer resolve under the Strict TypeScript API (`TS2307`, see also [AppAndFlow/react-native-safe-area-context#744](https://github.com/AppAndFlow/react-native-safe-area-context/pull/744)). `skipLibCheck` does not contain it because it does not apply to `.ts`/`.tsx`.

**This diff**

Move the mock into the builder-bob build so consuming projects only ever see this library's `.d.ts` files, which are exempt from typechecking. Same fix as [AppAndFlow/react-native-safe-area-context#745](https://github.com/AppAndFlow/react-native-safe-area-context/pull/745), independent of the deep-import cleanup in #744.

- Move `mock/index.ts` to `src/mock/index.ts` so builder-bob compiles it like the rest of the library; repoint its imports from `'../src'` to `'..'`.
- Preserve the `@expensify/react-native-live-markdown/mock` subpath via shims: `mock/index.js` re-exports `../lib/commonjs/mock/index.js`, `mock/index.d.ts` re-exports `../lib/typescript/src/mock/index`.
- Drop `mock/**/*` from tsconfig `include` so the source is only picked up under `src/`, and lint-ignore `mock/**/*` since the shims point into build output.
- ✅ Consuming projects now only see this library's `.d.ts` files, which are exempt from typechecking due to `skipLibCheck: true`.

No `exports` map is introduced — the package has none today, and shims are the conservative, non-breaking equivalent.

### Related Issues

- https://github.com/react-native-community/template/issues/245

### Manual Tests

- `yarn typecheck`, `yarn lint:root`, and the Jest suite (153 tests) all pass.
- `yarn prepare` (bob build) emits `lib/commonjs/mock/index.js`, `lib/module/mock/index.js`, and `lib/typescript/src/mock/index.d.ts`; the stale `lib/typescript/mock/` is gone.
- `npm pack --dry-run` confirms the three `lib/**/mock` outputs plus the `mock/index.js` / `mock/index.d.ts` shims ship, and `mock/index.ts` no longer appears at the public `mock/` path.
- Verified the emitted `lib/commonjs/mock/index.js` retains the module-scope `global.jsi_*` assignments and the `'worklet'` directive.

### Linked PRs

<!-- N/A -->
