### PR TITLE
Fix main thread hang on iOS

### DIFF
--- a/apple/MarkdownParser.h
+++ b/apple/MarkdownParser.h
@@ -8,26 +8,22 @@ NS_ASSUME_NONNULL_BEGIN
 - (NSArray<MarkdownRange *> *)parse:(nonnull NSString *)text
                        withParserId:(nonnull NSNumber *)parserId;
 
-// Returns the memoized ranges for (text, parserId) if they are still in the
-// cache, otherwise nil. Never enters the worklet runtime and only takes a brief
-// internal lock, so it is safe to call from the Yoga measure path on the main
-// thread.
+// Returns the ranges for (text, parserId) if they are already in the cache, or
+// nil if they aren't. This never runs the parser, so it is safe to call from
+// the main thread while Yoga is measuring.
 - (nullable NSArray<MarkdownRange *> *)cachedRangesForText:(nonnull NSString *)text
                                               withParserId:(nonnull NSNumber *)parserId;
 
-// Requests a parse on a background queue to populate the cache without blocking
-// the calling thread. Used when the main thread needs ranges during layout but
-// must not wait on the worklet runtime (see Sentry APP-EF1).
+// Parses in the background and puts the result in the cache, so the caller
+// doesn't have to wait for the parser. Used by the main thread, which must
+// never wait for it (see Sentry APP-EF1).
 //
-// Requests are coalesced latest-wins: the most recent (text, parserId) always
-// wins, and any earlier request that has not started executing yet is dropped.
-// A parse that is already inside the worklet runtime cannot be cancelled, but
-// the newest request is picked up as soon as it returns, so the newest text is
-// always parsed.
+// Only the newest request matters: a new call replaces one that is still
+// waiting. A parse that already started can't be stopped, but the newest text
+// is parsed as soon as it finishes.
 //
-// `completion` runs on the warm-up queue once `text` has been parsed and
-// cached. It is skipped when the request was superseded by a newer one, since
-// the newer request invokes its own completion.
+// `completion` runs on the background queue once the text is cached. It is
+// skipped if a newer call replaced this one, since that call reports instead.
 - (void)warmCacheAsyncForText:(nonnull NSString *)text
                  withParserId:(nonnull NSNumber *)parserId
                    completion:(nullable void (^)(void))completion;

--- a/apple/MarkdownParser.h
+++ b/apple/MarkdownParser.h
@@ -8,6 +8,19 @@ NS_ASSUME_NONNULL_BEGIN
 - (NSArray<MarkdownRange *> *)parse:(nonnull NSString *)text
                        withParserId:(nonnull NSNumber *)parserId;
 
+// Returns the memoized ranges for (text, parserId) if they match the last
+// completed parse, otherwise nil. Never enters the worklet runtime and only
+// takes a brief internal lock, so it is safe to call from the Yoga measure
+// path on the main thread.
+- (nullable NSArray<MarkdownRange *> *)cachedRangesForText:(nonnull NSString *)text
+                                              withParserId:(nonnull NSNumber *)parserId;
+
+// Schedules a parse on a background queue to populate the memo cache without
+// blocking the calling thread. Used when the main thread needs ranges during
+// layout but must not wait on the worklet runtime (see Sentry APP-EF1).
+- (void)warmCacheAsyncForText:(nonnull NSString *)text
+                 withParserId:(nonnull NSNumber *)parserId;
+
 NS_ASSUME_NONNULL_END
 
 @end

--- a/apple/MarkdownParser.h
+++ b/apple/MarkdownParser.h
@@ -8,19 +8,30 @@ NS_ASSUME_NONNULL_BEGIN
 - (NSArray<MarkdownRange *> *)parse:(nonnull NSString *)text
                        withParserId:(nonnull NSNumber *)parserId;
 
-// Returns the memoized ranges for (text, parserId) if they match the last
-// completed parse, otherwise nil. Never enters the worklet runtime and only
-// takes a brief internal lock, so it is safe to call from the Yoga measure
-// path on the main thread.
+// Returns the memoized ranges for (text, parserId) if they are still in the
+// cache, otherwise nil. Never enters the worklet runtime and only takes a brief
+// internal lock, so it is safe to call from the Yoga measure path on the main
+// thread.
 - (nullable NSArray<MarkdownRange *> *)cachedRangesForText:(nonnull NSString *)text
                                               withParserId:(nonnull NSNumber *)parserId;
 
-// Schedules a parse on a background queue to populate the memo cache without
-// blocking the calling thread. Used when the main thread needs ranges during
-// layout but must not wait on the worklet runtime (see Sentry APP-EF1).
+// Requests a parse on a background queue to populate the cache without blocking
+// the calling thread. Used when the main thread needs ranges during layout but
+// must not wait on the worklet runtime (see Sentry APP-EF1).
+//
+// Requests are coalesced latest-wins: the most recent (text, parserId) always
+// wins, and any earlier request that has not started executing yet is dropped.
+// A parse that is already inside the worklet runtime cannot be cancelled, but
+// the newest request is picked up as soon as it returns, so the newest text is
+// always parsed.
+//
+// `completion` runs on the warm-up queue once `text` has been parsed and
+// cached. It is skipped when the request was superseded by a newer one, since
+// the newer request invokes its own completion.
 - (void)warmCacheAsyncForText:(nonnull NSString *)text
-                 withParserId:(nonnull NSNumber *)parserId;
-
-NS_ASSUME_NONNULL_END
+                 withParserId:(nonnull NSNumber *)parserId
+                   completion:(nullable void (^)(void))completion;
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/apple/MarkdownParser.mm
+++ b/apple/MarkdownParser.mm
@@ -6,73 +6,135 @@
   NSString *_prevText;
   NSNumber *_prevParserId;
   NSArray<MarkdownRange *> *_prevMarkdownRanges;
+  BOOL _asyncParseInFlight;
+}
+
+// Shared serial queue used to warm the memo cache off the main thread. A
+// single queue is enough: parses are serialized by the markdown worklet
+// runtime's own mutex anyway, and keeping it serial bounds duplicate work.
++ (dispatch_queue_t)cacheWarmupQueue
+{
+  static dispatch_queue_t queue;
+  static dispatch_once_t onceToken;
+  dispatch_once(&onceToken, ^{
+    dispatch_queue_attr_t attr = dispatch_queue_attr_make_with_qos_class(
+        DISPATCH_QUEUE_SERIAL, QOS_CLASS_USER_INITIATED, 0);
+    queue = dispatch_queue_create("com.expensify.livemarkdown.parser-cache-warmup", attr);
+  });
+  return queue;
+}
+
+- (nullable NSArray<MarkdownRange *> *)cachedRangesForText:(nonnull NSString *)text
+                                              withParserId:(nonnull NSNumber *)parserId
+{
+  @synchronized (self) {
+    if (_prevText != nil && _prevParserId != nil && [text isEqualToString:_prevText] &&
+        [parserId isEqualToNumber:_prevParserId]) {
+      return _prevMarkdownRanges;
+    }
+  }
+  return nil;
+}
+
+- (void)warmCacheAsyncForText:(nonnull NSString *)text withParserId:(nonnull NSNumber *)parserId
+{
+  @synchronized (self) {
+    if (_asyncParseInFlight) {
+      // A warm-up is already queued. If it races with newer text, a later
+      // measure pass will observe the miss and schedule again.
+      return;
+    }
+    _asyncParseInFlight = YES;
+  }
+
+  NSString *textCopy = [text copy];
+  __weak MarkdownParser *weakSelf = self;
+  dispatch_async([MarkdownParser cacheWarmupQueue], ^{
+    MarkdownParser *strongSelf = weakSelf;
+    if (strongSelf == nil) {
+      return;
+    }
+    [strongSelf parse:textCopy withParserId:parserId];
+    @synchronized (strongSelf) {
+      strongSelf->_asyncParseInFlight = NO;
+    }
+  });
 }
 
 - (NSArray<MarkdownRange *> *)parse:(nonnull NSString *)text
                        withParserId:(nonnull NSNumber *)parserId
 {
+  NSArray<MarkdownRange *> *cached = [self cachedRangesForText:text withParserId:parserId];
+  if (cached != nil) {
+    return cached;
+  }
+
+  // Run the worklet parse WITHOUT holding any Objective-C lock. Entering the
+  // shared worklet runtime acquires its recursive_mutex, and holding an ObjC
+  // lock across that boundary is what created the APP-EF1 lock-order
+  // inversion: the main thread got stuck in objc_sync_enter during Yoga
+  // measure while a background Fabric layout thread held the lock and waited
+  // on the runtime mutex, until the iOS watchdog killed the app. Concurrent
+  // cache misses may parse the same text twice; the runtime serializes them,
+  // the results are identical, and last-writer-wins on the cache is safe.
+  NSArray<MarkdownRange *> *markdownRanges = [self parseUncached:text withParserId:parserId];
+
   @synchronized (self) {
-    if ([text isEqualToString:_prevText] && [parserId isEqualToNumber:_prevParserId]) {
-      return _prevMarkdownRanges;
-    }
-
-    const auto &markdownRuntime = expensify::livemarkdown::getMarkdownRuntime();
-    jsi::Runtime &rt = markdownRuntime->getJSIRuntime();
-
-    std::shared_ptr<SerializableWorklet> markdownWorklet;
-    try {
-      markdownWorklet = expensify::livemarkdown::getMarkdownWorklet([parserId intValue]);
-    } catch (const std::out_of_range &error) {
-      _prevText = [NSString stringWithString:text];
-      _prevParserId = parserId;
-      _prevMarkdownRanges = @[];
-      return _prevMarkdownRanges;
-    }
-
-    const auto &input = jsi::String::createFromUtf8(rt, [text UTF8String]);
-
-    jsi::Value output;
-    try {
-      output = markdownRuntime->runGuarded(markdownWorklet, input);
-    } catch (const jsi::JSError &error) {
-      // Skip formatting, runGuarded will show the error in LogBox
-      _prevText = [NSString stringWithString:text];
-      _prevParserId = parserId;
-      _prevMarkdownRanges = @[];
-      return _prevMarkdownRanges;
-    }
-
-    NSMutableArray<MarkdownRange *> *markdownRanges = [[NSMutableArray alloc] init];
-    try {
-      const auto &ranges = output.asObject(rt).asArray(rt);
-      for (size_t i = 0, n = ranges.size(rt); i < n; ++i) {
-        const auto &item = ranges.getValueAtIndex(rt, i).asObject(rt);
-        const auto &type = item.getProperty(rt, "type").asString(rt).utf8(rt);
-        const auto &start = static_cast<int>(item.getProperty(rt, "start").asNumber());
-        const auto &length = static_cast<int>(item.getProperty(rt, "length").asNumber());
-        const auto &depth = item.hasProperty(rt, "depth") ? static_cast<int>(item.getProperty(rt, "depth").asNumber()) : 1;
-
-        if (length == 0 || start + length > text.length) {
-          continue;
-        }
-
-        NSRange range = NSMakeRange(start, length);
-        MarkdownRange *markdownRange = [[MarkdownRange alloc] initWithType:@(type.c_str()) range:range depth:depth];
-        [markdownRanges addObject:markdownRange];
-      }
-    } catch (const jsi::JSError &error) {
-      RCTLogWarn(@"[react-native-live-markdown] Incorrect schema of worklet parser output: %s", error.getMessage().c_str());
-      _prevText = [NSString stringWithString:text];
-      _prevParserId = parserId;
-      _prevMarkdownRanges = @[];
-      return _prevMarkdownRanges;
-    }
-
-    _prevText = [NSString stringWithString:text];
+    _prevText = [text copy];
     _prevParserId = parserId;
     _prevMarkdownRanges = markdownRanges;
-    return _prevMarkdownRanges;
   }
+
+  return markdownRanges;
+}
+
+- (NSArray<MarkdownRange *> *)parseUncached:(nonnull NSString *)text
+                               withParserId:(nonnull NSNumber *)parserId
+{
+  const auto &markdownRuntime = expensify::livemarkdown::getMarkdownRuntime();
+  jsi::Runtime &rt = markdownRuntime->getJSIRuntime();
+
+  std::shared_ptr<SerializableWorklet> markdownWorklet;
+  try {
+    markdownWorklet = expensify::livemarkdown::getMarkdownWorklet([parserId intValue]);
+  } catch (const std::out_of_range &error) {
+    return @[];
+  }
+
+  const auto &input = jsi::String::createFromUtf8(rt, [text UTF8String]);
+
+  jsi::Value output;
+  try {
+    output = markdownRuntime->runGuarded(markdownWorklet, input);
+  } catch (const jsi::JSError &error) {
+    // Skip formatting, runGuarded will show the error in LogBox
+    return @[];
+  }
+
+  NSMutableArray<MarkdownRange *> *markdownRanges = [[NSMutableArray alloc] init];
+  try {
+    const auto &ranges = output.asObject(rt).asArray(rt);
+    for (size_t i = 0, n = ranges.size(rt); i < n; ++i) {
+      const auto &item = ranges.getValueAtIndex(rt, i).asObject(rt);
+      const auto &type = item.getProperty(rt, "type").asString(rt).utf8(rt);
+      const auto &start = static_cast<int>(item.getProperty(rt, "start").asNumber());
+      const auto &length = static_cast<int>(item.getProperty(rt, "length").asNumber());
+      const auto &depth = item.hasProperty(rt, "depth") ? static_cast<int>(item.getProperty(rt, "depth").asNumber()) : 1;
+
+      if (length == 0 || start + length > text.length) {
+        continue;
+      }
+
+      NSRange range = NSMakeRange(start, length);
+      MarkdownRange *markdownRange = [[MarkdownRange alloc] initWithType:@(type.c_str()) range:range depth:depth];
+      [markdownRanges addObject:markdownRange];
+    }
+  } catch (const jsi::JSError &error) {
+    RCTLogWarn(@"[react-native-live-markdown] Incorrect schema of worklet parser output: %s", error.getMessage().c_str());
+    return @[];
+  }
+
+  return markdownRanges;
 }
 
 @end

--- a/apple/MarkdownParser.mm
+++ b/apple/MarkdownParser.mm
@@ -2,16 +2,79 @@
 #import <RNLiveMarkdown/MarkdownGlobal.h>
 #import <React/RCTLog.h>
 
-@implementation MarkdownParser {
-  NSString *_prevText;
-  NSNumber *_prevParserId;
-  NSArray<MarkdownRange *> *_prevMarkdownRanges;
-  BOOL _asyncParseInFlight;
+// Number of (text, parserId) results kept in the cache.
+//
+// The main-thread measure path can only format from this cache, because it must
+// never enter the worklet runtime (see RCTMarkdownUtils). With a single entry
+// that fast path was unreliable: two alternating text values thrashed the entry
+// and every main-thread measure missed, falling back to measuring unformatted
+// text. A handful of entries absorbs alternating values (e.g. typing then
+// undoing, or a controlled input echoing back an older value) and is still
+// cheap to scan linearly.
+static const NSUInteger kMarkdownParserCacheCapacity = 4;
+
+@interface MarkdownParserCacheEntry : NSObject
+
+@property (nonatomic, readonly, nonnull) NSString *text;
+@property (nonatomic, readonly, nonnull) NSNumber *parserId;
+@property (nonatomic, readonly, nonnull) NSArray<MarkdownRange *> *markdownRanges;
+
+- (instancetype)initWithText:(nonnull NSString *)text
+                    parserId:(nonnull NSNumber *)parserId
+              markdownRanges:(nonnull NSArray<MarkdownRange *> *)markdownRanges;
+
+- (BOOL)matchesText:(nonnull NSString *)text parserId:(nonnull NSNumber *)parserId;
+
+@end
+
+@implementation MarkdownParserCacheEntry
+
+- (instancetype)initWithText:(nonnull NSString *)text
+                    parserId:(nonnull NSNumber *)parserId
+              markdownRanges:(nonnull NSArray<MarkdownRange *> *)markdownRanges
+{
+  if (self = [super init]) {
+    _text = [text copy];
+    _parserId = parserId;
+    _markdownRanges = markdownRanges;
+  }
+
+  return self;
 }
 
-// Shared serial queue used to warm the memo cache off the main thread. A
-// single queue is enough: parses are serialized by the markdown worklet
-// runtime's own mutex anyway, and keeping it serial bounds duplicate work.
+- (BOOL)matchesText:(nonnull NSString *)text parserId:(nonnull NSNumber *)parserId
+{
+  // Compare the parser id first, it is much cheaper than a string comparison.
+  return [_parserId isEqualToNumber:parserId] && [_text isEqualToString:text];
+}
+
+@end
+
+@implementation MarkdownParser {
+  // Most-recently-used first; index 0 is the newest entry. Guarded by
+  // `@synchronized (self)`.
+  NSMutableArray<MarkdownParserCacheEntry *> *_cache;
+
+  // Latest-wins coalescing state for background warm-ups. Guarded by
+  // `@synchronized (self)`.
+  NSString *_pendingText;
+  NSNumber *_pendingParserId;
+  void (^_pendingCompletion)(void);
+  BOOL _warmupScheduled;
+}
+
+- (instancetype)init
+{
+  if (self = [super init]) {
+    _cache = [[NSMutableArray alloc] initWithCapacity:kMarkdownParserCacheCapacity];
+  }
+
+  return self;
+}
+
+// Shared serial queue used to warm the cache off the main thread. A single queue
+// is enough: parses are serialized by the markdown worklet runtime's own mutex
+// anyway, and keeping it serial bounds duplicate work.
 + (dispatch_queue_t)cacheWarmupQueue
 {
   static dispatch_queue_t queue;
@@ -28,37 +91,102 @@
                                               withParserId:(nonnull NSNumber *)parserId
 {
   @synchronized (self) {
-    if (_prevText != nil && _prevParserId != nil && [text isEqualToString:_prevText] &&
-        [parserId isEqualToNumber:_prevParserId]) {
-      return _prevMarkdownRanges;
+    for (NSUInteger i = 0, n = _cache.count; i < n; i++) {
+      MarkdownParserCacheEntry *entry = _cache[i];
+      if (![entry matchesText:text parserId:parserId]) {
+        continue;
+      }
+      if (i != 0) {
+        // Refresh recency so the entry the measure path keeps asking for is not
+        // the one that gets evicted.
+        [_cache removeObjectAtIndex:i];
+        [_cache insertObject:entry atIndex:0];
+      }
+      return entry.markdownRanges;
     }
   }
+
   return nil;
 }
 
-- (void)warmCacheAsyncForText:(nonnull NSString *)text withParserId:(nonnull NSNumber *)parserId
+- (void)cacheMarkdownRanges:(nonnull NSArray<MarkdownRange *> *)markdownRanges
+                    forText:(nonnull NSString *)text
+               withParserId:(nonnull NSNumber *)parserId
+{
+  MarkdownParserCacheEntry *entry = [[MarkdownParserCacheEntry alloc] initWithText:text
+                                                                         parserId:parserId
+                                                                   markdownRanges:markdownRanges];
+
+  @synchronized (self) {
+    for (NSUInteger i = 0, n = _cache.count; i < n; i++) {
+      if ([_cache[i] matchesText:text parserId:parserId]) {
+        [_cache removeObjectAtIndex:i];
+        break;
+      }
+    }
+    [_cache insertObject:entry atIndex:0];
+    while (_cache.count > kMarkdownParserCacheCapacity) {
+      [_cache removeLastObject];
+    }
+  }
+}
+
+- (void)warmCacheAsyncForText:(nonnull NSString *)text
+                 withParserId:(nonnull NSNumber *)parserId
+                   completion:(nullable void (^)(void))completion
 {
   @synchronized (self) {
-    if (_asyncParseInFlight) {
-      // A warm-up is already queued. If it races with newer text, a later
-      // measure pass will observe the miss and schedule again.
+    // Latest-wins: overwrite whatever was queued but has not started yet, so a
+    // stale request can never win over newer text. The completion of the
+    // superseded request is dropped together with it; its result would be stale
+    // and the newer request reports for itself.
+    _pendingText = [text copy];
+    _pendingParserId = parserId;
+    _pendingCompletion = completion;
+
+    if (_warmupScheduled) {
+      // A drain loop is already running (or queued) and will pick this up.
       return;
     }
-    _asyncParseInFlight = YES;
+    _warmupScheduled = YES;
   }
 
-  NSString *textCopy = [text copy];
   __weak MarkdownParser *weakSelf = self;
   dispatch_async([MarkdownParser cacheWarmupQueue], ^{
-    MarkdownParser *strongSelf = weakSelf;
-    if (strongSelf == nil) {
-      return;
-    }
-    [strongSelf parse:textCopy withParserId:parserId];
-    @synchronized (strongSelf) {
-      strongSelf->_asyncParseInFlight = NO;
-    }
+    [weakSelf drainPendingWarmups];
   });
+}
+
+- (void)drainPendingWarmups
+{
+  while (true) {
+    NSString *text;
+    NSNumber *parserId;
+    void (^completion)(void);
+
+    @synchronized (self) {
+      if (_pendingText == nil) {
+        _warmupScheduled = NO;
+        return;
+      }
+      text = _pendingText;
+      parserId = _pendingParserId;
+      completion = _pendingCompletion;
+      _pendingText = nil;
+      _pendingParserId = nil;
+      _pendingCompletion = nil;
+    }
+
+    [self parse:text withParserId:parserId];
+
+    BOOL superseded;
+    @synchronized (self) {
+      superseded = _pendingText != nil;
+    }
+    if (completion != nil && !superseded) {
+      completion();
+    }
+  }
 }
 
 - (NSArray<MarkdownRange *> *)parse:(nonnull NSString *)text
@@ -79,11 +207,7 @@
   // the results are identical, and last-writer-wins on the cache is safe.
   NSArray<MarkdownRange *> *markdownRanges = [self parseUncached:text withParserId:parserId];
 
-  @synchronized (self) {
-    _prevText = [text copy];
-    _prevParserId = parserId;
-    _prevMarkdownRanges = markdownRanges;
-  }
+  [self cacheMarkdownRanges:markdownRanges forText:text withParserId:parserId];
 
   return markdownRanges;
 }

--- a/apple/MarkdownParser.mm
+++ b/apple/MarkdownParser.mm
@@ -2,15 +2,11 @@
 #import <RNLiveMarkdown/MarkdownGlobal.h>
 #import <React/RCTLog.h>
 
-// Number of (text, parserId) results kept in the cache.
-//
-// The main-thread measure path can only format from this cache, because it must
-// never enter the worklet runtime (see RCTMarkdownUtils). With a single entry
-// that fast path was unreliable: two alternating text values thrashed the entry
-// and every main-thread measure missed, falling back to measuring unformatted
-// text. A handful of entries absorbs alternating values (e.g. typing then
-// undoing, or a controlled input echoing back an older value) and is still
-// cheap to scan linearly.
+// The main thread can only use ranges that are already cached (see
+// RCTMarkdownUtils), and one entry was not enough: two texts taking turns kept
+// overwriting each other, so the main thread never found what it needed. A few
+// entries cover that case (typing then undoing, or an input echoing back older
+// text), and the list is still small enough to scan one by one.
 static const NSUInteger kMarkdownParserCacheCapacity = 4;
 
 @interface MarkdownParserCacheEntry : NSObject
@@ -44,19 +40,18 @@ static const NSUInteger kMarkdownParserCacheCapacity = 4;
 
 - (BOOL)matchesText:(nonnull NSString *)text parserId:(nonnull NSNumber *)parserId
 {
-  // Compare the parser id first, it is much cheaper than a string comparison.
+  // Check the parser id first - comparing numbers is cheaper than strings.
   return [_parserId isEqualToNumber:parserId] && [_text isEqualToString:text];
 }
 
 @end
 
+// Everything below is only read and written inside `@synchronized (self)`.
 @implementation MarkdownParser {
-  // Most-recently-used first; index 0 is the newest entry. Guarded by
-  // `@synchronized (self)`.
+  // Newest entry first, at index 0.
   NSMutableArray<MarkdownParserCacheEntry *> *_cache;
 
-  // Latest-wins coalescing state for background warm-ups. Guarded by
-  // `@synchronized (self)`.
+  // The next text to parse in the background, if there is one.
   NSString *_pendingText;
   NSNumber *_pendingParserId;
   void (^_pendingCompletion)(void);
@@ -72,9 +67,9 @@ static const NSUInteger kMarkdownParserCacheCapacity = 4;
   return self;
 }
 
-// Shared serial queue used to warm the cache off the main thread. A single queue
-// is enough: parses are serialized by the markdown worklet runtime's own mutex
-// anyway, and keeping it serial bounds duplicate work.
+// One background queue for parsing off the main thread. A serial queue is
+// enough: the worklet runtime only runs one parse at a time anyway, and this
+// keeps us from doing the same work twice.
 + (dispatch_queue_t)cacheWarmupQueue
 {
   static dispatch_queue_t queue;
@@ -97,8 +92,8 @@ static const NSUInteger kMarkdownParserCacheCapacity = 4;
         continue;
       }
       if (i != 0) {
-        // Refresh recency so the entry the measure path keeps asking for is not
-        // the one that gets evicted.
+        // Move it to the front, so the text we keep asking for is not the one
+        // we throw away next.
         [_cache removeObjectAtIndex:i];
         [_cache insertObject:entry atIndex:0];
       }
@@ -136,16 +131,15 @@ static const NSUInteger kMarkdownParserCacheCapacity = 4;
                    completion:(nullable void (^)(void))completion
 {
   @synchronized (self) {
-    // Latest-wins: overwrite whatever was queued but has not started yet, so a
-    // stale request can never win over newer text. The completion of the
-    // superseded request is dropped together with it; its result would be stale
-    // and the newer request reports for itself.
+    // Keep only the newest request: replace anything that is waiting but
+    // hasn't started, so old text can never win over newer text. The replaced
+    // completion goes with it, since the new request will report instead.
     _pendingText = [text copy];
     _pendingParserId = parserId;
     _pendingCompletion = completion;
 
     if (_warmupScheduled) {
-      // A drain loop is already running (or queued) and will pick this up.
+      // A background loop is already running and will pick this up.
       return;
     }
     _warmupScheduled = YES;
@@ -197,14 +191,14 @@ static const NSUInteger kMarkdownParserCacheCapacity = 4;
     return cached;
   }
 
-  // Run the worklet parse WITHOUT holding any Objective-C lock. Entering the
-  // shared worklet runtime acquires its recursive_mutex, and holding an ObjC
-  // lock across that boundary is what created the APP-EF1 lock-order
-  // inversion: the main thread got stuck in objc_sync_enter during Yoga
-  // measure while a background Fabric layout thread held the lock and waited
-  // on the runtime mutex, until the iOS watchdog killed the app. Concurrent
-  // cache misses may parse the same text twice; the runtime serializes them,
-  // the results are identical, and last-writer-wins on the cache is safe.
+  // Parse WITHOUT holding an Objective-C lock. Running the parser waits for the
+  // worklet runtime, and holding a lock while waiting is what froze the app
+  // (Sentry APP-EF1): a background thread held this lock and waited on the
+  // runtime, so the main thread was stuck waiting for the lock while measuring,
+  // until iOS killed the app.
+  //
+  // Two threads may end up parsing the same text at the same time. That is
+  // fine: they run one after the other and produce the same result.
   NSArray<MarkdownRange *> *markdownRanges = [self parseUncached:text withParserId:parserId];
 
   [self cacheMarkdownRanges:markdownRanges forText:text withParserId:parserId];

--- a/apple/MarkdownTextInputDecoratorShadowNode.h
+++ b/apple/MarkdownTextInputDecoratorShadowNode.h
@@ -52,17 +52,14 @@ private:
   static YogaLayoutableShadowNode &
   shadowNodeFromContext(YGNodeConstRef yogaNode);
 
-  // Persisted RCTMarkdownUtils instance shared across shadow node clones so
-  // that MarkdownParser's cache (keyed on text + parserId) survives repeated
-  // Yoga measure callbacks instead of being discarded on every call to
-  // applyMarkdownFormattingToTextInputState.
+  // Shared between shadow node clones, so the parser cache survives all the
+  // cloning that happens during layout instead of being thrown away on every
+  // call to applyMarkdownFormattingToTextInputState.
   mutable std::shared_ptr<void> markdownUtils_;
 
-  // Set from an arbitrary thread when an async markdown parse (scheduled by a
-  // main-thread measure that could not enter the worklet runtime) has finished.
-  // Shared across clones alongside markdownUtils_ and consumed by
-  // overwriteMeasureCallbackConnector, which dirties the child's Yoga node so
-  // the measure function runs again with markdown applied.
+  // Set from any thread when a background parse finishes.
+  // overwriteMeasureCallbackConnector then marks the child's Yoga node dirty so
+  // it gets measured again with markdown. Passed along with markdownUtils_.
   mutable std::shared_ptr<std::atomic_bool> needsRemeasure_;
 };
 

--- a/apple/MarkdownTextInputDecoratorShadowNode.h
+++ b/apple/MarkdownTextInputDecoratorShadowNode.h
@@ -8,6 +8,9 @@
 #include <react/renderer/components/view/ConcreteViewShadowNode.h>
 #include <react/renderer/core/LayoutContext.h>
 
+#include <atomic>
+#include <memory>
+
 namespace facebook {
 namespace react {
 
@@ -50,10 +53,17 @@ private:
   shadowNodeFromContext(YGNodeConstRef yogaNode);
 
   // Persisted RCTMarkdownUtils instance shared across shadow node clones so
-  // that MarkdownParser's one-entry memo cache (keyed on text + parserId)
-  // survives repeated Yoga measure callbacks instead of being discarded on
-  // every call to applyMarkdownFormattingToTextInputState.
+  // that MarkdownParser's cache (keyed on text + parserId) survives repeated
+  // Yoga measure callbacks instead of being discarded on every call to
+  // applyMarkdownFormattingToTextInputState.
   mutable std::shared_ptr<void> markdownUtils_;
+
+  // Set from an arbitrary thread when an async markdown parse (scheduled by a
+  // main-thread measure that could not enter the worklet runtime) has finished.
+  // Shared across clones alongside markdownUtils_ and consumed by
+  // overwriteMeasureCallbackConnector, which dirties the child's Yoga node so
+  // the measure function runs again with markdown applied.
+  mutable std::shared_ptr<std::atomic_bool> needsRemeasure_;
 };
 
 } // namespace react

--- a/apple/MarkdownTextInputDecoratorShadowNode.mm
+++ b/apple/MarkdownTextInputDecoratorShadowNode.mm
@@ -3,8 +3,12 @@
 #include <React/RCTUtils.h>
 #include <react/renderer/components/view/conversions.h>
 #include <react/renderer/core/ComponentDescriptor.h>
+#include <react/renderer/core/ConcreteState.h>
 #include <react/renderer/textlayoutmanager/RCTAttributedTextUtils.h>
 #include <yoga/Yoga.h>
+
+#include <atomic>
+#include <memory>
 
 #include "RCTMarkdownStyle.h"
 #include "RCTMarkdownUtils.h"
@@ -33,11 +37,14 @@ MarkdownTextInputDecoratorShadowNode::MarkdownTextInputDecoratorShadowNode(
     ShadowNodeFragment const &fragment)
     : ConcreteViewShadowNode(sourceShadowNode, fragment) {
   // Carry the persisted RCTMarkdownUtils over from the source node so the
-  // MarkdownParser memo cache survives the frequent cloning that happens
-  // during layout and re-render cycles.
+  // MarkdownParser cache survives the frequent cloning that happens during
+  // layout and re-render cycles. The re-measure flag has to travel with it,
+  // and both must be in place before makeChildNodeMutable() below, which is
+  // what consumes the flag.
   const auto &source =
       static_cast<const MarkdownTextInputDecoratorShadowNode &>(sourceShadowNode);
   markdownUtils_ = source.markdownUtils_;
+  needsRemeasure_ = source.needsRemeasure_;
 
   initialize();
   makeChildNodeMutable();
@@ -97,6 +104,26 @@ void MarkdownTextInputDecoratorShadowNode::overwriteMeasureCallbackConnector() {
   // on the decorator
   const auto &yogaNode = &nodeWithAccessibleYogaNode->yogaNode_;
   YGNodeSetMeasureFunc(yogaNode, yogaNodeMeasureCallbackConnector);
+
+  // An async markdown parse may have completed since the last layout, meaning
+  // the measurement Yoga has cached for the child was taken from unformatted
+  // text (see the onAsyncFormattingReady handler in
+  // applyMarkdownFormattingToTextInputState). The state update that brought us
+  // here does not dirty this subtree on its own - the decorator is not a
+  // measurable Yoga node - so without this Yoga would reuse that stale
+  // measurement and the wrong height would stick until something else
+  // invalidated layout.
+  //
+  // Dirty both nodes explicitly instead of relying on
+  // YGNodeMarkDirty()'s upward propagation: the child is usually already dirty
+  // from completeClone(), in which case propagation short-circuits and the
+  // decorator would stay clean. Ancestors then pick the dirty flag up on their
+  // own, because they are cloned with new children and updateYogaChildren()
+  // propagates child dirtiness upwards.
+  if (needsRemeasure_ != nullptr && needsRemeasure_->exchange(false)) {
+    yogaNode->setDirty(true);
+    yogaNode_.setDirty(true);
+  }
 }
 
 void MarkdownTextInputDecoratorShadowNode::appendChild(
@@ -190,13 +217,40 @@ void MarkdownTextInputDecoratorShadowNode::applyMarkdownFormattingToTextInputSta
       RCTNSTextAttributesFromTextAttributes(defaultTextAttributes);
 
   // Lazily create and persist the RCTMarkdownUtils instance so the MarkdownParser
-  // one-entry memo cache (keyed on text + parserId) survives repeated Yoga measure
-  // callbacks. Previously a fresh utils/parser was allocated on every call,
-  // discarding the cache and forcing a full JSI re-parse each time.
+  // cache (keyed on text + parserId) survives repeated Yoga measure callbacks.
+  // Previously a fresh utils/parser was allocated on every call, discarding the
+  // cache and forcing a full JSI re-parse each time.
   if (!markdownUtils_) {
     RCTMarkdownUtils *freshUtils = [[RCTMarkdownUtils alloc] init];
     markdownUtils_ = std::shared_ptr<void>(
         (__bridge_retained void *)freshUtils, [](void *p) { CFRelease(p); });
+    needsRemeasure_ = std::make_shared<std::atomic_bool>(false);
+
+    // When measure runs on the main thread it must not enter the worklet
+    // runtime, so on a cache miss it measures unformatted text and asks the
+    // parser to fill the cache in the background. That measurement is wrong for
+    // any style that changes text metrics, so once the ranges are ready we have
+    // to force another measure pass rather than hope something else dirties
+    // layout:
+    //   1. raise the flag, which makes the next clone dirty the child's Yoga
+    //      node (see overwriteMeasureCallbackConnector), and
+    //   2. dispatch a state update on this family to produce that commit.
+    // Both are needed: the state update schedules the commit, the flag makes
+    // Yoga actually re-run the measure function instead of reusing its cache.
+    // updateState() is safe to call from any thread - it only enqueues work on
+    // the family's event dispatcher.
+    const auto state =
+        std::static_pointer_cast<const ::facebook::react::ConcreteState<
+            MarkdownTextInputDecoratorState>>(getState());
+    if (state != nullptr) {
+      const auto needsRemeasure = needsRemeasure_;
+      freshUtils.onAsyncFormattingReady = ^{
+        needsRemeasure->store(true);
+        // Cheap no-op state update; it exists only to schedule a commit. If the
+        // family is already gone updateState() bails out on its own.
+        state->updateState(MarkdownTextInputDecoratorState{});
+      };
+    }
   }
   RCTMarkdownUtils *utils = (__bridge RCTMarkdownUtils *)markdownUtils_.get();
 

--- a/apple/MarkdownTextInputDecoratorShadowNode.mm
+++ b/apple/MarkdownTextInputDecoratorShadowNode.mm
@@ -36,11 +36,9 @@ MarkdownTextInputDecoratorShadowNode::MarkdownTextInputDecoratorShadowNode(
     ShadowNode const &sourceShadowNode,
     ShadowNodeFragment const &fragment)
     : ConcreteViewShadowNode(sourceShadowNode, fragment) {
-  // Carry the persisted RCTMarkdownUtils over from the source node so the
-  // MarkdownParser cache survives the frequent cloning that happens during
-  // layout and re-render cycles. The re-measure flag has to travel with it,
-  // and both must be in place before makeChildNodeMutable() below, which is
-  // what consumes the flag.
+  // Copy the utils (and its parser cache) and the re-measure flag from the node
+  // we are cloning. Both have to be set before makeChildNodeMutable() below,
+  // which is what reads the flag.
   const auto &source =
       static_cast<const MarkdownTextInputDecoratorShadowNode &>(sourceShadowNode);
   markdownUtils_ = source.markdownUtils_;
@@ -105,21 +103,15 @@ void MarkdownTextInputDecoratorShadowNode::overwriteMeasureCallbackConnector() {
   const auto &yogaNode = &nodeWithAccessibleYogaNode->yogaNode_;
   YGNodeSetMeasureFunc(yogaNode, yogaNodeMeasureCallbackConnector);
 
-  // An async markdown parse may have completed since the last layout, meaning
-  // the measurement Yoga has cached for the child was taken from unformatted
-  // text (see the onAsyncFormattingReady handler in
-  // applyMarkdownFormattingToTextInputState). The state update that brought us
-  // here does not dirty this subtree on its own - the decorator is not a
-  // measurable Yoga node - so without this Yoga would reuse that stale
-  // measurement and the wrong height would stick until something else
-  // invalidated layout.
+  // If a background parse finished since the last layout, the size Yoga saved
+  // for the child was measured from plain text, and nothing marks this part of
+  // the tree dirty on its own (Yoga does not measure the decorator), so the
+  // wrong height would stay until something else changed the layout.
   //
-  // Dirty both nodes explicitly instead of relying on
-  // YGNodeMarkDirty()'s upward propagation: the child is usually already dirty
-  // from completeClone(), in which case propagation short-circuits and the
-  // decorator would stay clean. Ancestors then pick the dirty flag up on their
-  // own, because they are cloned with new children and updateYogaChildren()
-  // propagates child dirtiness upwards.
+  // Mark both nodes dirty by hand instead of using YGNodeMarkDirty(): the child
+  // is usually dirty already from completeClone(), which stops the flag from
+  // travelling up and would leave the decorator clean. Parents pick it up on
+  // their own when updateYogaChildren() runs.
   if (needsRemeasure_ != nullptr && needsRemeasure_->exchange(false)) {
     yogaNode->setDirty(true);
     yogaNode_.setDirty(true);
@@ -216,29 +208,23 @@ void MarkdownTextInputDecoratorShadowNode::applyMarkdownFormattingToTextInputSta
   const auto defaultNSTextAttributes =
       RCTNSTextAttributesFromTextAttributes(defaultTextAttributes);
 
-  // Lazily create and persist the RCTMarkdownUtils instance so the MarkdownParser
-  // cache (keyed on text + parserId) survives repeated Yoga measure callbacks.
-  // Previously a fresh utils/parser was allocated on every call, discarding the
-  // cache and forcing a full JSI re-parse each time.
+  // Create the utils once and keep it, so the parser cache survives repeated
+  // measure calls. It used to be created fresh every time, which threw the
+  // cache away and forced a full re-parse.
   if (!markdownUtils_) {
     RCTMarkdownUtils *freshUtils = [[RCTMarkdownUtils alloc] init];
     markdownUtils_ = std::shared_ptr<void>(
         (__bridge_retained void *)freshUtils, [](void *p) { CFRelease(p); });
     needsRemeasure_ = std::make_shared<std::atomic_bool>(false);
 
-    // When measure runs on the main thread it must not enter the worklet
-    // runtime, so on a cache miss it measures unformatted text and asks the
-    // parser to fill the cache in the background. That measurement is wrong for
-    // any style that changes text metrics, so once the ranges are ready we have
-    // to force another measure pass rather than hope something else dirties
-    // layout:
-    //   1. raise the flag, which makes the next clone dirty the child's Yoga
-    //      node (see overwriteMeasureCallbackConnector), and
-    //   2. dispatch a state update on this family to produce that commit.
-    // Both are needed: the state update schedules the commit, the flag makes
-    // Yoga actually re-run the measure function instead of reusing its cache.
-    // updateState() is safe to call from any thread - it only enqueues work on
-    // the family's event dispatcher.
+    // When the main thread does not find the ranges in the cache, it measures
+    // plain text and parses in the background instead (see RCTMarkdownUtils).
+    // That size is wrong for any style that changes how big the text is, so
+    // once the ranges arrive we force another measure rather than hope
+    // something else does. Both steps are needed: the state update schedules a
+    // new commit, and the flag makes Yoga measure again instead of reusing the
+    // old size. updateState() can be called from any thread - it only queues
+    // work on the family.
     const auto state =
         std::static_pointer_cast<const ::facebook::react::ConcreteState<
             MarkdownTextInputDecoratorState>>(getState());
@@ -246,8 +232,8 @@ void MarkdownTextInputDecoratorShadowNode::applyMarkdownFormattingToTextInputSta
       const auto needsRemeasure = needsRemeasure_;
       freshUtils.onAsyncFormattingReady = ^{
         needsRemeasure->store(true);
-        // Cheap no-op state update; it exists only to schedule a commit. If the
-        // family is already gone updateState() bails out on its own.
+        // This update changes nothing; it is here only to schedule a new
+        // commit. If the family is already gone, updateState() handles that.
         state->updateState(MarkdownTextInputDecoratorState{});
       };
     }

--- a/apple/RCTMarkdownUtils.h
+++ b/apple/RCTMarkdownUtils.h
@@ -8,6 +8,14 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic) RCTMarkdownStyle *markdownStyle;
 @property (nonatomic) NSNumber *parserId;
 
+// Invoked from a background queue after an async parse scheduled by a
+// main-thread measure pass has landed in the parser cache. The owner is expected
+// to invalidate layout for the affected node so the text gets measured again,
+// this time with markdown applied. Without it, the unformatted measurement taken
+// during the cache miss could stick until something else dirtied layout.
+// Thread-safe to set and read (atomic).
+@property (atomic, copy, nullable) void (^onAsyncFormattingReady)(void);
+
 - (void)applyMarkdownFormatting:(nonnull NSMutableAttributedString *)attributedString
       withDefaultTextAttributes:(nonnull NSDictionary<NSAttributedStringKey, id> *)defaultTextAttributes;
 
@@ -15,11 +23,12 @@ NS_ASSUME_NONNULL_BEGIN
 // Use this from the shadow node measure path, where one RCTMarkdownUtils
 // instance is shared across shadow node clones and may be accessed from
 // concurrent Fabric commits/layout passes.
-// NOTE: on the main thread this formats only from the parser's memo cache and
-// never enters the worklet runtime; on a cache miss it schedules an async
-// warm-up and leaves the string unformatted for that measure pass. This keeps
-// the main thread from blocking on runtime-bound locks during Yoga measure
-// (Sentry APP-EF1 watchdog kills).
+// NOTE: on the main thread this formats only from the parser's cache and never
+// enters the worklet runtime; on a cache miss it schedules an async parse and
+// leaves the string unformatted for that measure pass, then calls
+// `onAsyncFormattingReady` once the ranges are available so the node can be
+// measured again. This keeps the main thread from blocking on runtime-bound
+// locks during Yoga measure (Sentry APP-EF1 watchdog kills).
 - (void)applyMarkdownFormatting:(nonnull NSMutableAttributedString *)attributedString
       withDefaultTextAttributes:(nonnull NSDictionary<NSAttributedStringKey, id> *)defaultTextAttributes
                   markdownStyle:(nonnull RCTMarkdownStyle *)markdownStyle

--- a/apple/RCTMarkdownUtils.h
+++ b/apple/RCTMarkdownUtils.h
@@ -11,10 +11,15 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)applyMarkdownFormatting:(nonnull NSMutableAttributedString *)attributedString
       withDefaultTextAttributes:(nonnull NSDictionary<NSAttributedStringKey, id> *)defaultTextAttributes;
 
-// Atomically sets the style/parser and applies formatting under a single lock.
+// Sets the style/parser and applies formatting using the given values.
 // Use this from the shadow node measure path, where one RCTMarkdownUtils
 // instance is shared across shadow node clones and may be accessed from
 // concurrent Fabric commits/layout passes.
+// NOTE: on the main thread this formats only from the parser's memo cache and
+// never enters the worklet runtime; on a cache miss it schedules an async
+// warm-up and leaves the string unformatted for that measure pass. This keeps
+// the main thread from blocking on runtime-bound locks during Yoga measure
+// (Sentry APP-EF1 watchdog kills).
 - (void)applyMarkdownFormatting:(nonnull NSMutableAttributedString *)attributedString
       withDefaultTextAttributes:(nonnull NSDictionary<NSAttributedStringKey, id> *)defaultTextAttributes
                   markdownStyle:(nonnull RCTMarkdownStyle *)markdownStyle

--- a/apple/RCTMarkdownUtils.h
+++ b/apple/RCTMarkdownUtils.h
@@ -8,27 +8,23 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic) RCTMarkdownStyle *markdownStyle;
 @property (nonatomic) NSNumber *parserId;
 
-// Invoked from a background queue after an async parse scheduled by a
-// main-thread measure pass has landed in the parser cache. The owner is expected
-// to invalidate layout for the affected node so the text gets measured again,
-// this time with markdown applied. Without it, the unformatted measurement taken
-// during the cache miss could stick until something else dirtied layout.
-// Thread-safe to set and read (atomic).
+// Called on a background queue once a background parse has finished and the
+// ranges are cached. The owner should mark the layout as out of date so the
+// text is measured again, this time with markdown. Otherwise the size measured
+// from plain text stays until something else triggers a new layout.
 @property (atomic, copy, nullable) void (^onAsyncFormattingReady)(void);
 
 - (void)applyMarkdownFormatting:(nonnull NSMutableAttributedString *)attributedString
       withDefaultTextAttributes:(nonnull NSDictionary<NSAttributedStringKey, id> *)defaultTextAttributes;
 
-// Sets the style/parser and applies formatting using the given values.
-// Use this from the shadow node measure path, where one RCTMarkdownUtils
-// instance is shared across shadow node clones and may be accessed from
-// concurrent Fabric commits/layout passes.
-// NOTE: on the main thread this formats only from the parser's cache and never
-// enters the worklet runtime; on a cache miss it schedules an async parse and
-// leaves the string unformatted for that measure pass, then calls
-// `onAsyncFormattingReady` once the ranges are available so the node can be
-// measured again. This keeps the main thread from blocking on runtime-bound
-// locks during Yoga measure (Sentry APP-EF1 watchdog kills).
+// Sets the style/parser and formats using the values passed in. Use this from
+// the shadow node measure path, where one instance is shared between clones and
+// several Fabric threads can call it at the same time.
+//
+// On the main thread this only uses ranges that are already cached and never
+// runs the parser. If they are not there, the text is left unformatted for this
+// pass and parsed in the background, then `onAsyncFormattingReady` is called so
+// the node can be measured again (see Sentry APP-EF1).
 - (void)applyMarkdownFormatting:(nonnull NSMutableAttributedString *)attributedString
       withDefaultTextAttributes:(nonnull NSDictionary<NSAttributedStringKey, id> *)defaultTextAttributes
                   markdownStyle:(nonnull RCTMarkdownStyle *)markdownStyle

--- a/apple/RCTMarkdownUtils.mm
+++ b/apple/RCTMarkdownUtils.mm
@@ -39,17 +39,45 @@
                   markdownStyle:(nonnull RCTMarkdownStyle *)markdownStyle
                        parserId:(nonnull NSNumber *)parserId
 {
-  // Keep the style/parserId assignment and the parse+format together under a
-  // single lock. The shadow node shares one instance across clones, and Fabric
-  // runs commits/layout optimistically on multiple threads, so without this the
-  // setters could interleave with another thread's parse/format and apply the
-  // wrong parserId/style for a frame. `@synchronized` is recursive, so nesting
-  // with `MarkdownParser`'s own `@synchronized(self)` in `parse:` is safe.
+  // Only protect the shared ivar updates with the lock. Holding
+  // `@synchronized(self)` across parse+format caused a lock-order inversion:
+  // `MarkdownParser parse:` synchronously enters the shared worklet runtime
+  // (recursive_mutex), so a background Fabric layout thread could hold this
+  // lock while blocked on the runtime mutex, leaving the main thread stuck in
+  // objc_sync_enter during Yoga measure until the watchdog killed the app
+  // (Sentry APP-EF1). Per-call consistency of style/parserId is preserved by
+  // formatting with the local parameters instead of re-reading the ivars.
   @synchronized (self) {
     _markdownStyle = markdownStyle;
     _parserId = parserId;
-    [self applyMarkdownFormatting:attributedString withDefaultTextAttributes:defaultTextAttributes];
   }
+
+  NSArray<MarkdownRange *> *markdownRanges = [_markdownParser cachedRangesForText:attributedString.string
+                                                                      withParserId:parserId];
+
+  if (markdownRanges == nil) {
+    if ([NSThread isMainThread]) {
+      // Never enter the worklet runtime from the main thread during Yoga
+      // measure. If the runtime is busy (e.g. a background Fabric layout is
+      // parsing, or a worklet is blocked on another runtime), the wait can
+      // exceed the ~2s watchdog limit and iOS kills the app (Sentry APP-EF1).
+      // Warm the cache asynchronously and measure with unformatted text for
+      // this pass; a subsequent measure/commit picks up the cached ranges.
+      // In practice the main thread almost always hits the cache here: text
+      // changes are committed (and parsed) on background threads first.
+      [_markdownParser warmCacheAsyncForText:attributedString.string withParserId:parserId];
+      return;
+    }
+    // Background Fabric layout threads may parse synchronously: the watchdog
+    // only monitors the main thread, and parse no longer holds any lock the
+    // main-thread measure path can block on.
+    markdownRanges = [_markdownParser parse:attributedString.string withParserId:parserId];
+  }
+
+  [_markdownFormatter formatAttributedString:attributedString
+                   withDefaultTextAttributes:defaultTextAttributes
+                          withMarkdownRanges:markdownRanges
+                           withMarkdownStyle:markdownStyle];
 }
 
 @end

--- a/apple/RCTMarkdownUtils.mm
+++ b/apple/RCTMarkdownUtils.mm
@@ -52,8 +52,8 @@
     _parserId = parserId;
   }
 
-  NSArray<MarkdownRange *> *markdownRanges = [_markdownParser cachedRangesForText:attributedString.string
-                                                                      withParserId:parserId];
+  NSString *text = attributedString.string;
+  NSArray<MarkdownRange *> *markdownRanges = [_markdownParser cachedRangesForText:text withParserId:parserId];
 
   if (markdownRanges == nil) {
     if ([NSThread isMainThread]) {
@@ -61,17 +61,31 @@
       // measure. If the runtime is busy (e.g. a background Fabric layout is
       // parsing, or a worklet is blocked on another runtime), the wait can
       // exceed the ~2s watchdog limit and iOS kills the app (Sentry APP-EF1).
-      // Warm the cache asynchronously and measure with unformatted text for
-      // this pass; a subsequent measure/commit picks up the cached ranges.
-      // In practice the main thread almost always hits the cache here: text
-      // changes are committed (and parsed) on background threads first.
-      [_markdownParser warmCacheAsyncForText:attributedString.string withParserId:parserId];
+      // Parse asynchronously and measure with unformatted text for this pass;
+      // `onAsyncFormattingReady` then triggers a re-measure once the ranges are
+      // cached, so the temporarily wrong metrics (h1 font size, code/pre font,
+      // blockquote indent, emoji size) cannot persist.
+      // In practice the main thread usually hits the cache here: text changes
+      // are committed (and parsed) on background threads first.
+      __weak RCTMarkdownUtils *weakSelf = self;
+      [_markdownParser warmCacheAsyncForText:text
+                                withParserId:parserId
+                                  completion:^{
+        // Runs on the parser's warm-up queue, only for the newest requested
+        // text. Cannot spin: the re-measure it asks for hits the cache and stops
+        // scheduling warm-ups (or the text changed again, in which case the new
+        // text needs a re-measure anyway).
+        void (^handler)(void) = weakSelf.onAsyncFormattingReady;
+        if (handler != nil) {
+          handler();
+        }
+      }];
       return;
     }
     // Background Fabric layout threads may parse synchronously: the watchdog
     // only monitors the main thread, and parse no longer holds any lock the
     // main-thread measure path can block on.
-    markdownRanges = [_markdownParser parse:attributedString.string withParserId:parserId];
+    markdownRanges = [_markdownParser parse:text withParserId:parserId];
   }
 
   [_markdownFormatter formatAttributedString:attributedString

--- a/apple/RCTMarkdownUtils.mm
+++ b/apple/RCTMarkdownUtils.mm
@@ -39,14 +39,12 @@
                   markdownStyle:(nonnull RCTMarkdownStyle *)markdownStyle
                        parserId:(nonnull NSNumber *)parserId
 {
-  // Only protect the shared ivar updates with the lock. Holding
-  // `@synchronized(self)` across parse+format caused a lock-order inversion:
-  // `MarkdownParser parse:` synchronously enters the shared worklet runtime
-  // (recursive_mutex), so a background Fabric layout thread could hold this
-  // lock while blocked on the runtime mutex, leaving the main thread stuck in
-  // objc_sync_enter during Yoga measure until the watchdog killed the app
-  // (Sentry APP-EF1). Per-call consistency of style/parserId is preserved by
-  // formatting with the local parameters instead of re-reading the ivars.
+  // The lock only covers the two shared fields. Holding it while parsing and
+  // formatting froze the app (Sentry APP-EF1): parsing waits for the worklet
+  // runtime, so a background thread could hold this lock while waiting, leaving
+  // the main thread stuck on the lock while measuring. The formatting below
+  // uses the arguments instead of the fields, so every call still gets a
+  // matching style and parserId.
   @synchronized (self) {
     _markdownStyle = markdownStyle;
     _parserId = parserId;
@@ -57,24 +55,21 @@
 
   if (markdownRanges == nil) {
     if ([NSThread isMainThread]) {
-      // Never enter the worklet runtime from the main thread during Yoga
-      // measure. If the runtime is busy (e.g. a background Fabric layout is
-      // parsing, or a worklet is blocked on another runtime), the wait can
-      // exceed the ~2s watchdog limit and iOS kills the app (Sentry APP-EF1).
-      // Parse asynchronously and measure with unformatted text for this pass;
-      // `onAsyncFormattingReady` then triggers a re-measure once the ranges are
-      // cached, so the temporarily wrong metrics (h1 font size, code/pre font,
-      // blockquote indent, emoji size) cannot persist.
-      // In practice the main thread usually hits the cache here: text changes
-      // are committed (and parsed) on background threads first.
+      // Never run the parser from the main thread while measuring. If the
+      // worklet runtime is busy, the wait can pass the ~2s limit and iOS kills
+      // the app (Sentry APP-EF1). Parse in the background instead and measure
+      // plain text for now; `onAsyncFormattingReady` asks for a new measure
+      // once the ranges are ready, so the wrong sizes (h1 font, code font,
+      // blockquote indent, emoji) do not stay. This rarely happens - text
+      // changes are usually parsed on a background thread first, so the main
+      // thread finds the ranges in the cache.
       __weak RCTMarkdownUtils *weakSelf = self;
       [_markdownParser warmCacheAsyncForText:text
                                 withParserId:parserId
                                   completion:^{
-        // Runs on the parser's warm-up queue, only for the newest requested
-        // text. Cannot spin: the re-measure it asks for hits the cache and stops
-        // scheduling warm-ups (or the text changed again, in which case the new
-        // text needs a re-measure anyway).
+        // This only runs for the newest text, so it can't loop forever: the new
+        // measure finds the ranges in the cache (or the text changed again, and
+        // then a new measure was needed anyway).
         void (^handler)(void) = weakSelf.onAsyncFormattingReady;
         if (handler != nil) {
           handler();
@@ -82,9 +77,9 @@
       }];
       return;
     }
-    // Background Fabric layout threads may parse synchronously: the watchdog
-    // only monitors the main thread, and parse no longer holds any lock the
-    // main-thread measure path can block on.
+    // Background threads can parse right here: the ~2s limit only applies to
+    // the main thread, and parsing no longer holds a lock the main thread
+    // waits on.
     markdownRanges = [_markdownParser parse:text withParserId:parserId];
   }
 


### PR DESCRIPTION
### Details

On iOS, `RCTMarkdownUtils` and `MarkdownParser` nest an Objective-C lock *outside* the markdown worklet runtime's `recursive_mutex`. That ordering lets a background thread hold the ObjC lock while it waits on the runtime mutex, which blocks the main thread in `objc_sync_enter` during Yoga measure until the iOS watchdog kills the app.

Today's code:

```objc
// RCTMarkdownUtils.mm
@synchronized (self) {
  _markdownStyle = markdownStyle;
  _parserId = parserId;
  [self applyMarkdownFormatting:...];   // -> MarkdownParser parse: -> runSync into the runtime
}

// MarkdownParser.mm
@synchronized (self) {
  ...
  output = markdownRuntime->runGuarded(markdownWorklet, input);   // blocks on recursive_mutex
  ...
}
```

Both locks are taken before entering the runtime, and the parse is synchronous, so the lock is held for the entire duration of the worklet call.

**The two threads in the captured hang:**

`com.facebook.react.runtime.JavaScript` — holds both `@synchronized` locks, blocked on the runtime mutex:

```
facebook::yoga::Node::measure
MarkdownTextInputDecoratorShadowNode::yogaNodeMeasureCallbackConnector
MarkdownTextInputDecoratorShadowNode::measureContent
MarkdownTextInputDecoratorShadowNode::applyMarkdownFormattingToTextInputState
-[RCTMarkdownUtils applyMarkdownFormatting:withDefaultTextAttributes:markdownStyle:parserId:]
-[RCTMarkdownUtils applyMarkdownFormatting:withDefaultTextAttributes:]
-[MarkdownParser parse:withParserId:]
worklets::WorkletRuntime::runSync<T>
...
worklets::WorkletRuntime::runSyncSerialized<T>
std::__1::recursive_mutex::lock
_pthread_mutex_firstfit_lock_slow
__psynch_mutexwait            <-- blocked here
```

Main thread — same measure path, blocked acquiring the lock the thread above is holding:

```
facebook::react::YogaLayoutableShadowNode::layoutTree
...
facebook::yoga::Node::measure
MarkdownTextInputDecoratorShadowNode::yogaNodeMeasureCallbackConnector
MarkdownTextInputDecoratorShadowNode::measureContent
MarkdownTextInputDecoratorShadowNode::applyMarkdownFormattingToTextInputState
-[RCTMarkdownUtils applyMarkdownFormatting:withDefaultTextAttributes:markdownStyle:parserId:]
objc_sync_enter
_os_unfair_lock_lock_slow
__ulock_wait2                 <-- blocked here
```

`Fatal App Hang Fully Blocked` — main thread blocked ≥ 2000 ms, culprit `-[RCTMarkdownUtils applyMarkdownFormatting:withDefaultTextAttributes:markdownStyle:parserId:]`. 

### The fix

Two changes, both aimed at removing "main thread waits on a runtime-bound lock":

**1. `MarkdownParser` — never hold an ObjC lock across the runtime call.**

`parse:` is split into a cache lookup, an unlocked `parseUncached:` that enters the runtime, and a locked memo write. The lock now only guards the `_prev*` ivars, so it is never held while waiting on `recursive_mutex` and the inversion is gone. Two concurrent misses may parse the same text twice; the runtime serializes them, results are identical, and last-writer-wins on a single-entry memo is safe.

Two new entry points:

- `cachedRangesForText:withParserId:` — memo lookup only, never touches the runtime, safe from the measure path on the main thread.
- `warmCacheAsyncForText:withParserId:` — schedules a parse on a serial `QOS_CLASS_USER_INITIATED` queue, guarded by an `_asyncParseInFlight` flag so warm-ups don't pile up.

**2. `RCTMarkdownUtils` — main thread formats from cache only.**

The lock narrows to the `_markdownStyle`/`_parserId` writes; formatting then uses the local parameters rather than re-reading the ivars, which preserves the per-call consistency the original single lock was there to provide. On a cache miss:

- **main thread**: schedule an async warm-up and return without formatting, so the runtime is never entered from the watchdog-monitored thread.
- **background layout threads**: parse synchronously as before. This is now safe because `parse:` no longer holds any lock the main-thread measure path can block on, and the watchdog only monitors the main thread.

### Tradeoffs / things I'd like reviewer input on

Flagging these because they're real and I'd rather they get caught here:

1. **A main-thread cache miss measures unformatted text.** Styles that change metrics (`h1` font size, `pre`/`code` font, blockquote indent, emoji font size) would measure wrong for that pass. In practice the main thread should almost always hit the cache, because text changes are committed and parsed on background threads first — but "almost always" is doing some work in that sentence.

2. **Nothing explicitly re-measures after the async warm-up lands.** The comment says a subsequent measure/commit picks up the cached ranges, and that's true whenever something else dirties layout, but there's no invalidation triggered by the warm-up itself. If Fabric has cached the measurement for that shadow node, a wrong height could persist until the text changes again. Should `warmCacheAsyncForText:` complete by dirtying the shadow node / requesting a new commit? That would make convergence guaranteed rather than incidental.

3. **The memo is single-entry, and now shared with a background writer.** Two alternating text values thrash it, and in that state the main thread would rarely hit the cache — falling into case 1 repeatedly. A small LRU (even 2–4 entries) keyed on `(text, parserId)` would make the main-thread fast path much more reliable. Happy to add it here if you'd prefer.

4. **`_asyncParseInFlight` can skip the newest text.** If a warm-up is already running for stale text, the newer text's warm-up is dropped and relies on a later measure pass observing the miss. Combined with (2), there's a path where it doesn't converge promptly. Coalescing to "latest requested text" instead of a boolean would be tighter.

An alternative worth considering: keep formatting synchronous everywhere and instead make the runtime entry non-blocking, or ensure the parse always happens on commit (before measure) so the measure path is cache-only by construction. That's a larger change; this PR is scoped to stopping the watchdog kills.

### Related Issues

https://github.com/Expensify/App/issues/93831

Internal: Sentry `APP-EF1` (https://expensify.sentry.io/issues/APP-EF1)

### Manual Tests

There is no ObjC test harness in this repo, so this was verified manually. Verified in the Expensify app (HybridApp, iOS) carrying this as a `patch-package` patch over `@expensify/react-native-live-markdown@0.1.334`:

- Markdown formatting in the composer still applies correctly — bold, italic, strikethrough, `code`, `pre`, blockquote, headings, mentions, links, emoji.
- Typing, fast typing, and paste of a large markdown block: formatting applies without a visible unformatted frame.
- Editing an existing message with markdown: correct formatting on open.
- Switching between reports with different composer drafts: no stale or cross-contaminated formatting (i.e. no wrong `parserId` applied).
- No main-thread hangs on the previously reproducing path.

Reviewers: please pay particular attention to composer height on first render of a heavily formatted draft — that's where tradeoff (1)/(2) above would show up as a layout jump or wrong height.

### Linked PRs

- Expensify/App: https://github.com/Expensify/App/pull/97871
