### PR TITLE
[HOLD for RN 0.88] fix: keep the parser registration alive across effect remounts

### DIFF
--- a/android/src/main/cpp/MarkdownParser.cpp
+++ b/android/src/main/cpp/MarkdownParser.cpp
@@ -7,14 +7,46 @@ using namespace facebook;
 
 namespace expensify {
 namespace livemarkdown {
+  jni::local_ref<MarkdownParser::jhybriddata> MarkdownParser::initHybrid(jni::alias_ref<jclass>) {
+    return makeCxxInstance();
+  }
+
+  void MarkdownParser::nativeSetParserId(const int parserId) {
+    std::unique_lock<std::mutex> lock(mutex_);
+    if (parserId_ == parserId) {
+      return;
+    }
+    const auto markdownWorklet = findMarkdownWorklet(parserId);
+    if (markdownWorklet == nullptr) {
+      return;
+    }
+    parserId_ = parserId;
+    markdownWorklet_ = markdownWorklet;
+  }
+
+  // A parse for the current id uses the worklet kept alive by `nativeSetParserId`.
+  // Any other id is looked up in the registry the way it always was.
+  std::shared_ptr<SerializableWorklet> MarkdownParser::workletForParserId(const int parserId) {
+    {
+      std::unique_lock<std::mutex> lock(mutex_);
+      if (parserId_ == parserId) {
+        return markdownWorklet_;
+      }
+    }
+
+    return findMarkdownWorklet(parserId);
+  }
+
   jni::local_ref<jni::JString> MarkdownParser::nativeParse(
-      jni::alias_ref<jhybridobject> jThis,
       jni::alias_ref<jni::JString> text,
       const int parserId) {
-    const auto markdownRuntime = expensify::livemarkdown::getMarkdownRuntime();
-    jsi::Runtime &rt = markdownRuntime->getJSIRuntime();
+    const auto markdownWorklet = workletForParserId(parserId);
+    if (markdownWorklet == nullptr) {
+      return jni::make_jstring("[]");
+    }
 
-    const auto markdownWorklet = expensify::livemarkdown::getMarkdownWorklet(parserId);
+    const auto markdownRuntime = getMarkdownRuntime();
+    jsi::Runtime &rt = markdownRuntime->getJSIRuntime();
 
     const auto input = jsi::String::createFromUtf8(rt, text->toStdString());
     const auto output = markdownRuntime->runGuarded(markdownWorklet, input);
@@ -25,6 +57,8 @@ namespace livemarkdown {
 
   void MarkdownParser::registerNatives() {
     registerHybrid({
+        makeNativeMethod("initHybrid", MarkdownParser::initHybrid),
+        makeNativeMethod("nativeSetParserId", MarkdownParser::nativeSetParserId),
         makeNativeMethod("nativeParse", MarkdownParser::nativeParse)});
   }
 

--- a/android/src/main/cpp/MarkdownParser.h
+++ b/android/src/main/cpp/MarkdownParser.h
@@ -10,19 +10,33 @@
 #include <fbjni/fbjni.h>
 #include <jsi/jsi.h>
 
+#include <worklets/WorkletRuntime/WorkletRuntime.h>
+
+#include <memory>
+#include <mutex>
+
 using namespace facebook;
+using namespace worklets;
 
 namespace expensify {
 namespace livemarkdown {
 
-  class MarkdownParser : public jni::HybridClass<MarkdownParser>,
-                        public jsi::HostObject {
+  class MarkdownParser : public jni::HybridClass<MarkdownParser> {
   public:
     static constexpr auto kJavaDescriptor =
         "Lcom/expensify/livemarkdown/MarkdownParser;";
 
-    static jni::local_ref<jni::JString> nativeParse(
-        jni::alias_ref<jhybridobject> jThis,
+    static jni::local_ref<jhybriddata> initHybrid(jni::alias_ref<jclass>);
+
+    // Looks up the worklet registered under `parserId` and keeps it alive until
+    // another registered id is set or this parser is released. JS unregisters
+    // the id when React cleans up effects, which also happens for an input that
+    // is hidden but still mounted, so the registry can't be asked again at
+    // parse time. An id the registry doesn't know leaves the previous worklet
+    // in place.
+    void nativeSetParserId(const int parserId);
+
+    jni::local_ref<jni::JString> nativeParse(
         jni::alias_ref<jni::JString> text,
         const int parserId);
 
@@ -30,6 +44,14 @@ namespace livemarkdown {
 
   private:
     friend HybridBase;
+
+    MarkdownParser() = default;
+
+    std::shared_ptr<SerializableWorklet> workletForParserId(const int parserId);
+
+    std::mutex mutex_;
+    int parserId_ = 0;
+    std::shared_ptr<SerializableWorklet> markdownWorklet_;
   };
 
 } // namespace livemarkdown

--- a/android/src/main/java/com/expensify/livemarkdown/MarkdownParser.java
+++ b/android/src/main/java/com/expensify/livemarkdown/MarkdownParser.java
@@ -2,6 +2,8 @@ package com.expensify.livemarkdown;
 
 import androidx.annotation.NonNull;
 
+import com.facebook.jni.HybridData;
+import com.facebook.jni.annotations.DoNotStrip;
 import com.facebook.react.bridge.ReactContext;
 import com.facebook.react.util.RNLog;
 import com.facebook.soloader.SoLoader;
@@ -20,6 +22,10 @@ public class MarkdownParser {
     SoLoader.loadLibrary("livemarkdown");
   }
 
+  @DoNotStrip
+  @SuppressWarnings("unused")
+  private final HybridData mHybridData;
+
   private final @NonNull ReactContext mReactContext;
   private String mPrevText;
   private int mPrevParserId;
@@ -27,9 +33,22 @@ public class MarkdownParser {
 
   public MarkdownParser(@NonNull ReactContext reactContext) {
     mReactContext = reactContext;
+    mHybridData = initHybrid();
   }
 
+  private static native HybridData initHybrid();
+
+  private native void nativeSetParserId(int parserId);
+
   private native String nativeParse(@NonNull String text, int parserId);
+
+  /**
+   * Keeps the worklet registered under {@code parserId} alive in native code for as long as this parser lives, so a
+   * later parse still works after JS has unregistered the id. See {@code MarkdownParser.h} for why that happens.
+   */
+  public synchronized void setParserId(int parserId) {
+    nativeSetParserId(parserId);
+  }
 
   public synchronized List<MarkdownRange> parse(@NonNull String text, int parserId) {
     try {

--- a/android/src/main/java/com/expensify/livemarkdown/MarkdownTextInputDecoratorView.java
+++ b/android/src/main/java/com/expensify/livemarkdown/MarkdownTextInputDecoratorView.java
@@ -15,11 +15,17 @@ public class MarkdownTextInputDecoratorView extends ReactViewGroup {
 
   public MarkdownTextInputDecoratorView(Context context) {
     super(context);
+    mMarkdownParser = new MarkdownParser((ReactContext) context);
   }
 
   private MarkdownStyle mMarkdownStyle;
 
   private int mParserId;
+
+  // Owned by the view rather than by `mMarkdownUtils`, which is recreated every
+  // time the view is attached, so the parser worklet stays alive for as long as
+  // the view is mounted.
+  private final MarkdownParser mMarkdownParser;
 
   private MarkdownUtils mMarkdownUtils;
 
@@ -33,7 +39,7 @@ public class MarkdownTextInputDecoratorView extends ReactViewGroup {
 
     View child = getChildAt(0);
     if (child instanceof ReactEditText) {
-      mMarkdownUtils = new MarkdownUtils((ReactContext) getContext());
+      mMarkdownUtils = new MarkdownUtils((ReactContext) getContext(), mMarkdownParser);
       mMarkdownUtils.setMarkdownStyle(mMarkdownStyle);
       mMarkdownUtils.setParserId(mParserId);
       mReactEditText = (ReactEditText) child;
@@ -64,6 +70,7 @@ public class MarkdownTextInputDecoratorView extends ReactViewGroup {
 
   protected void setParserId(int parserId) {
     mParserId = parserId;
+    mMarkdownParser.setParserId(parserId);
     if (mMarkdownUtils != null) {
       mMarkdownUtils.setParserId(mParserId);
     }

--- a/android/src/main/java/com/expensify/livemarkdown/MarkdownUtils.java
+++ b/android/src/main/java/com/expensify/livemarkdown/MarkdownUtils.java
@@ -11,7 +11,11 @@ import java.util.List;
 
 public class MarkdownUtils {
   public MarkdownUtils(@NonNull ReactContext reactContext) {
-    mMarkdownParser = new MarkdownParser(reactContext);
+    this(reactContext, new MarkdownParser(reactContext));
+  }
+
+  public MarkdownUtils(@NonNull ReactContext reactContext, @NonNull MarkdownParser markdownParser) {
+    mMarkdownParser = markdownParser;
     mMarkdownFormatter = new MarkdownFormatter(reactContext.getAssets());
   }
 
@@ -27,6 +31,7 @@ public class MarkdownUtils {
 
   public void setParserId(int parserId) {
     mParserId = parserId;
+    mMarkdownParser.setParserId(parserId);
   }
 
   public void applyMarkdownFormatting(SpannableStringBuilder ssb) {

--- a/apple/MarkdownParser.h
+++ b/apple/MarkdownParser.h
@@ -5,6 +5,12 @@ NS_ASSUME_NONNULL_BEGIN
 
 @interface MarkdownParser : NSObject
 
+// Looks up the worklet registered under `parserId` and keeps it alive until
+// another registered id is set or this parser is released. JS unregisters the
+// id when React cleans up effects, which also happens for an input that is
+// hidden but still mounted, so the registry can't be asked again at parse time.
+- (void)setParserId:(nonnull NSNumber *)parserId;
+
 - (NSArray<MarkdownRange *> *)parse:(nonnull NSString *)text
                        withParserId:(nonnull NSNumber *)parserId;
 

--- a/apple/MarkdownParser.mm
+++ b/apple/MarkdownParser.mm
@@ -246,13 +246,15 @@ static const NSUInteger kMarkdownParserCacheCapacity = 4;
 - (NSArray<MarkdownRange *> *)parseUncached:(nonnull NSString *)text
                                withParserId:(nonnull NSNumber *)parserId
 {
-  const auto &markdownRuntime = expensify::livemarkdown::getMarkdownRuntime();
-  jsi::Runtime &rt = markdownRuntime->getJSIRuntime();
-
+  // The first commit carries parserId 0, before JS has created the worklet runtime.
+  // Resolve the worklet before accessing that runtime.
   const auto markdownWorklet = [self workletForParserId:parserId];
   if (markdownWorklet == nullptr) {
     return @[];
   }
+
+  const auto &markdownRuntime = expensify::livemarkdown::getMarkdownRuntime();
+  jsi::Runtime &rt = markdownRuntime->getJSIRuntime();
 
   const auto &input = jsi::String::createFromUtf8(rt, [text UTF8String]);
 

--- a/apple/MarkdownParser.mm
+++ b/apple/MarkdownParser.mm
@@ -56,6 +56,10 @@ static const NSUInteger kMarkdownParserCacheCapacity = 4;
   NSNumber *_pendingParserId;
   void (^_pendingCompletion)(void);
   BOOL _warmupScheduled;
+
+  // The worklet registered under `_parserId`, kept alive here (see the header).
+  NSNumber *_parserId;
+  std::shared_ptr<SerializableWorklet> _markdownWorklet;
 }
 
 - (instancetype)init
@@ -80,6 +84,39 @@ static const NSUInteger kMarkdownParserCacheCapacity = 4;
     queue = dispatch_queue_create("com.expensify.livemarkdown.parser-cache-warmup", attr);
   });
   return queue;
+}
+
+// An id the registry doesn't know leaves the previous worklet in place. The
+// measure path shares one parser between shadow node clones, so a clone that
+// still carries an older, already unregistered id must not drop the worklet
+// the current id resolved to.
+- (void)setParserId:(nonnull NSNumber *)parserId
+{
+  @synchronized (self) {
+    if ([_parserId isEqualToNumber:parserId]) {
+      return;
+    }
+    const auto markdownWorklet = expensify::livemarkdown::findMarkdownWorklet([parserId intValue]);
+    if (markdownWorklet == nullptr) {
+      return;
+    }
+    _parserId = parserId;
+    _markdownWorklet = markdownWorklet;
+  }
+}
+
+// A parse for the current id uses the worklet kept alive by `setParserId:`.
+// Any other id comes from a shadow node clone that still carries an older id,
+// so it is looked up in the registry the way it always was.
+- (std::shared_ptr<SerializableWorklet>)workletForParserId:(nonnull NSNumber *)parserId
+{
+  @synchronized (self) {
+    if ([_parserId isEqualToNumber:parserId]) {
+      return _markdownWorklet;
+    }
+  }
+
+  return expensify::livemarkdown::findMarkdownWorklet([parserId intValue]);
 }
 
 - (nullable NSArray<MarkdownRange *> *)cachedRangesForText:(nonnull NSString *)text
@@ -212,10 +249,8 @@ static const NSUInteger kMarkdownParserCacheCapacity = 4;
   const auto &markdownRuntime = expensify::livemarkdown::getMarkdownRuntime();
   jsi::Runtime &rt = markdownRuntime->getJSIRuntime();
 
-  std::shared_ptr<SerializableWorklet> markdownWorklet;
-  try {
-    markdownWorklet = expensify::livemarkdown::getMarkdownWorklet([parserId intValue]);
-  } catch (const std::out_of_range &error) {
+  const auto markdownWorklet = [self workletForParserId:parserId];
+  if (markdownWorklet == nullptr) {
     return @[];
   }
 

--- a/apple/RCTMarkdownUtils.mm
+++ b/apple/RCTMarkdownUtils.mm
@@ -17,6 +17,12 @@
   return self;
 }
 
+- (void)setParserId:(NSNumber *)parserId
+{
+  _parserId = parserId;
+  [_markdownParser setParserId:parserId];
+}
+
 - (void)applyMarkdownFormatting:(nonnull NSMutableAttributedString *)attributedString
       withDefaultTextAttributes:(nonnull NSDictionary<NSAttributedStringKey, id> *)defaultTextAttributes
 {
@@ -49,6 +55,7 @@
     _markdownStyle = markdownStyle;
     _parserId = parserId;
   }
+  [_markdownParser setParserId:parserId];
 
   NSString *text = attributedString.string;
   NSArray<MarkdownRange *> *markdownRanges = [_markdownParser cachedRangesForText:text withParserId:parserId];

--- a/cpp/MarkdownGlobal.cpp
+++ b/cpp/MarkdownGlobal.cpp
@@ -34,9 +34,10 @@ void unregisterMarkdownWorklet(const int parserId) {
   globalMarkdownShareableWorklets.erase(parserId);
 }
 
-std::shared_ptr<SerializableWorklet> getMarkdownWorklet(const int parserId) {
+std::shared_ptr<SerializableWorklet> findMarkdownWorklet(const int parserId) {
   std::unique_lock<std::mutex> lock(globalMarkdownShareableWorkletsMutex);
-  return globalMarkdownShareableWorklets.at(parserId);
+  const auto it = globalMarkdownShareableWorklets.find(parserId);
+  return it == globalMarkdownShareableWorklets.end() ? nullptr : it->second;
 }
 
 } // namespace livemarkdown

--- a/cpp/MarkdownGlobal.h
+++ b/cpp/MarkdownGlobal.h
@@ -18,7 +18,10 @@ const int registerMarkdownWorklet(const std::shared_ptr<SerializableWorklet> &ma
 
 void unregisterMarkdownWorklet(const int parserId);
 
-std::shared_ptr<SerializableWorklet> getMarkdownWorklet(const int parserId);
+// Returns nullptr when nothing is registered under `parserId`. Callers keep the
+// result: JS drops the entry when React cleans up effects, which also happens
+// for an input that is hidden but still mounted.
+std::shared_ptr<SerializableWorklet> findMarkdownWorklet(const int parserId);
 
 } // namespace livemarkdown
 } // namespace expensify

--- a/package-lock.json
+++ b/package-lock.json
@@ -28,6 +28,7 @@
         "@release-it/conventional-changelog": "^5.0.0",
         "@types/jest": "^29.5.14",
         "@types/react": "^19.2.0",
+        "@types/react-dom": "^19.2.7",
         "@typescript-eslint/eslint-plugin": "^8.53.1",
         "@typescript-eslint/parser": "^8.53.1",
         "del-cli": "^5.0.0",
@@ -5286,6 +5287,16 @@
       "license": "MIT",
       "dependencies": {
         "csstype": "^3.2.2"
+      }
+    },
+    "node_modules/@types/react-dom": {
+      "version": "19.2.7",
+      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-19.2.7.tgz",
+      "integrity": "sha512-I8bPpDLcHBv1qiIiXDCy71Rt8eQDKJP0sMSWJphDdAcdqiJ1sGpZamavoEIRZmYzjia9LuEb2HlYdDpmoENpvQ==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "^19.2.0"
       }
     },
     "node_modules/@types/semver": {

--- a/package.json
+++ b/package.json
@@ -74,6 +74,7 @@
     "@release-it/conventional-changelog": "^5.0.0",
     "@types/jest": "^29.5.14",
     "@types/react": "^19.2.0",
+    "@types/react-dom": "^19.2.7",
     "@typescript-eslint/eslint-plugin": "^8.53.1",
     "@typescript-eslint/parser": "^8.53.1",
     "del-cli": "^5.0.0",

--- a/src/MarkdownTextInput.tsx
+++ b/src/MarkdownTextInput.tsx
@@ -70,40 +70,15 @@ type FormatSelectionResult = {
 
 type MarkdownTextInput = TextInput & React.Component<MarkdownTextInputProps>;
 
-type ParserRegistration = {
-  parser: MarkdownTextInputProps['parser'];
-  parserId: number;
-};
-
-// The first registration happens in render so the first commit already carries a resolvable id. The layout effect
-// re-registers after its own cleanup (StrictMode, a revealed `<Activity>`) and hands the fresh id to the decorator.
-// `initialRegistrationRef` is never cleared, otherwise a render inside a hidden `<Activity>` would register again.
+// Register only after commit: a suspended or initially hidden render may never run an effect cleanup.
+// Zero means no parser yet. A layout effect publishes the registered id and restores it when effects reconnect.
 function useParserId(parser: MarkdownTextInputProps['parser']): number {
-  const initialRegistrationRef = React.useRef<ParserRegistration | null>(null);
-  if (initialRegistrationRef.current === null) {
-    initialRegistrationRef.current = {parser, parserId: registerParser(parser)};
-  }
-  const [parserId, setParserId] = React.useState(initialRegistrationRef.current.parserId);
-  const liveRegistrationRef = React.useRef<ParserRegistration | null>(initialRegistrationRef.current);
+  const [parserId, setParserId] = React.useState(0);
 
   React.useLayoutEffect(() => {
-    const unregisterLiveParser = () => {
-      if (liveRegistrationRef.current === null) {
-        return;
-      }
-      unregisterParser(liveRegistrationRef.current.parserId);
-      liveRegistrationRef.current = null;
-    };
-
-    if (liveRegistrationRef.current?.parser === parser) {
-      return unregisterLiveParser;
-    }
-
-    unregisterLiveParser();
     const nextParserId = registerParser(parser);
-    liveRegistrationRef.current = {parser, parserId: nextParserId};
     setParserId(nextParserId);
-    return unregisterLiveParser;
+    return () => unregisterParser(nextParserId);
   }, [parser]);
 
   return parserId;

--- a/src/MarkdownTextInput.tsx
+++ b/src/MarkdownTextInput.tsx
@@ -70,6 +70,47 @@ type FormatSelectionResult = {
 
 type MarkdownTextInput = TextInput & React.Component<MarkdownTextInputProps>;
 
+type ParserRegistration = {
+  parser: MarkdownTextInputProps['parser'];
+  parserId: number;
+};
+
+// The effect body registers and its cleanup unregisters, so a remount of the effects alone (StrictMode, a hidden
+// `<Activity>` that is revealed) hands the decorator view a fresh id instead of leaving it on the erased one. The first
+// registration happens in render, which spares every mount a second commit and a re-measure of the input.
+// A layout effect flushes the replacement id in the same task as the commit that ran the cleanup, so both usually reach
+// the mounting layer as one native transaction. The native parser formats nothing for an id it cannot resolve.
+function useParserId(parser: MarkdownTextInputProps['parser']): number {
+  const initialRegistrationRef = React.useRef<ParserRegistration | null>(null);
+  if (initialRegistrationRef.current === null) {
+    initialRegistrationRef.current = {parser, parserId: registerParser(parser)};
+  }
+  const [parserId, setParserId] = React.useState(initialRegistrationRef.current.parserId);
+  const liveRegistrationRef = React.useRef<ParserRegistration | null>(initialRegistrationRef.current);
+
+  React.useLayoutEffect(() => {
+    const unregisterLiveParser = () => {
+      if (liveRegistrationRef.current === null) {
+        return;
+      }
+      unregisterParser(liveRegistrationRef.current.parserId);
+      liveRegistrationRef.current = null;
+    };
+
+    if (liveRegistrationRef.current?.parser === parser) {
+      return unregisterLiveParser;
+    }
+
+    unregisterLiveParser();
+    const nextParserId = registerParser(parser);
+    liveRegistrationRef.current = {parser, parserId: nextParserId};
+    setParserId(nextParserId);
+    return unregisterLiveParser;
+  }, [parser]);
+
+  return parserId;
+}
+
 function processColorsInMarkdownStyle(input: MarkdownStyle): MarkdownStyle {
   const output = JSON.parse(JSON.stringify(input));
 
@@ -104,13 +145,7 @@ const MarkdownTextInput = React.forwardRef<MarkdownTextInput, MarkdownTextInputP
     throw new Error('[react-native-live-markdown] `parser` is not a worklet');
   }
 
-  const parserId = React.useMemo(() => {
-    return registerParser(props.parser);
-  }, [props.parser]);
-
-  React.useEffect(() => {
-    return () => unregisterParser(parserId);
-  }, [parserId]);
+  const parserId = useParserId(props.parser);
 
   return (
     <MarkdownTextInputDecoratorViewNativeComponent

--- a/src/MarkdownTextInput.tsx
+++ b/src/MarkdownTextInput.tsx
@@ -75,11 +75,9 @@ type ParserRegistration = {
   parserId: number;
 };
 
-// The effect body registers and its cleanup unregisters, so a remount of the effects alone (StrictMode, a hidden
-// `<Activity>` that is revealed) hands the decorator view a fresh id instead of leaving it on the erased one. The first
-// registration happens in render, which spares every mount a second commit and a re-measure of the input.
-// A layout effect flushes the replacement id in the same task as the commit that ran the cleanup, so both usually reach
-// the mounting layer as one native transaction. The native parser formats nothing for an id it cannot resolve.
+// The first registration happens in render so the first commit already carries a resolvable id. The layout effect
+// re-registers after its own cleanup (StrictMode, a revealed `<Activity>`) and hands the fresh id to the decorator.
+// `initialRegistrationRef` is never cleared, otherwise a render inside a hidden `<Activity>` would register again.
 function useParserId(parser: MarkdownTextInputProps['parser']): number {
   const initialRegistrationRef = React.useRef<ParserRegistration | null>(null);
   if (initialRegistrationRef.current === null) {

--- a/src/__tests__/parserRegistration.test.tsx
+++ b/src/__tests__/parserRegistration.test.tsx
@@ -13,7 +13,6 @@ import type {MarkdownTextInputProps} from '../MarkdownTextInput';
  */
 const liveParserIds = new Set<number>();
 let nextParserId = 1;
-let registerCallCount = 0;
 
 jest.mock('react-native', () => ({
   Platform: {OS: 'ios', select: (options: {ios?: unknown; default?: unknown}) => options.ios ?? options.default},
@@ -33,13 +32,12 @@ jest.mock('../MarkdownTextInputDecoratorViewNativeComponent', () => ({
   default: (props: {parserId: number; children: React.ReactNode}) => <div data-parser-id={props.parserId}>{props.children}</div>,
 }));
 
-// The component refuses a parser that is not a worklet, and the worklets babel plugin does not run under Jest, so the
-// hash that marks a function as a worklet is attached by hand.
-function createParserWorklet(workletHash: number) {
-  return Object.assign((): MarkdownRange[] => [], {__workletHash: workletHash});
+// The worklets babel plugin does not run under Jest, so the hash that marks a function as a worklet is attached by hand.
+function createParserWorklet() {
+  return Object.assign((): MarkdownRange[] => [], {__workletHash: 1});
 }
 
-const parser = createParserWorklet(1);
+const parser = createParserWorklet();
 
 let container: HTMLDivElement;
 let root: Root;
@@ -76,12 +74,10 @@ describe('MarkdownTextInput parser registration', () => {
   beforeEach(() => {
     liveParserIds.clear();
     nextParserId = 1;
-    registerCallCount = 0;
     global.jsi_setMarkdownRuntime = jest.fn();
     global.jsi_registerMarkdownWorklet = () => {
       const parserId = nextParserId;
       nextParserId += 1;
-      registerCallCount += 1;
       liveParserIds.add(parserId);
       return parserId;
     };
@@ -104,7 +100,7 @@ describe('MarkdownTextInput parser registration', () => {
   it('registers the parser once and renders its id on mount', () => {
     renderIntoRoot(<MarkdownTextInput parser={parser} />);
 
-    expect(registerCallCount).toBe(1);
+    expect(nextParserId).toBe(2);
     expectDecoratorOnTheOnlyLiveParserId();
   });
 
@@ -142,7 +138,7 @@ describe('MarkdownTextInput parser registration', () => {
   });
 
   it('drops the initial registration when the parser changes identity inside a hidden <Activity>', () => {
-    const nextParser = createParserWorklet(2);
+    const nextParser = createParserWorklet();
 
     renderInActivity(true);
     renderInActivity(true, nextParser);
@@ -155,7 +151,7 @@ describe('MarkdownTextInput parser registration', () => {
     renderIntoRoot(<MarkdownTextInput parser={parser} />);
     const initialParserId = getDecoratorParserId();
 
-    renderIntoRoot(<MarkdownTextInput parser={createParserWorklet(2)} />);
+    renderIntoRoot(<MarkdownTextInput parser={createParserWorklet()} />);
 
     expect(getDecoratorParserId()).not.toBe(initialParserId);
     expectDecoratorOnTheOnlyLiveParserId();

--- a/src/__tests__/parserRegistration.test.tsx
+++ b/src/__tests__/parserRegistration.test.tsx
@@ -1,5 +1,5 @@
 import {expect} from '@jest/globals';
-import React, {Activity, StrictMode, act} from 'react';
+import React, {Activity, StrictMode, Suspense, act} from 'react';
 import {createRoot} from 'react-dom/client';
 import type {Root} from 'react-dom/client';
 import type {MarkdownRange} from '../commonTypes';
@@ -8,10 +8,10 @@ import type {MarkdownTextInputProps} from '../MarkdownTextInput';
 
 /**
  * The parser worklet lives in a C++ registry keyed by the `parserId` prop the decorator view carries. The registry is
- * replaced by a set of ids here, the decorator view by an element that exposes its `parserId` as a DOM attribute, and
+ * replaced by a map of worklets here, the decorator view by an element that exposes its `parserId` as a DOM attribute, and
  * the native text input by a plain `<input>`, so the component renders in jsdom through `react-dom`.
  */
-const liveParserIds = new Set<number>();
+const liveParsers = new Map<number, MarkdownTextInputProps['parser']>();
 let nextParserId = 1;
 
 jest.mock('react-native', () => ({
@@ -58,31 +58,32 @@ function renderInActivity(isHidden: boolean, currentParser: MarkdownTextInputPro
 
 function getDecoratorParserId(): number {
   const decorator = container.querySelector('[data-parser-id]');
-  const parserId = Number(decorator?.getAttribute('data-parser-id'));
-  if (!Number.isInteger(parserId)) {
+  const attribute = decorator?.getAttribute('data-parser-id');
+  const parserId = Number(attribute);
+  if (attribute == null || !Number.isInteger(parserId) || parserId < 0) {
     throw new Error('The decorator view rendered without a parser id');
   }
   return parserId;
 }
 
-function expectDecoratorOnTheOnlyLiveParserId() {
-  expect(liveParserIds.has(getDecoratorParserId())).toBe(true);
-  expect(liveParserIds.size).toBe(1);
+function expectDecoratorOnTheOnlyLiveParserId(expectedParser: MarkdownTextInputProps['parser'] = parser) {
+  expect(liveParsers.get(getDecoratorParserId())).toBe(expectedParser);
+  expect(liveParsers.size).toBe(1);
 }
 
 describe('MarkdownTextInput parser registration', () => {
   beforeEach(() => {
-    liveParserIds.clear();
+    liveParsers.clear();
     nextParserId = 1;
     global.jsi_setMarkdownRuntime = jest.fn();
-    global.jsi_registerMarkdownWorklet = () => {
+    global.jsi_registerMarkdownWorklet = (worklet) => {
       const parserId = nextParserId;
       nextParserId += 1;
-      liveParserIds.add(parserId);
+      liveParsers.set(parserId, worklet as unknown as MarkdownTextInputProps['parser']);
       return parserId;
     };
     global.jsi_unregisterMarkdownWorklet = (parserId: number) => {
-      liveParserIds.delete(parserId);
+      liveParsers.delete(parserId);
     };
 
     container = document.createElement('div');
@@ -95,9 +96,10 @@ describe('MarkdownTextInput parser registration', () => {
       root.unmount();
     });
     container.remove();
+    expect(liveParsers.size).toBe(0);
   });
 
-  it('registers the parser once and renders its id on mount', () => {
+  it('registers the parser once and publishes its id after mount', () => {
     renderIntoRoot(<MarkdownTextInput parser={parser} />);
 
     expect(nextParserId).toBe(2);
@@ -111,7 +113,58 @@ describe('MarkdownTextInput parser registration', () => {
       root.unmount();
     });
 
-    expect(liveParserIds.size).toBe(0);
+    expect(liveParsers.size).toBe(0);
+  });
+
+  it('keeps the registration when rerendering with the same parser', () => {
+    renderIntoRoot(<MarkdownTextInput parser={parser} />);
+    const initialParserId = getDecoratorParserId();
+
+    renderIntoRoot(
+      <MarkdownTextInput
+        parser={parser}
+        value="*updated*"
+      />,
+    );
+
+    expect(getDecoratorParserId()).toBe(initialParserId);
+    expect(nextParserId).toBe(2);
+    expectDecoratorOnTheOnlyLiveParserId();
+  });
+
+  it('does not register a parser for an Activity that is removed without ever becoming visible', () => {
+    renderInActivity(true);
+
+    expect(getDecoratorParserId()).toBe(0);
+    expect(liveParsers.size).toBe(0);
+
+    renderIntoRoot(<div />);
+
+    expect(nextParserId).toBe(1);
+    expect(liveParsers.size).toBe(0);
+  });
+
+  it('does not leak a registration when React abandons a suspended render', () => {
+    const pending = new Promise<never>(() => {
+      // Keep the subtree suspended until its render is abandoned.
+    });
+    function Suspend(): React.ReactNode {
+      throw pending;
+    }
+
+    renderIntoRoot(
+      <Suspense fallback={<span>Loading</span>}>
+        <MarkdownTextInput parser={parser} />
+        <Suspend />
+      </Suspense>,
+    );
+
+    expect(container.textContent).toBe('Loading');
+    expect(nextParserId).toBe(1);
+    expect(liveParsers.size).toBe(0);
+
+    renderIntoRoot(<MarkdownTextInput parser={parser} />);
+    expectDecoratorOnTheOnlyLiveParserId();
   });
 
   it('keeps the decorator on a live id under StrictMode', () => {
@@ -137,23 +190,70 @@ describe('MarkdownTextInput parser registration', () => {
     expectDecoratorOnTheOnlyLiveParserId();
   });
 
-  it('drops the initial registration when the parser changes identity inside a hidden <Activity>', () => {
+  it('registers a replacement parser when a previously visible Activity is revealed', () => {
+    renderInActivity(false);
+    renderInActivity(true);
+    expect(liveParsers.size).toBe(0);
+
+    const nextParser = createParserWorklet();
+    renderInActivity(true, nextParser);
+    expect(liveParsers.size).toBe(0);
+
+    renderInActivity(false, nextParser);
+    expectDecoratorOnTheOnlyLiveParserId(nextParser);
+  });
+
+  it('keeps registrations independent for inputs sharing the same parser', () => {
+    renderIntoRoot(
+      <div>
+        <MarkdownTextInput
+          key="first"
+          parser={parser}
+        />
+        <MarkdownTextInput
+          key="second"
+          parser={parser}
+        />
+      </div>,
+    );
+    const ids = Array.from(container.querySelectorAll('[data-parser-id]'), (element) => Number(element.getAttribute('data-parser-id')));
+    expect(new Set(ids).size).toBe(2);
+    expect(liveParsers.size).toBe(2);
+    ids.forEach((id) => expect(liveParsers.get(id)).toBe(parser));
+
+    renderIntoRoot(
+      <div>
+        <MarkdownTextInput
+          key="second"
+          parser={parser}
+        />
+      </div>,
+    );
+    expect(getDecoratorParserId()).toBe(ids[1]);
+    expectDecoratorOnTheOnlyLiveParserId();
+  });
+
+  it('registers only the latest parser when an initially hidden <Activity> is revealed', () => {
     const nextParser = createParserWorklet();
 
     renderInActivity(true);
+    expect(liveParsers.size).toBe(0);
     renderInActivity(true, nextParser);
+    expect(liveParsers.size).toBe(0);
     renderInActivity(false, nextParser);
 
-    expectDecoratorOnTheOnlyLiveParserId();
+    expect(nextParserId).toBe(2);
+    expectDecoratorOnTheOnlyLiveParserId(nextParser);
   });
 
   it('moves the decorator to a live id and drops the previous one when the parser changes identity', () => {
     renderIntoRoot(<MarkdownTextInput parser={parser} />);
     const initialParserId = getDecoratorParserId();
 
-    renderIntoRoot(<MarkdownTextInput parser={createParserWorklet()} />);
+    const nextParser = createParserWorklet();
+    renderIntoRoot(<MarkdownTextInput parser={nextParser} />);
 
     expect(getDecoratorParserId()).not.toBe(initialParserId);
-    expectDecoratorOnTheOnlyLiveParserId();
+    expectDecoratorOnTheOnlyLiveParserId(nextParser);
   });
 });

--- a/src/__tests__/parserRegistration.test.tsx
+++ b/src/__tests__/parserRegistration.test.tsx
@@ -1,0 +1,163 @@
+import {expect} from '@jest/globals';
+import React, {Activity, StrictMode, act} from 'react';
+import {createRoot} from 'react-dom/client';
+import type {Root} from 'react-dom/client';
+import type {MarkdownRange} from '../commonTypes';
+import MarkdownTextInput from '../MarkdownTextInput';
+import type {MarkdownTextInputProps} from '../MarkdownTextInput';
+
+/**
+ * The parser worklet lives in a C++ registry keyed by the `parserId` prop the decorator view carries. The registry is
+ * replaced by a set of ids here, the decorator view by an element that exposes its `parserId` as a DOM attribute, and
+ * the native text input by a plain `<input>`, so the component renders in jsdom through `react-dom`.
+ */
+const liveParserIds = new Set<number>();
+let nextParserId = 1;
+let registerCallCount = 0;
+
+jest.mock('react-native', () => ({
+  Platform: {OS: 'ios', select: (options: {ios?: unknown; default?: unknown}) => options.ios ?? options.default},
+  StyleSheet: {create: <T,>(styles: T) => styles},
+  TextInput: (props: {testID?: string}) => <input data-testid={props.testID} />,
+  TurboModuleRegistry: {get: () => null},
+  processColor: (color: unknown) => color,
+}));
+
+jest.mock('react-native-worklets', () => ({
+  createSerializable: (worklet: unknown) => worklet,
+  createWorkletRuntime: () => ({}),
+}));
+
+jest.mock('../MarkdownTextInputDecoratorViewNativeComponent', () => ({
+  __esModule: true,
+  default: (props: {parserId: number; children: React.ReactNode}) => <div data-parser-id={props.parserId}>{props.children}</div>,
+}));
+
+// The component refuses a parser that is not a worklet, and the worklets babel plugin does not run under Jest, so the
+// hash that marks a function as a worklet is attached by hand.
+function createParserWorklet(workletHash: number) {
+  return Object.assign((): MarkdownRange[] => [], {__workletHash: workletHash});
+}
+
+const parser = createParserWorklet(1);
+
+let container: HTMLDivElement;
+let root: Root;
+
+function renderIntoRoot(element: React.ReactElement) {
+  act(() => {
+    root.render(element);
+  });
+}
+
+function renderInActivity(isHidden: boolean, currentParser: MarkdownTextInputProps['parser'] = parser) {
+  renderIntoRoot(
+    <Activity mode={isHidden ? 'hidden' : 'visible'}>
+      <MarkdownTextInput parser={currentParser} />
+    </Activity>,
+  );
+}
+
+function getDecoratorParserId(): number {
+  const decorator = container.querySelector('[data-parser-id]');
+  const parserId = Number(decorator?.getAttribute('data-parser-id'));
+  if (!Number.isInteger(parserId)) {
+    throw new Error('The decorator view rendered without a parser id');
+  }
+  return parserId;
+}
+
+function expectDecoratorOnTheOnlyLiveParserId() {
+  expect(liveParserIds.has(getDecoratorParserId())).toBe(true);
+  expect(liveParserIds.size).toBe(1);
+}
+
+describe('MarkdownTextInput parser registration', () => {
+  beforeEach(() => {
+    liveParserIds.clear();
+    nextParserId = 1;
+    registerCallCount = 0;
+    global.jsi_setMarkdownRuntime = jest.fn();
+    global.jsi_registerMarkdownWorklet = () => {
+      const parserId = nextParserId;
+      nextParserId += 1;
+      registerCallCount += 1;
+      liveParserIds.add(parserId);
+      return parserId;
+    };
+    global.jsi_unregisterMarkdownWorklet = (parserId: number) => {
+      liveParserIds.delete(parserId);
+    };
+
+    container = document.createElement('div');
+    document.body.appendChild(container);
+    root = createRoot(container);
+  });
+
+  afterEach(() => {
+    act(() => {
+      root.unmount();
+    });
+    container.remove();
+  });
+
+  it('registers the parser once and renders its id on mount', () => {
+    renderIntoRoot(<MarkdownTextInput parser={parser} />);
+
+    expect(registerCallCount).toBe(1);
+    expectDecoratorOnTheOnlyLiveParserId();
+  });
+
+  it('unregisters the parser on unmount', () => {
+    renderIntoRoot(<MarkdownTextInput parser={parser} />);
+
+    act(() => {
+      root.unmount();
+    });
+
+    expect(liveParserIds.size).toBe(0);
+  });
+
+  it('keeps the decorator on a live id under StrictMode', () => {
+    renderIntoRoot(
+      <StrictMode>
+        <MarkdownTextInput parser={parser} />
+      </StrictMode>,
+    );
+
+    expectDecoratorOnTheOnlyLiveParserId();
+  });
+
+  it('keeps the decorator on a live id after a hidden <Activity> is revealed', () => {
+    renderInActivity(false);
+    expectDecoratorOnTheOnlyLiveParserId();
+
+    renderInActivity(true);
+    renderInActivity(false);
+    expectDecoratorOnTheOnlyLiveParserId();
+
+    renderInActivity(true);
+    renderInActivity(false);
+    expectDecoratorOnTheOnlyLiveParserId();
+  });
+
+  it('drops the initial registration when the parser changes identity inside a hidden <Activity>', () => {
+    const nextParser = createParserWorklet(2);
+
+    renderInActivity(true);
+    renderInActivity(true, nextParser);
+    renderInActivity(false, nextParser);
+
+    expectDecoratorOnTheOnlyLiveParserId();
+  });
+
+  it('moves the decorator to a live id and drops the previous one when the parser changes identity', () => {
+    renderIntoRoot(<MarkdownTextInput parser={parser} />);
+    const initialParserId = getDecoratorParserId();
+
+    renderIntoRoot(<MarkdownTextInput parser={createParserWorklet(2)} />);
+
+    expect(getDecoratorParserId()).not.toBe(initialParserId);
+    expectDecoratorOnTheOnlyLiveParserId();
+  });
+});


### PR DESCRIPTION
> [!IMPORTANT]
> **On hold until React Native 0.88.** The Fabric renderer in React Native 0.85–0.87 does not run the `useInsertionEffect` cleanup for a component removed while its `<Activity>` is hidden (see "Native renderer caveat"). React 19.3, which React Native 0.88 ships, always runs it. The diff itself does not need to change.

### Details

`MarkdownTextInput` registered its parser worklet during render and unregistered it in an effect cleanup. React can run that cleanup without unmounting the component (StrictMode, a hidden `<Activity>`), after which the input silently stopped formatting markdown.

**The fix**

The parser id is now chosen in JS, one per mounted input and a fresh one on every `parser` change, and the worklet is registered in `useInsertionEffect` inside the new `useParserId` hook. Insertion effects are neither double-invoked in StrictMode nor disconnected for a hidden `<Activity>`, and they run before the host tree is committed, so the registration lives exactly as long as the input and the first commit already carries a valid id.

The native registry becomes a plain map from id to worklet; an unknown id yields no ranges instead of throwing.

**Native renderer caveat**

React Native 0.85–0.87 build the Fabric renderer with `enableHiddenSubtreeInsertionEffectCleanup` off, so removing an input behind a hidden `<Activity>` skips the insertion cleanup and leaks its worklet in the native registry. Formatting stays correct because ids are never reused. `react-dom` has the flag on, and React 19.3 removed it and always runs the cleanup (facebook/react#30954, #34372, #35918).

**Example app**

New buttons reproduce the scenarios on a device: hide and show an `<Activity>` around the input, keep the input painted while hidden (`AlwaysPaintedView`), and swap the `parser` prop.

### Related Issues

https://github.com/Expensify/App/issues/98254

### Manual Tests

`src/__tests__/parserRegistration.test.tsx` covers mount, unmount, StrictMode, hidden and removed `<Activity>`, an abandoned render, shared parsers and a parser swap, and checks that nothing stays registered. The StrictMode and `<Activity>` cases fail without the fix.

Example app on iOS and Android with rebuilt native code:

1. Cold start: the initial value is formatted on the first frame.
2. Type `Hello *bold* and https://expensify.com`: bold and link render as you type.
3. Hide and show the `<Activity>`: the input comes back formatted and keeps formatting new text.
4. Swap the parser back and forth: the input follows each swap.
5. Wrap the input in `<React.StrictMode>` and type `*sm*`: it renders bold.

| iOS | Android |
| --- | --- |
| https://github.com/user-attachments/assets/399d4133-ca5a-47f6-bb91-56b9273ad0e1 | https://github.com/user-attachments/assets/41731a94-e59f-4ec7-9323-7a28e35727d4 |

### Linked PRs

https://github.com/Expensify/App/pull/100318
